### PR TITLE
Workaround for issue where numerical value in filter must have a spac…

### DIFF
--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
@@ -158,7 +158,11 @@ public class Parser
   public static Filter parseFilter(final String filterString)
       throws BadRequestException
   {
-    return readFilter(new StringReader(filterString.trim()), false);
+    // always precede ')' with a space char since we may instantiate a JSON
+    // parser to help with parsing the filter, and a JSON root context
+    // requires it.
+    String safeFilterString = filterString.trim().replace(")", " )");
+    return readFilter(new StringReader(safeFilterString), false);
   }
 
   /**

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
@@ -122,6 +122,7 @@ public class FilterEvaluatorTestCase
   {
     return new Object[][]
         {
+            new Object[] { "not (weight gt 175)", false },
             new Object[] { "name.first eq \"nAme:fiRst\"", true },
             new Object[] { "naMe.fIrst ne \"nAme:fiRst\"", false },
             new Object[] { "null eq null", true },


### PR DESCRIPTION
…e preceding ')'
