### PR TITLE
Remove oraclejdk7 build target from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
 script: mvn package


### PR DESCRIPTION
Travis CI no longer supports Oracle JDK 7 because Oracle no longer supports it. OpenJDK 7 can continue to be used to confirm general JDK 7 compatibility.