### PR TITLE
Adding method to throw the proper exception if SchemaChecker.Result c…

### DIFF
--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
@@ -95,7 +95,7 @@ public class SchemaChecker
     /**
      * Throws an exception if there are schema validation errors.  The exception
      * will contain all of the syntax errors, mutability errors or path issues
-     * (in that or of precedence.  The exception message will be the content
+     * (in that order of precedence).  The exception message will be the content
      * of baseExceptionMessage followed by a space delimited list of all of the
      * issues of the type (syntax, mutability, or path) being reported.
      *
@@ -129,21 +129,15 @@ public class SchemaChecker
     private String getErrorString(final String errorMessage,
                                   final List<String> issues)
     {
-      if((issues == null) || issues.isEmpty())
+      if ((issues == null) || issues.isEmpty())
       {
         return null;
       }
 
-      StringBuilder builder = new StringBuilder();
-      builder.append(errorMessage);
-
-      for (String issue : issues)
-      {
-        builder.append(" ");
-        builder.append(issue);
-      }
-
-      return builder.toString();
+      StringBuilder errorStringBuilder = new StringBuilder(errorMessage);
+      errorStringBuilder.append(" ");
+      errorStringBuilder.append(StaticUtils.collectionToString(issues, " "));
+      return errorStringBuilder.toString();
     }
   }
 

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaCheckerTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaCheckerTestCase.java
@@ -1654,25 +1654,25 @@ public class SchemaCheckerTestCase
     catch(BadRequestException ex)
     {
       caughtException = ex;
-      Assert.assertEquals(expectedMsg, caughtException.getMessage());
+      Assert.assertEquals(caughtException.getMessage(), expectedMsg);
     }
 
     if (!syntaxIssues.isEmpty())
     {
       Assert.assertNotNull(caughtException);
-      Assert.assertEquals(BadRequestException.INVALID_SYNTAX,
-          caughtException.getScimError().getScimType());
+      Assert.assertEquals(caughtException.getScimError().getScimType(),
+          BadRequestException.INVALID_SYNTAX);
     } else if (!mutabilityIssues.isEmpty())
     {
       Assert.assertNotNull(caughtException);
-      Assert.assertEquals(BadRequestException.MUTABILITY,
-          caughtException.getScimError().getScimType());
+      Assert.assertEquals(caughtException.getScimError().getScimType(),
+          BadRequestException.MUTABILITY);
     }
     else if (!pathIssues.isEmpty())
     {
       Assert.assertNotNull(caughtException);
-      Assert.assertEquals(BadRequestException.INVALID_PATH,
-          caughtException.getScimError().getScimType());
+      Assert.assertEquals(caughtException.getScimError().getScimType(),
+          BadRequestException.INVALID_PATH);
     } else
     {
       Assert.assertNull(caughtException, "Bad exception thrown");


### PR DESCRIPTION
…ontains errors
1.  Method in Results to throw proper exception on errors.
2.  Unit test for this.
