### PR TITLE
Update GitHub URLs to use 'pingidentity' organization instead of 'UnboundID'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ For clients using UnboundID-specific features:
 </dependency>
 ```
 
-You may also download SCIM 2 SDK builds from the [Releases](https://github.com/UnboundID/scim2/releases) page.
+You may also download SCIM 2 SDK builds from the [Releases](https://github.com/pingidentity/scim2/releases) page.
 
-If you're looking for a Java SDK for SCIM 1.1, you can find it [here](https://github.com/UnboundID/scim).
+If you're looking for a Java SDK for SCIM 1.1, you can find it [here](https://github.com/pingidentity/scim).
 
 # How to use it
 The SCIM 2 SDK requires Java 7 or greater.
@@ -108,11 +108,11 @@ ListResponse<UserResource> searchResponse =
         .invoke(UserResource.class);
 ```
 
-For detailed information about using the SCIM 2 SDK, including more examples, please see the [wiki](https://github.com/UnboundID/scim2/wiki).
+For detailed information about using the SCIM 2 SDK, including more examples, please see the [wiki](https://github.com/pingidentity/scim2/wiki).
 
 # Reporting issues
 
-Please report bug reports and enhancement requests through this project's [issue tracker](https://github.com/UnboundID/scim2/issues).
+Please report bug reports and enhancement requests through this project's [issue tracker](https://github.com/pingidentity/scim2/issues).
 
 # License
-The UnboundID SCIM2 SDK is available under three licenses: the GNU General Public License version 2 (GPLv2), the GNU Lesser General Public License version 2.1 (LGPLv2.1), and a free-right-to-use license created by UnboundID Corp. See the [LICENSE](https://github.com/UnboundID/scim2/blob/master/resource/LICENSE.txt) file for more info.
+The UnboundID SCIM2 SDK is available under three licenses: the GNU General Public License version 2 (GPLv2), the GNU Lesser General Public License version 2.1 (LGPLv2.1), and a free-right-to-use license created by UnboundID Corp. See the [LICENSE](https://github.com/pingidentity/scim2/blob/master/resource/LICENSE.txt) file for more info.

--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,10 @@
     See http://simplecloud.info for more information.
   </description>
   <inceptionYear>2015</inceptionYear>
-  <url>https://github.com/UnboundID/scim2</url>
+  <url>https://github.com/pingidentity/scim2</url>
   <scm>
-    <url>https://github.com/UnboundID/scim2</url>
-    <connection>scm:git:https://github.com/UnboundID/scim2</connection>
+    <url>https://github.com/pingidentity/scim2</url>
+    <connection>scm:git:https://github.com/pingidentity/scim2</connection>
   </scm>
   <organization>
     <name>UnboundID Corp.</name>
@@ -55,7 +55,7 @@
     </license>
     <license>
       <name>UnboundID SCIM2 SDK Free Use License</name>
-      <url>https://github.com/UnboundID/scim2</url>
+      <url>https://github.com/pingidentity/scim2</url>
       <comments>This license is available in the source code repository at the provided URL.</comments>
     </license>
   </licenses>

--- a/scim2-sdk-client/pom.xml
+++ b/scim2-sdk-client/pom.xml
@@ -31,10 +31,10 @@
       See http://simplecloud.info for more information.
     </description>
     <inceptionYear>2015</inceptionYear>
-    <url>https://github.com/UnboundID/scim2</url>
+    <url>https://github.com/pingidentity/scim2</url>
     <scm>
-      <url>https://github.com/UnboundID/scim2</url>
-      <connection>scm:git:https://github.com/UnboundID/scim2</connection>
+      <url>https://github.com/pingidentity/scim2</url>
+      <connection>scm:git:https://github.com/pingidentity/scim2</connection>
     </scm>
     <organization>
       <name>UnboundID Corp.</name>
@@ -58,7 +58,7 @@
       </license>
       <license>
         <name>UnboundID SCIM2 SDK Free Use License</name>
-        <url>https://github.com/UnboundID/scim2</url>
+        <url>https://github.com/pingidentity/scim2</url>
         <comments>This license is available in the source code repository at the provided URL.</comments>
       </license>
     </licenses>

--- a/scim2-sdk-common/pom.xml
+++ b/scim2-sdk-common/pom.xml
@@ -31,10 +31,10 @@
       See http://simplecloud.info for more information.
     </description>
     <inceptionYear>2015</inceptionYear>
-    <url>https://github.com/UnboundID/scim2</url>
+    <url>https://github.com/pingidentity/scim2</url>
     <scm>
-      <url>https://github.com/UnboundID/scim2</url>
-      <connection>scm:git:https://github.com/UnboundID/scim2</connection>
+      <url>https://github.com/pingidentity/scim2</url>
+      <connection>scm:git:https://github.com/pingidentity/scim2</connection>
     </scm>
     <organization>
       <name>UnboundID Corp.</name>
@@ -58,7 +58,7 @@
       </license>
       <license>
         <name>UnboundID SCIM2 SDK Free Use License</name>
-        <url>https://github.com/UnboundID/scim2</url>
+        <url>https://github.com/pingidentity/scim2</url>
         <comments>This license is available in the source code repository at the provided URL.</comments>
       </license>
     </licenses>

--- a/scim2-sdk-server/pom.xml
+++ b/scim2-sdk-server/pom.xml
@@ -31,10 +31,10 @@
     See http://simplecloud.info for more information.
   </description>
   <inceptionYear>2015</inceptionYear>
-  <url>https://github.com/UnboundID/scim2</url>
+  <url>https://github.com/pingidentity/scim2</url>
   <scm>
-    <url>https://github.com/UnboundID/scim2</url>
-    <connection>scm:git:https://github.com/UnboundID/scim2</connection>
+    <url>https://github.com/pingidentity/scim2</url>
+    <connection>scm:git:https://github.com/pingidentity/scim2</connection>
   </scm>
   <organization>
     <name>UnboundID Corp.</name>
@@ -58,7 +58,7 @@
     </license>
     <license>
       <name>UnboundID SCIM2 SDK Free Use License</name>
-      <url>https://github.com/UnboundID/scim2</url>
+      <url>https://github.com/pingidentity/scim2</url>
       <comments>This license is available in the source code repository at the provided URL.</comments>
     </license>
   </licenses>

--- a/scim2-ubid-extensions/README.md
+++ b/scim2-ubid-extensions/README.md
@@ -5,4 +5,4 @@ This component contains model classes representing UnboundID-proprietary extensi
   
 The UnboundID SCIM 2 SDK for Java provides a powerful and flexible set of APIs for interacting with SCIM service providers and resources. Use it to build applications and servers that interoperate with SCIM servers such as the [UnboundID Data Broker](https://www.unboundid.com/data-broker).
 
-Please refer to the [SCIM 2 SDK README](https://github.com/UnboundID/scim2) for license and support information.
+Please refer to the [SCIM 2 SDK README](https://github.com/pingidentity/scim2) for license and support information.

--- a/scim2-ubid-extensions/pom.xml
+++ b/scim2-ubid-extensions/pom.xml
@@ -31,10 +31,10 @@
     See http://simplecloud.info for more information.
   </description>
   <inceptionYear>2015</inceptionYear>
-  <url>https://github.com/UnboundID/scim2</url>
+  <url>https://github.com/pingidentity/scim2</url>
   <scm>
-    <url>https://github.com/UnboundID/scim2</url>
-    <connection>scm:git:https://github.com/UnboundID/scim2</connection>
+    <url>https://github.com/pingidentity/scim2</url>
+    <connection>scm:git:https://github.com/pingidentity/scim2</connection>
   </scm>
   <organization>
     <name>UnboundID Corp.</name>
@@ -58,7 +58,7 @@
     </license>
     <license>
       <name>UnboundID SCIM2 SDK Free Use License</name>
-      <url>https://github.com/UnboundID/scim2</url>
+      <url>https://github.com/pingidentity/scim2</url>
       <comments>This license is available in the source code repository at the provided URL.</comments>
     </license>
   </licenses>


### PR DESCRIPTION
All public UnboundID repositories were recently transferred to the Ping Identity organization. While existing GitHub URLs should continue to work, it makes sense to use the canonical URLs going forward. This rather boring PR updates the GitHub URLs in the READMEs and POMs to use the 'pingidentity' organization instead of 'UnboundID'.

JiraIssue: DP-281