### PR TITLE
Add a replace(...) method to ScimService that allows a URI to be spec…

### DIFF
--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimService.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimService.java
@@ -355,6 +355,22 @@ public class ScimService
    * Build a request to modify a SCIM resource by replacing the resource's
    * attributes at the service provider.
    *
+   * @param uri The URL of the resource to modify.
+   * @param resource The resource to replace.
+   * @param <T> The Java type of the resource.
+   * @return The request builder that may be used to specify additional request
+   * parameters and to invoke the request.
+   */
+  public <T extends ScimResource> ReplaceRequestBuilder<T> replaceRequest(
+      final URI uri, final T resource)
+  {
+    return new ReplaceRequestBuilder<T>(resolveWebTarget(uri), resource);
+  }
+
+  /**
+   * Build a request to modify a SCIM resource by replacing the resource's
+   * attributes at the service provider.
+   *
    * @param resource The previously retrieved and revised resource.
    * @param <T> The Java type of the resource.
    * @return The request builder that may be used to specify additional request


### PR DESCRIPTION
Add a replace(...) method to ScimService that allows a URI to be specified.

This accommodates cases in which the resource to be updated by PUT cannot be retrieved beforehand.

There will be test code that exercises this in an internal project. I didn't see a good way to exercise this in the SDK unit tests that wasn't trivial.
