### PR TITLE
simplify client extension for working with not-quite-compliant servers

### DIFF
--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/CreateRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/CreateRequestBuilder.java
@@ -27,7 +27,7 @@ import javax.ws.rs.core.Response;
 /**
  * A builder for SCIM create requests.
  */
-public final class CreateRequestBuilder<T extends ScimResource>
+public class CreateRequestBuilder<T extends ScimResource>
     extends ResourceReturningRequestBuilder<CreateRequestBuilder<T>>
 {
   private final T resource;

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/DeleteRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/DeleteRequestBuilder.java
@@ -58,7 +58,7 @@ public class DeleteRequestBuilder extends RequestBuilder<DeleteRequestBuilder>
    * {@inheritDoc}
    */
   @Override
-  Invocation.Builder buildRequest()
+  protected Invocation.Builder buildRequest()
   {
     Invocation.Builder request = super.buildRequest();
     if(version != null)

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ModifyRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ModifyRequestBuilder.java
@@ -66,7 +66,7 @@ public abstract class ModifyRequestBuilder<T extends ModifyRequestBuilder<T>>
    * {@inheritDoc}
    */
   @Override
-  Invocation.Builder buildRequest()
+  protected Invocation.Builder buildRequest()
   {
     Invocation.Builder request = super.buildRequest();
     if(version != null)

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ReplaceRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ReplaceRequestBuilder.java
@@ -29,7 +29,7 @@ import javax.ws.rs.core.Response;
 /**
  * A builder for SCIM replace requests.
  */
-public final class ReplaceRequestBuilder<T extends ScimResource>
+public class ReplaceRequestBuilder<T extends ScimResource>
     extends ResourceReturningRequestBuilder<ReplaceRequestBuilder<T>>
 {
   private final T resource;
@@ -63,7 +63,7 @@ public final class ReplaceRequestBuilder<T extends ScimResource>
    * {@inheritDoc}
    */
   @Override
-  Invocation.Builder buildRequest()
+  protected Invocation.Builder buildRequest()
   {
     Invocation.Builder request = super.buildRequest();
     if(version != null)

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RequestBuilder.java
@@ -167,7 +167,7 @@ public class RequestBuilder<T extends RequestBuilder>
    * @param response The JAX-RS response.
    * @return the converted ScimException.
    */
-  static ScimException toScimException(final Response response)
+  protected static ScimException toScimException(final Response response)
   {
     try
     {
@@ -203,7 +203,7 @@ public class RequestBuilder<T extends RequestBuilder>
    *
    * @return The WebTarget for the request.
    */
-  WebTarget buildTarget()
+  protected WebTarget buildTarget()
   {
     for(Map.Entry<String, List<Object>> queryParam : queryParams.entrySet())
     {
@@ -237,7 +237,7 @@ public class RequestBuilder<T extends RequestBuilder>
    *
    * @return The Invocation.Builder for the request.
    */
-  Invocation.Builder buildRequest()
+  protected Invocation.Builder buildRequest()
   {
     Invocation.Builder builder =
         buildTarget().request(accept.toArray(new String[accept.size()]));

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ResourceReturningRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ResourceReturningRequestBuilder.java
@@ -54,7 +54,7 @@ public abstract class ResourceReturningRequestBuilder
    *
    * @return The WebTarget for the request.
    */
-  WebTarget buildTarget()
+  protected WebTarget buildTarget()
   {
     if(attributes != null && attributes.size() > 0)
     {

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RetrieveRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RetrieveRequestBuilder.java
@@ -51,7 +51,7 @@ public abstract class RetrieveRequestBuilder
    * {@inheritDoc}
    */
   @Override
-  Invocation.Builder buildRequest()
+  protected Invocation.Builder buildRequest()
   {
     Invocation.Builder request = super.buildRequest();
     if(version != null)

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/SearchRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/SearchRequestBuilder.java
@@ -53,7 +53,7 @@ import static com.unboundid.scim2.common.utils.ApiConstants.QUERY_PARAMETER_SORT
 /**
  * A builder for SCIM search requests.
  */
-public final class SearchRequestBuilder
+public class SearchRequestBuilder
     extends ResourceReturningRequestBuilder<SearchRequestBuilder>
 {
   private String filter;
@@ -119,7 +119,7 @@ public final class SearchRequestBuilder
    * {@inheritDoc}
    */
   @Override
-  WebTarget buildTarget()
+  protected WebTarget buildTarget()
   {
     WebTarget target = super.buildTarget();
     if(filter != null)


### PR DESCRIPTION
expand buildRequest and toScimException access from package-only to protected, and remove final modifier from builders.  This allows easier wrapping for interaction with not-quite-compliant scim2 implementations