### PR TITLE
Enum as not complex type.

### DIFF
--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/SchemaUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/SchemaUtils.java
@@ -18,6 +18,7 @@
 package com.unboundid.scim2.common.utils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.unboundid.scim2.common.types.AttributeDefinition.Builder;
 import com.unboundid.scim2.common.types.Meta;
 import com.unboundid.scim2.common.annotations.Schema;
 import com.unboundid.scim2.common.annotations.Attribute;
@@ -227,7 +228,6 @@ public class SchemaUtils
       addReferenceTypes(attributeBuilder, schemaProperty);
       addMutability(attributeBuilder, schemaProperty);
       addMultiValued(attributeBuilder, propertyDescriptor, schemaProperty);
-      addCanonicalValues(attributeBuilder, schemaProperty);
 
       Class propertyCls = propertyDescriptor.getPropertyType();
 
@@ -237,6 +237,7 @@ public class SchemaUtils
       {
         propertyCls = schemaProperty.multiValueClass();
       }
+      addCanonicalValues(attributeBuilder, schemaProperty, propertyCls);
 
       AttributeDefinition.Type type = getAttributeType(propertyCls);
       attributeBuilder.setType(type);
@@ -400,15 +401,24 @@ public class SchemaUtils
    * @param attributeBuilder builder for a scim attribute.
    * @param schemaProperty the schema property annotation for the field
    *                       to build an attribute for.
+   * @param propertyCls
    * @return this.
    */
   private static AttributeDefinition.Builder addCanonicalValues(
-      final AttributeDefinition.Builder attributeBuilder,
-      final Attribute schemaProperty)
+          final Builder attributeBuilder,
+          final Attribute schemaProperty,
+          final Class propertyCls)
   {
     if(schemaProperty != null)
     {
-      attributeBuilder.addCanonicalValues(schemaProperty.canonicalValues());
+        if(propertyCls.isEnum()){
+            Enum[] enumVales = (Enum[]) propertyCls.getEnumConstants();
+            for (Enum e: enumVales) {
+                attributeBuilder.addCanonicalValues(e.name());
+            }
+        } else {
+            attributeBuilder.addCanonicalValues(schemaProperty.canonicalValues());
+        }
     }
 
     return attributeBuilder;
@@ -532,7 +542,7 @@ public class SchemaUtils
       return AttributeDefinition.Type.DECIMAL;
     }
     else if ((cls == String.class) ||
-        (cls == boolean.class))
+        (cls == boolean.class) || cls.isEnum())
     {
       return AttributeDefinition.Type.STRING;
     }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/SchemaGenerationTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/SchemaGenerationTest.java
@@ -17,15 +17,8 @@
 
 package com.unboundid.scim2.common.schema;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.unboundid.scim2.common.types.AttributeDefinition;
-import com.unboundid.scim2.common.types.SchemaResource;
-import com.unboundid.scim2.common.schema.testobjects.TestObject1;
-import com.unboundid.scim2.common.schema.testobjects.TestObject2;
-import com.unboundid.scim2.common.schema.testobjects.TestObject3;
-import com.unboundid.scim2.common.utils.SchemaUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Lists.transform;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,6 +26,20 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.unboundid.scim2.common.schema.testobjects.TestEnumObject;
+import com.unboundid.scim2.common.schema.testobjects.TestObject1;
+import com.unboundid.scim2.common.schema.testobjects.TestObject2;
+import com.unboundid.scim2.common.schema.testobjects.TestObject3;
+import com.unboundid.scim2.common.schema.testobjects.TestObject4;
+import com.unboundid.scim2.common.types.AttributeDefinition;
+import com.unboundid.scim2.common.types.SchemaResource;
+import com.unboundid.scim2.common.utils.SchemaUtils;
 
 /**
  * Tests cases for SCIM schema generation.
@@ -73,6 +80,28 @@ public class SchemaGenerationTest
     SchemaResource schemaDefinition =
         SchemaUtils.getSchema(TestObject1.class);
     String schemaJsonString = mapper.writeValueAsString(schemaDefinition);
+  }
+
+    /**
+     * Test enum as a field.
+     * @throws Exception in the event an error occurs.
+     */
+  @Test
+  public void testEnumAsField() throws Exception {
+      SchemaResource schemaDefinition = SchemaUtils.getSchema(TestObject4.class);
+
+      Collection<AttributeDefinition> attributes = schemaDefinition.getAttributes();
+      Assert.assertNotNull(attributes);
+      Assert.assertEquals(attributes.size(), 1);
+      AttributeDefinition onlyAttribute = attributes.iterator().next();
+      Assert.assertNotNull(onlyAttribute.getCanonicalValues());
+      List<TestEnumObject> collect = newArrayList(TestEnumObject.values());
+      Assert.assertTrue(onlyAttribute.getCanonicalValues().containsAll( transform(collect,
+              new Function<TestEnumObject, String>() {
+                  public String apply(TestEnumObject input) {
+                      return input.name();
+                  }
+      })));
   }
 
   /**

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/SchemaGenerationTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/SchemaGenerationTest.java
@@ -98,7 +98,7 @@ public class SchemaGenerationTest
       List<TestEnumObject> collect = newArrayList(TestEnumObject.values());
       Assert.assertTrue(onlyAttribute.getCanonicalValues().containsAll( transform(collect,
               new Function<TestEnumObject, String>() {
-                  public String apply(TestEnumObject input) {
+                  public String apply(final TestEnumObject input) {
                       return input.name();
                   }
       })));

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/testobjects/TestEnumObject.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/testobjects/TestEnumObject.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2018 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+
+package com.unboundid.scim2.common.schema.testobjects;
+
+public enum TestEnumObject {
+    /**
+     * Test case 1.
+     */
+    CASE1,
+    /**
+     * Test case 2.
+     */
+    CASE2,
+    /**
+     * Test case 3.
+     */
+    CASE3
+}

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/testobjects/TestObject4.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/testobjects/TestObject4.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2018 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+
+package com.unboundid.scim2.common.schema.testobjects;
+
+import com.unboundid.scim2.common.annotations.Attribute;
+import com.unboundid.scim2.common.annotations.Schema;
+
+@Schema(id="urn:com.unboundid:schemas:TestObject4",
+        description = "description:TestObject4", name = "TestObject4")
+public class TestObject4 {
+
+    @Attribute(description = "description:value")
+    private TestEnumObject value;
+
+    /**
+     * Getter for attribute in test class.
+     * @param value attribute value.
+     */
+    public void setValue(TestEnumObject value) {
+        this.value = value;
+    }
+
+    /**
+     * Getter for attribute in test class.
+     * @return attribute value.
+     */
+    public TestEnumObject getValue() {
+        return value;
+    }
+}

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/testobjects/TestObject4.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/testobjects/TestObject4.java
@@ -31,7 +31,7 @@ public class TestObject4 {
      * Getter for attribute in test class.
      * @param value attribute value.
      */
-    public void setValue(TestEnumObject value) {
+    public void setValue(final TestEnumObject value) {
         this.value = value;
     }
 


### PR DESCRIPTION
Changes allow using enum as a simple type.
This change generates attribute definition for enum of type string with canonical values corresponding to enum values.

Issue #25 