### PR TITLE
handle removal of Json arrays with no filter

### DIFF
--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
@@ -136,6 +136,7 @@ public class JsonUtils
       if(node.isArray())
       {
         ArrayNode arrayNode = (ArrayNode) node;
+
         if(element.getValueFilter() != null)
         {
           arrayNode = filterArray((ArrayNode) node, element.getValueFilter(),
@@ -145,9 +146,10 @@ public class JsonUtils
         {
           values.add(v);
         }
-        if(removeValues && node.size() == 0)
+        if(removeValues &&
+            (element.getValueFilter() == null || node.size() == 0))
         {
-          // There is no more values left after removing the matching values.
+          // There are no more values left after removing the matching values.
           // Just remove the field.
           parent.remove(element.getAttribute());
         }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
@@ -704,6 +704,11 @@ public class JsonUtilsTestCase
         Map.class);
     assertEquals(mapResult.size(), 0);
 
+    removed = gso.removeValues("array");
+    assertEquals(removed, 2);
+
+    mapResult = gso.getValues("array", Map.class);
+    assertEquals(mapResult.size(), 0);
   }
 
 


### PR DESCRIPTION
This fixes a bug where if a JSON array node was removed without specifying a filter the node did not get removed.   Added a test case.
