### PR TITLE
The ResourcePreparer was inserting '[' and ']' around path parameter values in meta.location.

### DIFF
--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourcePreparer.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourcePreparer.java
@@ -28,11 +28,13 @@ import com.unboundid.scim2.common.messages.PatchOperation;
 import com.unboundid.scim2.common.types.Meta;
 import com.unboundid.scim2.common.utils.StaticUtils;
 
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -84,9 +86,22 @@ public class ResourcePreparer<T extends ScimResource>
             QUERY_PARAMETER_EXCLUDED_ATTRIBUTES),
         requestUriInfo.getBaseUriBuilder().
             path(resourceType.getEndpoint()).
-            buildFromMap(requestUriInfo.getPathParameters()));
+            buildFromMap(singleValuedMapFromMultivaluedMap(
+                requestUriInfo.getPathParameters())));
   }
 
+  private static Map<String, String> singleValuedMapFromMultivaluedMap(
+      final MultivaluedMap<String, String> multivaluedMap
+  )
+  {
+    final Map<String, String> returnMap = new LinkedHashMap<String, String>();
+    for (String k : multivaluedMap.keySet())
+    {
+      returnMap.put(k, multivaluedMap.getFirst(k));
+    }
+
+    return returnMap;
+  }
 
   /**
    * Private constructor used by unit-test.

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
@@ -296,8 +296,9 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
   @Test
   public void testGetUsers() throws ScimException
   {
+    final ScimService service = new ScimService(target());
     final ListResponse<UserResource> returnedUsers =
-        new ScimService(target()).searchRequest("Users").
+        service.searchRequest("Users").
             filter("meta.resourceType eq \"User\"").
             page(1, 10).
             sort("id", SortOrder.ASCENDING).
@@ -307,6 +308,9 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
     assertEquals(returnedUsers.getTotalResults(), 1);
     assertEquals(returnedUsers.getStartIndex(), new Integer(1));
     assertEquals(returnedUsers.getItemsPerPage(), new Integer(1));
+
+    final UserResource r = returnedUsers.getResources().get(0);
+    service.retrieve(r);
   }
 
   /**


### PR DESCRIPTION
JiraIssue: DS-14016
