### PR TITLE
All checks for fields with mutability ReadOnly are now ignored in all operations but PATCH

### DIFF
--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaCheckerTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaCheckerTestCase.java
@@ -2083,20 +2083,18 @@ public class SchemaCheckerTestCase
             setCoreSchema(schema).build();
     SchemaChecker checker = new SchemaChecker(resourceTypeDefinition);
 
-    // Can not create read-only
+    // Can check create read-only
     ObjectNode o = JsonUtils.getJsonNodeFactory().objectNode();
     o.putArray("schemas").add("urn:id:test");
     o.put("readOnly", "value");
     SchemaChecker.Results results = checker.checkCreate(o);
-    assertEquals(results.getMutabilityIssues().size(), 1,
+    assertEquals(results.getMutabilityIssues().size(), 0,
         results.getMutabilityIssues().toString());
-    assertTrue(containsIssueWith(results.getMutabilityIssues(), "read-only"));
 
-    // Can not replace read-only
+    // Can check replace read-only
     results = checker.checkReplace(o, null);
-    assertEquals(results.getMutabilityIssues().size(), 1,
+    assertEquals(results.getMutabilityIssues().size(), 0,
         results.getMutabilityIssues().toString());
-    assertTrue(containsIssueWith(results.getMutabilityIssues(), "read-only"));
 
     // Can not add read-only in patch
     results = checker.checkModify(Collections.singleton(


### PR DESCRIPTION
This change fixes library conformance to SCIM2.0 [3.3](https://tools.ietf.org/html/rfc7644#section-3.3) and [3.5.1](https://tools.ietf.org/html/rfc7644#section-3.5.1) with regards to ignoring ReadOnly fields.