### PR TITLE
Fix issues involving binary attribute handling

### DIFF
--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GenericScimResourceObjectTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GenericScimResourceObjectTest.java
@@ -17,6 +17,7 @@
 
 package com.unboundid.scim2.common;
 
+import com.fasterxml.jackson.core.Base64Variants;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 import com.unboundid.scim2.common.exceptions.ScimException;
@@ -465,11 +466,45 @@ public class GenericScimResourceObjectTest
     GenericScimResource gsr = new GenericScimResource();
     Assert.assertEquals(gsr.replaceValue(path1, value1).
         getBinaryValue(Path.fromString(path1)), value1);
+
+    // Set BinaryNode directly
+    Assert.assertEquals(gsr.replaceValue(path1,
+        JsonUtils.getJsonNodeFactory().binaryNode(value1)).
+        getBinaryValue(Path.fromString(path1)), value1);
+
+    // Set TextNode directly
+    Assert.assertEquals(gsr.replaceValue(path1,
+        JsonUtils.getJsonNodeFactory().textNode(
+            Base64Variants.getDefaultVariant().encode(value1))).
+        getBinaryValue(Path.fromString(path1)), value1);
+
     Assert.assertEquals(gsr.replaceValue(Path.fromString(path2), value2).
         getBinaryValue(path2), value2);
 
     List<byte[]> list1 = gsr.addBinaryValues(path3,
         Lists.<byte[]>newArrayList(arrayValue1, arrayValue2)).
+        getBinaryValueList(Path.fromString(path3));
+    Assert.assertEquals(list1.size(), 2);
+    assertByteArrayListContainsBytes(list1, arrayValue1);
+    assertByteArrayListContainsBytes(list1, arrayValue2);
+
+    // Set BinaryNode directly
+    list1 = gsr.replaceValue(path3,
+        JsonUtils.getJsonNodeFactory().arrayNode().
+            add(JsonUtils.getJsonNodeFactory().binaryNode(arrayValue1)).
+            add(JsonUtils.getJsonNodeFactory().binaryNode(arrayValue2))).
+        getBinaryValueList(Path.fromString(path3));
+    Assert.assertEquals(list1.size(), 2);
+    assertByteArrayListContainsBytes(list1, arrayValue1);
+    assertByteArrayListContainsBytes(list1, arrayValue2);
+
+    // Set TextNode directly
+    list1 = gsr.replaceValue(path3,
+        JsonUtils.getJsonNodeFactory().arrayNode().
+            add(JsonUtils.getJsonNodeFactory().textNode(
+                Base64Variants.getDefaultVariant().encode(arrayValue1))).
+            add(JsonUtils.getJsonNodeFactory().textNode(
+                Base64Variants.getDefaultVariant().encode(arrayValue2)))).
         getBinaryValueList(Path.fromString(path3));
     Assert.assertEquals(list1.size(), 2);
     assertByteArrayListContainsBytes(list1, arrayValue1);

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
@@ -17,7 +17,6 @@
 
 package com.unboundid.scim2.server.utils;
 
-import com.fasterxml.jackson.core.Base64Variants;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -1044,7 +1043,6 @@ public class SchemaChecker
     {
       case STRING:
       case DATETIME:
-      case BINARY:
       case REFERENCE:
         if (!node.isTextual())
         {
@@ -1078,6 +1076,14 @@ public class SchemaChecker
           return;
         }
         break;
+      case BINARY:
+        if (!node.isTextual() && !node.isBinary())
+        {
+          results.syntaxIssues.add(prefix + "Value for attribute " + path +
+              " must be a JSON string");
+          return;
+        }
+        break;
       default:
         throw new RuntimeException(
             "Unexpected attribute type " + attribute.getType());
@@ -1102,7 +1108,7 @@ public class SchemaChecker
       case BINARY:
         try
         {
-          Base64Variants.getDefaultVariant().decode(node.textValue());
+          node.binaryValue();
         }
         catch (Exception e)
         {


### PR DESCRIPTION
* GenericScimResource getter and setters now work correctly when the value is stored in a TextNode or a BinaryNode. Previously, calling (e.g.) GenericScimResource.getBinaryValue(...) could result in a NullPointerException.
* SchemaChecker no longer incorrectly reports an issue if the value is stored in a BinaryNode.

The changes in this PR were done by @digitalperk; I'm simply requesting that we accept these changes into master. Please see the internal issue DS-18091.