### PR TITLE
Update to Jackson 2.9.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: java
 jdk:
   - openjdk11
   - openjdk8
-  - openjdk7
 script: mvn package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
 jdk:
-  - openjdk11
   - openjdk8
 script: mvn package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk11
+  - openjdk8
   - openjdk7
 script: mvn package

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
     <compileSource>1.6</compileSource>
     <main.basedir>${project.basedir}</main.basedir>
     <ignore.test.failures>false</ignore.test.failures>
-    <jackson.version>2.7.4</jackson.version>
-    <jackson-databind.version>2.7.9.5</jackson-databind.version>
+    <jackson.version>2.9.9</jackson.version>
+    <jackson-databind.version>2.9.9</jackson-databind.version>
     <jax-rs.version>2.0.1</jax-rs.version>
     <jersey.version>2.17</jersey.version>
     <guava.version>20.0</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <compileSource>1.6</compileSource>
+    <compileSource>1.7</compileSource>
     <main.basedir>${project.basedir}</main.basedir>
     <ignore.test.failures>false</ignore.test.failures>
     <jackson.version>2.9.9</jackson.version>
@@ -146,6 +146,11 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>1.7</version>
         </plugin>
@@ -180,6 +185,14 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${compileSource}</source>
+          <target>${compileSource}</target>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
@@ -276,7 +276,7 @@ public final class Path implements Iterable<Path.Element>
    * @param index The exclusive index of the endpoint path element.
    * @return A new path to a beginning portion of this path.
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt; size()</tt>)
+   *         ({@code index < 0 || index > size()})
    */
   public Path subPath(final int index) throws IndexOutOfBoundsException
   {
@@ -297,7 +297,7 @@ public final class Path implements Iterable<Path.Element>
    * @param index The index of the path element to retrieve.
    * @return The path element at the index.
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt;= size()</tt>)
+   *         ({@code index < 0 || index >= size()})
    */
   public Element getElement(final int index) throws IndexOutOfBoundsException
   {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/BadRequestException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/BadRequestException.java
@@ -100,7 +100,7 @@ public class BadRequestException extends ScimException
    * @param errorMessage  The error message for this SCIM exception.
    * @param scimType      The SCIM detailed error keyword.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A <tt>null</tt> value
+   *                      {@link #getCause()} method).  (A {@code null} value
    *                      is permitted, and indicates that the cause is
    *                      nonexistent or unknown.)
    */
@@ -116,7 +116,7 @@ public class BadRequestException extends ScimException
    *
    * @param scimError     The SCIM error response.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A <tt>null</tt> value
+   *                      {@link #getCause()} method).  (A {@code null} value
    *                      is permitted, and indicates that the cause is
    *                      nonexistent or unknown.)
    */

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ForbiddenException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ForbiddenException.java
@@ -44,7 +44,7 @@ public class ForbiddenException extends ScimException
    * @param errorMessage  The error message for this SCIM exception.
    * @param scimType      The SCIM detailed error keyword.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A <tt>null</tt> value
+   *                      {@link #getCause()} method).  (A {@code null} value
    *                      is permitted, and indicates that the cause is
    *                      nonexistent or unknown.)
    */
@@ -60,7 +60,7 @@ public class ForbiddenException extends ScimException
    *
    * @param scimError     The SCIM error response.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A <tt>null</tt> value
+   *                      {@link #getCause()} method).  (A {@code null} value
    *                      is permitted, and indicates that the cause is
    *                      nonexistent or unknown.)
    */

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/MethodNotAllowedException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/MethodNotAllowedException.java
@@ -36,7 +36,7 @@ public class MethodNotAllowedException extends ScimException
    *
    * @param scimError     The SCIM error response.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A <tt>null</tt> value
+   *                      {@link #getCause()} method).  (A {@code null} value
    *                      is permitted, and indicates that the cause is
    *                      nonexistent or unknown.)
    */

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimDateFormat.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimDateFormat.java
@@ -28,7 +28,11 @@ import java.util.Date;
 /**
  * Like ISO8601DateFormat except this format includes milliseconds when
  * serializing.
+ *
+ * @deprecated This class will no longer be needed in a future version of the
+ * SCIM 2 SDK.
  */
+@Deprecated
 public class ScimDateFormat extends ISO8601DateFormat
 {
   /**


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Updates the SCIM 2 SDK to use Jackson 2.9.9.
Jackson 2.9.9 addresses a [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2019-12086) that was possible under certain specific conditions. The SCIM 2 SDK was not directly affected by this vulnerability.

This PR also includes the following changes:
* Deprecated the ScimDateFormat class. An alternative to this class will be provided in SCIM 2 SDK 2.3.0.
* Set the compile target to Java 7.
* Updated the Travis CI config to use OpenJDK 8. Java 7 is no longer available in the build environment, and Java 11 cannot be used until the target version is updated to Java 8 (see [this OpenJDK issue](https://bugs.openjdk.java.net/browse/JDK-8212233)).

Does this close any currently open issues?
------------------------------------------
This addresses #120. A followup set of changes will remove deprecated Jackson API usages.
