### PR TITLE
Serialize ErrorResponse status to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## v2.1.3 - 2018-xx-xx
+## v2.2.0 - 2018-xx-xx
 Updated ErrorResponse to serialize its "status" field as a JSON string rather than as a number to comply with RFC 7644. Deserialization of this field is backwards compatible and will accept either a number or a string. Non-SCIM 2 SDK clients expecting a JSON string will need to be updated for compatibility.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v2.2.0 - 2018-xx-xx
-Updated ErrorResponse to serialize its "status" field as a JSON string rather than as a number to comply with RFC 7644. Deserialization of this field is backwards compatible and will accept either a number or a string. Non-SCIM 2 SDK clients expecting a JSON string will need to be updated for compatibility.
+Updated ErrorResponse to serialize its "status" field as a JSON string rather than as a number for compliance with RFC 7644. Deserialization of this field is backwards compatible and will accept either a number or a string. Clients expecting the "status" field as a JSON string (including older SCIM 2 SDK clients) will need to be updated for compatibility.
 
 
 ## v2.1.3 - 2017-11-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v2.1.3 - 2017-xx-xx
+Updated ErrorResponse to serialize its "status" field as a JSON string rather than as a number to comply with RFC 7644. Deserialization of this field is backwards compatible and will accept either a number or a string. Non-SCIM 2 SDK clients expecting a JSON string will need to be updated for compatibility.
+
 Fixed several issues around binary attribute handling.
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.unboundid.product.scim2</groupId>
   <artifactId>scim2-parent</artifactId>
-  <version>2.1.4-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>UnboundID SCIM2 SDK Parent</name>
   <description>

--- a/scim2-assembly/pom.xml
+++ b/scim2-assembly/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-assembly</artifactId>
   <packaging>pom</packaging>

--- a/scim2-sdk-client/pom.xml
+++ b/scim2-sdk-client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>2.1.4-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>scim2-sdk-client</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-common/pom.xml
+++ b/scim2-sdk-common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>2.1.4-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>scim2-sdk-common</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ErrorResponse.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ErrorResponse.java
@@ -19,10 +19,14 @@ package com.unboundid.scim2.common.messages;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.unboundid.scim2.common.types.AttributeDefinition;
 import com.unboundid.scim2.common.annotations.Schema;
 import com.unboundid.scim2.common.annotations.Attribute;
 import com.unboundid.scim2.common.BaseScimResource;
+import com.unboundid.scim2.common.utils.StatusDeserializer;
+import com.unboundid.scim2.common.utils.StatusSerializer;
 
 /**
  * This object is returned whenever by SCIM when an error occurs.
@@ -42,6 +46,8 @@ public final class ErrorResponse extends BaseScimResource
   @Attribute(description = "The HTTP status code.",
       mutability = AttributeDefinition.Mutability.READ_ONLY,
       isRequired = true)
+  @JsonSerialize(using = StatusSerializer.class)
+  @JsonDeserialize(using = StatusDeserializer.class)
   private final int status;
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StatusDeserializer.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StatusDeserializer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2017 UnboundID Corp.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+
+package com.unboundid.scim2.common.utils;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+/**
+ * Deserializes the status field of
+ * {@link com.unboundid.scim2.common.messages.ErrorResponse} to an Integer.
+ */
+public class StatusDeserializer extends JsonDeserializer<Integer>
+{
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Integer deserialize(final JsonParser jp,
+                             final DeserializationContext ctxt)
+      throws IOException, JsonProcessingException
+  {
+    return jp.readValueAs(Integer.class);
+  }
+}

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StatusSerializer.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StatusSerializer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2017 UnboundID Corp.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+
+package com.unboundid.scim2.common.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+/**
+ * Serializes {@link com.unboundid.scim2.common.messages.ErrorResponse}'s
+ * status field to a String.
+ */
+public class StatusSerializer extends JsonSerializer<Integer>
+{
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void serialize(final Integer value, final JsonGenerator jgen,
+                        final SerializerProvider serializers)
+      throws IOException, JsonProcessingException
+  {
+    jgen.writeString(String.valueOf(value));
+  }
+}

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/ErrorResponseTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/ErrorResponseTest.java
@@ -21,16 +21,22 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.unboundid.scim2.common.exceptions.BadRequestException;
 import com.unboundid.scim2.common.messages.ErrorResponse;
 import com.unboundid.scim2.common.utils.JsonUtils;
