### PR TITLE
Fixed a bug that would not allow access to sub-attributes in a simple…

### DIFF
--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaCheckFilterVisitor.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaCheckFilterVisitor.java
@@ -318,6 +318,21 @@ public final class SchemaCheckFilterVisitor
       final Path fullPath = parentPath.attribute(path);
       final AttributeDefinition attribute =
           resourceType.getAttributeDefinition(fullPath);
+
+      // Simple, multi-valued attributes implicitly use "value" as the
+      // name to access sub-attributes. Don't print the sub-attribute undefined
+      // error in this case.
+      if (path.getElement(0).getAttribute().equalsIgnoreCase("value"))
+      {
+        final AttributeDefinition parentAttr =
+                resourceType.getAttributeDefinition(parentPath);
+        if (parentAttr.isMultiValued() &&
+                (parentAttr.getSubAttributes() == null))
+        {
+          return;
+        }
+      }
+
       if (attribute == null)
       {
         // Can't find the definition for the sub-attribute in a value filter.


### PR DESCRIPTION
… multi-valued attribute through the use of "value". Sub-attributes in a simple mulit-valued attribute

implicitly use value as their name.

===BEGIN-RELEASE-NOTE===
Fixed a SCIM issue to restore the use of the implicit "value" sub-attribute in filters to reference specific values of simple multi-valued attributes
===END-RELEASE-NOTE===

Reviewer: Bo Li

JiraIssue:DS-17570

SalesforceCaseNumber:00609465

Product:broker