### PR TITLE
Fixed an issue with GenericScimResource.replaceValue(String, Date)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## v2.2.1 - unreleased
 Maven POM changes: Removed unused dependencies, declared previously implicit dependencies, declared 'test' scope as appropriate, and added a dependencyManagement section to the scim2-parent POM.
 
+Fixed an issue with `GenericScimResource.replaceValue(String, Date)` wrapping date values in double quotes.
+
+
 ## v2.2.0 - 2018-05-21
 Updated ErrorResponse to serialize its "status" field as a JSON string rather than as a number for compliance with RFC 7644. Deserialization of this field is backwards compatible and will accept either a number or a string. Clients expecting the "status" field as a JSON string (including older SCIM 2 SDK clients) will need to be updated for compatibility.
 

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
@@ -2167,8 +2167,7 @@ public final class GenericScimResource implements ScimResource
     {
       return null;
     }
-    String dateString = jsonNode.textValue();
-    return getDateForString(dateString);
+    return getDateFromJsonNode(jsonNode);
   }
 
   /**
@@ -2243,38 +2242,6 @@ public final class GenericScimResource implements ScimResource
     return values;
   }
 
-  private static String getStringForDate(final Date date) throws ScimException
-  {
-    try
-    {
-      return JsonUtils.getObjectWriter().writeValueAsString(date);
-    }
-    catch(JsonProcessingException ex)
-    {
-      // this really should not happen, but we will handle it and
-      // translate to a SCIM exception just in case.
-      throw new ServerErrorException(ex.getMessage());
-    }
-  }
-
-  private static Date getDateForString(final String dateString)
-      throws ScimException
-  {
-    try
-    {
-      return JsonUtils.getObjectReader().forType(Date.class).
-          readValue(dateString);
-    }
-    catch(JsonProcessingException ex)
-    {
-      throw new ServerErrorException(ex.getMessage());
-    }
-    catch(IOException ex)
-    {
-      throw new ServerErrorException(ex.getMessage());
-    }
-  }
-
   /**
    * Gets a JsonNode that represents the supplied date.
    *
@@ -2285,7 +2252,7 @@ public final class GenericScimResource implements ScimResource
   public static TextNode getDateJsonNode(final Date date)
       throws ScimException
   {
-    return new TextNode(getStringForDate(date));
+    return JsonUtils.valueToNode(date);
   }
 
   /**
@@ -2298,7 +2265,18 @@ public final class GenericScimResource implements ScimResource
   public static Date getDateFromJsonNode(final JsonNode node)
       throws ScimException
   {
-    return getDateForString(node.textValue());
+    try
+    {
+      return JsonUtils.getObjectReader().forType(Date.class).readValue(node);
+    }
+    catch(JsonProcessingException ex)
+    {
+      throw new ServerErrorException(ex.getMessage());
+    }
+    catch(IOException ex)
+    {
+      throw new ServerErrorException(ex.getMessage());
+    }
   }
 
   /////////////////////////////////////

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GenericScimResourceObjectTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GenericScimResourceObjectTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import com.unboundid.scim2.common.types.Meta;
 import com.unboundid.scim2.common.utils.JsonUtils;
+import com.unboundid.scim2.common.utils.ScimDateFormat;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -373,6 +374,16 @@ public class GenericScimResourceObjectTest
         getDateValue(Path.fromString(path1)), value1);
     Assert.assertEquals(gsr.replaceValue(Path.fromString(path2), value2).
         getDateValue(path2), value2);
+
+    Assert.assertEquals(gsr.getDateValue(path1), value1);
+    Assert.assertEquals(GenericScimResource.getDateFromJsonNode(gsr.getValue(path1)),
+        value1);
+    Assert.assertEquals(gsr.getStringValue(path1), new ScimDateFormat().format(value1));
+
+    Assert.assertEquals(gsr.getDateValue(path2), value2);
+    Assert.assertEquals(GenericScimResource.getDateFromJsonNode(gsr.getValue(path2)),
+        value2);
+    Assert.assertEquals(gsr.getStringValue(path2), new ScimDateFormat().format(value2));
 
     List<Date> list1 = gsr.addDateValues(path3,
         Lists.<Date>newArrayList(arrayValue1, arrayValue2)).


### PR DESCRIPTION
This method would incorrectly set wrap date string values in double quotes.

This addresses #100.