+import com.unboundid.scim2.common.utils.SchemaUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 
 /**
  * Test cases for {@link com.unboundid.scim2.common.messages.ErrorResponse}.
  */
 public class ErrorResponseTest
 {
+  private static final String SCHEMA =
+      SchemaUtils.getSchemaIdFromAnnotation(ErrorResponse.class);
+  private static final int STATUS = 400;
+  private static final String SCIM_TYPE = BadRequestException.MUTABILITY;
+  private static final String DETAIL = "Attribute 'id' is readOnly";
+
   /**
    * Confirms that an ErrorResponse can be deserialized when the status field
    * is a JSON string.
@@ -38,25 +44,32 @@ public class ErrorResponseTest
    * @throws Exception if an error occurs.
    */
   @Test
-  public void testDeserializeStringStatus() throws Exception
+  public void testDeserializationAndSerializationWithStringStatus()
+      throws Exception
   {
     final ObjectNode node = (ObjectNode) JsonUtils.getObjectReader().readTree(
         "{\n" +
-        "  \"schemas\": [\"urn:ietf:params:scim:api:messages:2.0:Error\"],\n" +
-        "  \"scimType\":\"mutability\",\n" +
-        "  \"detail\":\"Attribute 'id' is readOnly\",\n" +
-        "  \"status\": \"400\"\n" +
+        "  \"schemas\": [\"" + SCHEMA + "\"],\n" +
+        "  \"scimType\":\"" + SCIM_TYPE + "\",\n" +
+        "  \"detail\":\"" + DETAIL + "\",\n" +
+        "  \"status\": \"" + STATUS + "\"\n" +
         "}"
     );
 
     final ErrorResponse errorResponse =
         JsonUtils.nodeToValue(node, ErrorResponse.class);
-    assertEquals(errorResponse.getStatus(), Integer.valueOf(400));
-    assertEquals(errorResponse.getScimType(), BadRequestException.MUTABILITY);
-    assertNotNull(errorResponse.getDetail());
+    assertEquals(errorResponse.getStatus(), Integer.valueOf(STATUS));
+    assertEquals(errorResponse.getScimType(), SCIM_TYPE);
+    assertEquals(errorResponse.getDetail(), DETAIL);
     assertEquals(errorResponse.getSchemaUrns().size(), 1);
-    assertEquals(errorResponse.getSchemaUrns().iterator().next(),
-        "urn:ietf:params:scim:api:messages:2.0:Error");
+    assertEquals(errorResponse.getSchemaUrns().iterator().next(), SCHEMA);
+
+    final String serializedString =
+        JsonUtils.getObjectWriter().writeValueAsString(errorResponse);
+    final ErrorResponse deserializedErrorResponse =
+        JsonUtils.getObjectReader().forType(ErrorResponse.class).
+            readValue(serializedString);
+    assertEquals(errorResponse, deserializedErrorResponse);
   }
 
   /**
@@ -66,24 +79,31 @@ public class ErrorResponseTest
    * @throws Exception if an error occurs.
    */
   @Test
-  public void testDeserializeNumberStatus() throws Exception
+  public void testDeserializationAndSerializationWithNumberStatus()
+      throws Exception
   {
     final ObjectNode node = (ObjectNode) JsonUtils.getObjectReader().readTree(
         "{\n" +
-        "  \"schemas\": [\"urn:ietf:params:scim:api:messages:2.0:Error\"],\n" +
-        "  \"scimType\":\"mutability\",\n" +
-        "  \"detail\":\"Attribute 'id' is readOnly\",\n" +
-        "  \"status\": 400\n" +
+        "  \"schemas\": [\"" + SCHEMA + "\"],\n" +
+        "  \"scimType\":\"" + SCIM_TYPE + "\",\n" +
+        "  \"detail\":\"" + DETAIL + "\",\n" +
+        "  \"status\": " + STATUS + "\n" +
         "}"
     );
 
     final ErrorResponse errorResponse =
         JsonUtils.nodeToValue(node, ErrorResponse.class);
-    assertEquals(errorResponse.getStatus(), Integer.valueOf(400));
-    assertEquals(errorResponse.getScimType(), BadRequestException.MUTABILITY);
-    assertNotNull(errorResponse.getDetail());
+    assertEquals(errorResponse.getStatus(), Integer.valueOf(STATUS));
+    assertEquals(errorResponse.getScimType(), SCIM_TYPE);
+    assertEquals(errorResponse.getDetail(), DETAIL);
     assertEquals(errorResponse.getSchemaUrns().size(), 1);
-    assertEquals(errorResponse.getSchemaUrns().iterator().next(),
-        "urn:ietf:params:scim:api:messages:2.0:Error");
+    assertEquals(errorResponse.getSchemaUrns().iterator().next(), SCHEMA);
+
+    final String serializedString =
+        JsonUtils.getObjectWriter().writeValueAsString(errorResponse);
+    final ErrorResponse deserializedErrorResponse =
+        JsonUtils.getObjectReader().forType(ErrorResponse.class).
+            readValue(serializedString);
+    assertEquals(errorResponse, deserializedErrorResponse);
   }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/ErrorResponseTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/ErrorResponseTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015-2017 UnboundID Corp.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+
+package com.unboundid.scim2.common;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.unboundid.scim2.common.exceptions.BadRequestException;
+import com.unboundid.scim2.common.messages.ErrorResponse;
+import com.unboundid.scim2.common.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Test cases for {@link com.unboundid.scim2.common.messages.ErrorResponse}.
+ */
+public class ErrorResponseTest
+{
+  /**
+   * Confirms that an ErrorResponse can be deserialized when the status field
+   * is a JSON string.
+   *
+   * @throws Exception if an error occurs.
+   */
+  @Test
+  public void testDeserializeStringStatus() throws Exception
+  {
+    final ObjectNode node = (ObjectNode) JsonUtils.getObjectReader().readTree(
+        "{\n" +
+        "  \"schemas\": [\"urn:ietf:params:scim:api:messages:2.0:Error\"],\n" +
+        "  \"scimType\":\"mutability\",\n" +
+        "  \"detail\":\"Attribute 'id' is readOnly\",\n" +
+        "  \"status\": \"400\"\n" +
+        "}"
+    );
+
+    final ErrorResponse errorResponse =
+        JsonUtils.nodeToValue(node, ErrorResponse.class);
+    assertEquals(errorResponse.getStatus(), Integer.valueOf(400));
+    assertEquals(errorResponse.getScimType(), BadRequestException.MUTABILITY);
+    assertNotNull(errorResponse.getDetail());
+    assertEquals(errorResponse.getSchemaUrns().size(), 1);
+    assertEquals(errorResponse.getSchemaUrns().iterator().next(),
+        "urn:ietf:params:scim:api:messages:2.0:Error");
+  }
+
+  /**
+   * Confirms that an ErrorResponse can be deserialized when the status field
+   * is a JSON number.
+   *
+   * @throws Exception if an error occurs.
+   */
+  @Test
+  public void testDeserializeNumberStatus() throws Exception
+  {
+    final ObjectNode node = (ObjectNode) JsonUtils.getObjectReader().readTree(
+        "{\n" +
+        "  \"schemas\": [\"urn:ietf:params:scim:api:messages:2.0:Error\"],\n" +
+        "  \"scimType\":\"mutability\",\n" +
+        "  \"detail\":\"Attribute 'id' is readOnly\",\n" +
+        "  \"status\": 400\n" +
+        "}"
+    );
+
+    final ErrorResponse errorResponse =
+        JsonUtils.nodeToValue(node, ErrorResponse.class);
+    assertEquals(errorResponse.getStatus(), Integer.valueOf(400));
+    assertEquals(errorResponse.getScimType(), BadRequestException.MUTABILITY);
+    assertNotNull(errorResponse.getDetail());
+    assertEquals(errorResponse.getSchemaUrns().size(), 1);
+    assertEquals(errorResponse.getSchemaUrns().iterator().next(),
+        "urn:ietf:params:scim:api:messages:2.0:Error");
+  }
+}

--- a/scim2-sdk-server/pom.xml
+++ b/scim2-sdk-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-sdk-server</artifactId>
   <packaging>jar</packaging>

--- a/scim2-ubid-extensions/pom.xml
+++ b/scim2-ubid-extensions/pom.xml
@@ -19,7 +19,7 @@
   <parent>
       <artifactId>scim2-parent</artifactId>
       <groupId>com.unboundid.product.scim2</groupId>
-      <version>2.1.4-SNAPSHOT</version>
+      <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-ubid-extensions</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
Previously, the ErrorResponse status value was serialized to a JSON number, but [RFC 7644](https://tools.ietf.org/html/rfc7644#section-3.12) actually calls for the field to be represented as a string. A custom serializer was added so that the status field is now serialized as a string; a custom deserializer was added that allows an ErrorResponse to be deserialized regardless of whether the status field is a string or a number. The SDK's ErrorResponse Java API is unchanged.

This addresses Issue #87.

JiraIssue: DS-18095