### PR TITLE
Remove usages of deprecated Jackson APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-dist: trusty
 language: java
 jdk:
-  - oraclejdk8
-  - oraclejdk11
-script: mvn package
+  - openjdk8
+script: mvn -PTravisCI package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+dist: xenial
 language: java
 jdk:
   - openjdk8
+  - openjdk11
 script: mvn package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-dist: xenial
+dist: trusty
 language: java
 jdk:
-  - openjdk8
-  - openjdk11
+  - oraclejdk8
+  - oraclejdk11
 script: mvn package

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,9 @@
     <ignore.test.failures>false</ignore.test.failures>
     <jackson.version>2.9.9</jackson.version>
     <jackson-databind.version>2.9.9</jackson-databind.version>
+    <jaxb.version>2.3.1</jaxb.version>
     <jax-rs.version>2.0.1</jax-rs.version>
-    <jersey.version>2.17</jersey.version>
+    <jersey.version>2.28</jersey.version>
     <guava.version>20.0</guava.version>
     <testng.version>6.4</testng.version>
   </properties>
@@ -160,7 +161,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.7</version>
+          <version>2.17</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
@@ -168,7 +169,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
@@ -181,6 +182,14 @@
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.7</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.2.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.1</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -199,7 +208,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
         <executions>
           <execution>
             <id>check-main</id>
@@ -256,7 +264,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
         <executions>
           <execution>
             <id>aggregate</id>
@@ -279,7 +286,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.2.2</version>
         <configuration>
           <tagNameFormat>scim-@{project.version}</tagNameFormat>
           <goals>deploy</goals>
@@ -291,7 +297,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>
@@ -347,6 +352,11 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${jaxb.version}</version>
+      </dependency>
+      <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.2</version>
@@ -361,6 +371,12 @@
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-client</artifactId>
+        <version>${jersey.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.inject</groupId>
+        <artifactId>jersey-hk2</artifactId>
         <version>${jersey.version}</version>
         <scope>test</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,20 @@
 
   <profiles>
     <profile>
+      <id>TravisCI</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <useFile>false</useFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>UnboundID</id>
       <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -191,14 +191,6 @@
         <configuration>
           <source>${compileSource}</source>
           <target>${compileSource}</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${compileSource}</source>
-          <target>${compileSource}</target>
           <compilerArgs>
             <arg>-Xlint:deprecation</arg>
           </compilerArgs>

--- a/scim2-assembly/pom.xml
+++ b/scim2-assembly/pom.xml
@@ -63,7 +63,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
 		<configuration>
 		  <skip>true</skip>
 		</configuration>

--- a/scim2-sdk-client/pom.xml
+++ b/scim2-sdk-client/pom.xml
@@ -124,7 +124,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
         <executions>
           <execution>
             <id>create-javadoc-archive</id>

--- a/scim2-sdk-common/pom.xml
+++ b/scim2-sdk-common/pom.xml
@@ -135,7 +135,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
         <executions>
           <execution>
             <id>create-javadoc-archive</id>
@@ -218,6 +217,10 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/Filter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/Filter.java
@@ -18,10 +18,10 @@
 package com.unboundid.scim2.common.filters;
 
 import com.fasterxml.jackson.databind.node.ValueNode;
-import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import com.unboundid.scim2.common.Path;
 import com.unboundid.scim2.common.exceptions.BadRequestException;
 import com.unboundid.scim2.common.exceptions.ScimException;
+import com.unboundid.scim2.common.utils.DateTimeUtils;
 import com.unboundid.scim2.common.utils.JsonUtils;
 import com.unboundid.scim2.common.utils.Parser;
 
@@ -313,7 +313,7 @@ public abstract class Filter
   {
     return new EqualFilter(Path.fromString(attributePath),
         JsonUtils.getJsonNodeFactory().textNode(
-            ISO8601Utils.format(filterValue)));
+            DateTimeUtils.format(filterValue)));
   }
 
   /**
@@ -449,7 +449,7 @@ public abstract class Filter
   {
     return new NotEqualFilter(Path.fromString(attributePath),
         JsonUtils.getJsonNodeFactory().textNode(
-            ISO8601Utils.format(filterValue)));
+            DateTimeUtils.format(filterValue)));
   }
 
   /**
@@ -662,7 +662,7 @@ public abstract class Filter
   {
     return new GreaterThanFilter(Path.fromString(attributePath),
         JsonUtils.getJsonNodeFactory().textNode(
-            ISO8601Utils.format(filterValue)));
+            DateTimeUtils.format(filterValue)));
   }
 
   /**
@@ -767,7 +767,7 @@ public abstract class Filter
   {
     return new GreaterThanOrEqualFilter(Path.fromString(attributePath),
         JsonUtils.getJsonNodeFactory().textNode(
-            ISO8601Utils.format(filterValue)));
+            DateTimeUtils.format(filterValue)));
   }
 
   /**
@@ -872,7 +872,7 @@ public abstract class Filter
   {
     return new LessThanFilter(Path.fromString(attributePath),
         JsonUtils.getJsonNodeFactory().textNode(
-            ISO8601Utils.format(filterValue)));
+            DateTimeUtils.format(filterValue)));
   }
 
   /**
@@ -977,7 +977,7 @@ public abstract class Filter
   {
     return new LessThanOrEqualFilter(Path.fromString(attributePath),
         JsonUtils.getJsonNodeFactory().textNode(
-            ISO8601Utils.format(filterValue)));
+            DateTimeUtils.format(filterValue)));
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/CalendarDeserializer.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/CalendarDeserializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+package com.unboundid.scim2.common.utils;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import java.io.IOException;
+import java.util.Calendar;
+
+/**
+ * Deserializes SCIM 2 DateTime values to {@link Calendar} objects.
+ */
+public class CalendarDeserializer extends JsonDeserializer<Calendar>
+{
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Calendar deserialize(final JsonParser jp,
+                              final DeserializationContext ctxt)
+      throws IOException, JsonProcessingException
+  {
+    String dateStr = jp.getText();
+    try
+    {
+      return DateTimeUtils.parse(dateStr);
+    }
+    catch (IllegalArgumentException e)
+    {
+      throw new InvalidFormatException(jp, "unable to deserialize value",
+          dateStr, Calendar.class);
+    }
+  }
+}

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/CalendarSerializer.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/CalendarSerializer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+package com.unboundid.scim2.common.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.util.Calendar;
+
+/**
+ * Serializes a {@link Calendar} object to a SCIM 2 DateTime string.
+ */
+public class CalendarSerializer extends JsonSerializer<Calendar>
+{
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void serialize(final Calendar value, final JsonGenerator jgen,
+                        final SerializerProvider serializers)
+      throws IOException
+  {
+    jgen.writeString(DateTimeUtils.format(value));
+  }
+}

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/DateDeserializer.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/DateDeserializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+package com.unboundid.scim2.common.utils;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import java.io.IOException;
+import java.util.Date;
+
+/**
+ * Deserializes SCIM 2 DateTime values to {@link Date} objects.
+ */
+public class DateDeserializer extends JsonDeserializer<Date>
+{
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Date deserialize(final JsonParser jp,
+                          final DeserializationContext ctxt)
+      throws IOException, JsonProcessingException
+  {
+    String dateStr = jp.getText();
+    try
+    {
+      return DateTimeUtils.parse(dateStr).getTime();
+    }
+    catch (IllegalArgumentException e)
+    {
+      throw new InvalidFormatException(jp, "unable to deserialize value",
+          dateStr, Date.class);
+    }
+  }
+}

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/DateSerializer.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/DateSerializer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+package com.unboundid.scim2.common.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.util.Date;
+
+/**
+ * Serializes a {@link Date} object to a SCIM 2 DateTime string.
+ */
+public class DateSerializer extends JsonSerializer<Date>
+{
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void serialize(final Date value, final JsonGenerator jgen,
+                        final SerializerProvider serializers)
+      throws IOException
+  {
+    jgen.writeString(DateTimeUtils.format(value));
+  }
+}

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/DateTimeUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/DateTimeUtils.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+package com.unboundid.scim2.common.utils;
+
+import javax.xml.bind.DatatypeConverter;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * Utility methods for handling SCIM 2 DateTime values. The SCIM 2 DateTime
+ * type is defined as a valid xsd:dateTime in RFC 7643, section 2.3.5.
+ */
+public final class DateTimeUtils
+{
+  private static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getTimeZone("UTC");
+
+  /**
+   * Formats a {@link Date} value as a SCIM 2 DateTime string.
+   *
+   * @param date A Date value.
+   * @return The value as a SCIM 2 DateTime string.
+   */
+  public static String format(final Date date)
+  {
+    return format(date, DEFAULT_TIME_ZONE);
+  }
+
+  /**
+   * Formats a {@link Date} value as a SCIM 2 DateTime string.
+   *
+   * @param date A Date value.
+   * @param timeZone The time zone.
+   * @return The value as a SCIM 2 DateTime string.
+   */
+  public static String format(final Date date, final TimeZone timeZone)
+  {
+    Calendar calendar = Calendar.getInstance(timeZone);
+    calendar.setTime(date);
+    return format(calendar);
+  }
+
+  /**
+   * Formats a {@link Calendar} value as a SCIM 2 DateTime string.
+   *
+   * @param calendar A Calendar value.
+   * @return The value as a SCIM 2 DateTime string.
+   */
+  public static String format(final Calendar calendar)
+  {
+    return DatatypeConverter.printDateTime(calendar);
+  }
+
+  /**
+   * Converts a SCIM 2 DateTime string to a {@link Calendar}.
+   *
+   * @param dateStr A SCIM 2 DateTime string.
+   * @return The DateTime string as a Calendar value.
+   * @throws IllegalArgumentException if the string cannot be parsed as an
+   * xsd:dateTime value.
+   */
+  public static Calendar parse(final String dateStr)
+      throws IllegalArgumentException
+  {
+    return DatatypeConverter.parseDateTime(dateStr);
+  }
+}

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/MapperFactory.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/MapperFactory.java
@@ -24,8 +24,11 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
+import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 
 /**
@@ -141,9 +144,14 @@ public class MapperFactory
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
 
-    // Only use ISO8601 format for dates.
+    // Only use xsd:dateTime format for dates.
     mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    mapper.setDateFormat(new ScimDateFormat());
+    SimpleModule dateTimeModule = new SimpleModule();
+    dateTimeModule.addSerializer(Calendar.class, new CalendarSerializer());
+    dateTimeModule.addDeserializer(Calendar.class, new CalendarDeserializer());
+    dateTimeModule.addSerializer(Date.class, new DateSerializer());
+    dateTimeModule.addDeserializer(Date.class, new DateDeserializer());
+    mapper.registerModule(dateTimeModule);
 
     // Do not care about case when de-serializing POJOs.
     mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/MapperFactory.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/MapperFactory.java
@@ -142,7 +142,6 @@ public class MapperFactory
 
     // Don't serialize POJO nulls as JSON nulls.
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    mapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
 
     // Only use xsd:dateTime format for dates.
     mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimDateFormat.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimDateFormat.java
@@ -29,10 +29,20 @@ import java.util.Date;
  * Like ISO8601DateFormat except this format includes milliseconds when
  * serializing.
  *
- * @deprecated This class will no longer be needed in a future version of the
- * SCIM 2 SDK.
+ * @deprecated This class relies on deprecated APIs from the Jackson library
+ * and will be removed in a future version of the SCIM 2 SDK.
+ * For general parsing and formatting of SCIM 2 DateTime values, see
+ * {@link DateTimeUtils}. For usages with a Jackson
+ * {@link com.fasterxml.jackson.databind.ObjectMapper}, see the SCIM 2 SDK's
+ * serializers and deserializers for {@link Date} and {@link java.util.Calendar}.
+ *
+ * @see DateTimeUtils
+ * @see DateSerializer
+ * @see DateDeserializer
+ * @see CalendarSerializer
+ * @see CalendarDeserializer
  */
-@Deprecated
+@Deprecated // since 2.2.2
 public class ScimDateFormat extends ISO8601DateFormat
 {
   /**

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
@@ -18,10 +18,10 @@
 package com.unboundid.scim2.common;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import com.unboundid.scim2.common.filters.Filter;
 import com.unboundid.scim2.common.filters.FilterType;
+import com.unboundid.scim2.common.utils.DateTimeUtils;
 import com.unboundid.scim2.common.utils.FilterEvaluator;
 import com.unboundid.scim2.common.utils.JsonUtils;
 import org.testng.annotations.BeforeClass;
@@ -60,7 +60,7 @@ public class FilterEvaluatorTestCase
             "    \"id\": \"user:id\",\n" +
             "    \"meta\": {\n" +
             "        \"created\": \"" +
-            ISO8601Utils.format(date, true) + "\",\n" +
+            DateTimeUtils.format(date) + "\",\n" +
             "        \"lastModified\": \"2015-02-27T11:29:39Z\",\n" +
             "        \"location\": \"http://here/user\",\n" +
             "        \"resourceType\": \"some resource type\",\n" +
@@ -188,36 +188,36 @@ public class FilterEvaluatorTestCase
             new Object[] { "addresses.priority ge 10", true },
             new Object[] { "addresses.priority le 0", true },
             new Object[] { "meta.created eq \"" +
-                ISO8601Utils.format(date, true) + "\"", true },
+                DateTimeUtils.format(date) + "\"", true },
             new Object[] { "meta.created eq \"" +
-                ISO8601Utils.format(date, true, TimeZone.getTimeZone("CST")) +
+                DateTimeUtils.format(date, TimeZone.getTimeZone("CST")) +
                 "\"", true },
             new Object[] { "meta.created eq \"" +
-                ISO8601Utils.format(date, true, TimeZone.getTimeZone("PST")) +
+                DateTimeUtils.format(date, TimeZone.getTimeZone("PST")) +
                 "\"", true },
             new Object[] { "meta.created ge \"" +
-                ISO8601Utils.format(date, true, TimeZone.getTimeZone("CST")) +
+                DateTimeUtils.format(date, TimeZone.getTimeZone("CST")) +
                 "\"", true },
             new Object[] { "meta.created le \"" +
-                ISO8601Utils.format(date, true, TimeZone.getTimeZone("CST")) +
+                DateTimeUtils.format(date, TimeZone.getTimeZone("CST")) +
                 "\"", true },
             new Object[] { "meta.created gt \"" +
-                ISO8601Utils.format(date, true, TimeZone.getTimeZone("CST")) +
+                DateTimeUtils.format(date, TimeZone.getTimeZone("CST")) +
                 "\"", false },
             new Object[] { "meta.created lt \"" +
-                ISO8601Utils.format(date, true, TimeZone.getTimeZone("CST")) +
+                DateTimeUtils.format(date, TimeZone.getTimeZone("CST")) +
                 "\"", false },
             new Object[] { "meta.created gt \"" +
-                ISO8601Utils.format(new Date(date.getTime() + 1000), false,
+                DateTimeUtils.format(new Date(date.getTime() + 1000),
                     TimeZone.getTimeZone("CST")) + "\"", false },
             new Object[] { "meta.created lt \"" +
-                ISO8601Utils.format(new Date(date.getTime() + 1000), false,
+                DateTimeUtils.format(new Date(date.getTime() + 1000),
                     TimeZone.getTimeZone("CST")) + "\"", true },
             new Object[] { "meta.created gt \"" +
-                ISO8601Utils.format(new Date(date.getTime() - 1000), false,
+                DateTimeUtils.format(new Date(date.getTime() - 1000),
                     TimeZone.getTimeZone("CST")) + "\"", true },
             new Object[] { "meta.created lt \"" +
-                ISO8601Utils.format(new Date(date.getTime() - 1000), false,
+                DateTimeUtils.format(new Date(date.getTime() - 1000),
                     TimeZone.getTimeZone("CST")) + "\"", false },
             new Object[] { "schemas[value eq " +
                 "\"urn:pingidentity:schemas:baseSchema\"]", true },

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GenericScimResourceObjectTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GenericScimResourceObjectTest.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import com.unboundid.scim2.common.types.Meta;
+import com.unboundid.scim2.common.utils.DateTimeUtils;
 import com.unboundid.scim2.common.utils.JsonUtils;
-import com.unboundid.scim2.common.utils.ScimDateFormat;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -378,12 +378,12 @@ public class GenericScimResourceObjectTest
     Assert.assertEquals(gsr.getDateValue(path1), value1);
     Assert.assertEquals(GenericScimResource.getDateFromJsonNode(gsr.getValue(path1)),
         value1);
-    Assert.assertEquals(gsr.getStringValue(path1), new ScimDateFormat().format(value1));
+    Assert.assertEquals(gsr.getStringValue(path1), DateTimeUtils.format(value1));
 
     Assert.assertEquals(gsr.getDateValue(path2), value2);
     Assert.assertEquals(GenericScimResource.getDateFromJsonNode(gsr.getValue(path2)),
         value2);
-    Assert.assertEquals(gsr.getStringValue(path2), new ScimDateFormat().format(value2));
+    Assert.assertEquals(gsr.getStringValue(path2), DateTimeUtils.format(value2));
 
     List<Date> list1 = gsr.addDateValues(path3,
         Lists.<Date>newArrayList(arrayValue1, arrayValue2)).

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
@@ -1202,4 +1202,20 @@ public class JsonUtilsTestCase
     Assert.assertEquals(name.getGivenName(), "Bob");
     Assert.assertEquals(name.getMiddleName(), "X");
   }
+
+  /**
+   * Test that the SCIM 2 SDK ObjectMapper ignores null map values.
+   */
+  @Test
+  public void testNullMapValue()
+  {
+    Map<String, String> map = new HashMap<>();
+    map.put("hasValue", "value1");
+    map.put("isNull", null);
+    ObjectNode objectNode = JsonUtils.valueToNode(map);
+
+    Assert.assertFalse(objectNode.path("hasValue").isMissingNode());
+    Assert.assertEquals(objectNode.path("hasValue").textValue(), "value1");
+    Assert.assertTrue(objectNode.path("isNull").isMissingNode());
+  }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
@@ -23,11 +23,11 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import com.google.common.collect.ImmutableMap;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import com.unboundid.scim2.common.filters.Filter;
 import com.unboundid.scim2.common.types.Name;
+import com.unboundid.scim2.common.utils.DateTimeUtils;
 import com.unboundid.scim2.common.utils.JsonUtils;
 import com.unboundid.scim2.common.utils.MapperFactory;
 import org.testng.Assert;
@@ -518,8 +518,8 @@ public class JsonUtilsTestCase
         Path.fromString("date"), gso.getObjectNode());
     assertEquals(dateResult.size(), 1);
     assertEquals(
-        ISO8601Utils.parse(dateResult.get(0).textValue(), new ParsePosition(0)),
-        ISO8601Utils.parse("2015-02-27T11:28:39Z", new ParsePosition(0)));
+        DateTimeUtils.parse(dateResult.get(0).textValue()),
+        DateTimeUtils.parse("2015-02-27T11:28:39Z"));
 
 
     List<JsonNode> binaryResult = JsonUtils.findMatchingPaths(

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
@@ -35,7 +35,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.text.ParsePosition;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/scim2-sdk-server/pom.xml
+++ b/scim2-sdk-server/pom.xml
@@ -182,7 +182,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
         <executions>
           <execution>
             <id>create-javadoc-archive</id>
@@ -243,6 +242,10 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
@@ -20,7 +20,6 @@ package com.unboundid.scim2.server.utils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import com.unboundid.scim2.common.types.AttributeDefinition;
 import com.unboundid.scim2.common.Path;
 import com.unboundid.scim2.common.types.SchemaResource;
@@ -36,7 +35,6 @@ import com.unboundid.scim2.common.utils.SchemaUtils;
 import com.unboundid.scim2.common.utils.StaticUtils;
 
 import java.net.URI;
-import java.text.ParsePosition;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -1099,14 +1097,14 @@ public class SchemaChecker
       case DATETIME:
         try
         {
-          ISO8601Utils.parse(node.textValue(), new ParsePosition(0));
+          JsonUtils.nodeToDateValue(node);
         }
         catch (Exception e)
         {
           Debug.debug(Level.INFO, DebugType.EXCEPTION,
-              "Invalid ISO8601 string during schema checking", e);
+              "Invalid xsd:dateTime string during schema checking", e);
           results.syntaxIssues.add(prefix + "Value for attribute " + path +
-              " is not a valid ISO8601 formatted string");
+              " is not a valid xsd:dateTime formatted string");
         }
         break;
       case BINARY:

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/ETagTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/ETagTestCase.java
@@ -43,6 +43,8 @@ import com.unboundid.scim2.server.resources.ResourceTypesEndpoint;
 import com.unboundid.scim2.server.resources.SchemasEndpoint;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.RequestEntityProcessing;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTestNg;
 import org.testng.Assert;
@@ -114,6 +116,8 @@ public class ETagTestCase extends JerseyTestNg.ContainerPerClassTest
   @Override
   protected void configureClient(final ClientConfig config)
   {
+    config.property(ClientProperties.REQUEST_ENTITY_PROCESSING,
+        RequestEntityProcessing.BUFFERED);
     config.connectorProvider(new ApacheConnectorProvider());
   }
 

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
@@ -61,6 +61,7 @@ import com.unboundid.scim2.server.utils.ResourceTypeDefinition;
 import com.unboundid.scim2.server.utils.ServerUtils;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTestNg;
 import org.testng.Assert;
@@ -68,6 +69,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
@@ -828,55 +830,85 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
   }
 
   /**
-   * Test empty entity in PATCH, and POST requests are handled correctly.
-   * Jersey client can't issue PUT request with empty entity.
+   * Test that empty entity in POST, PUT, and PATCH requests are handled
+   * correctly.
    *
    * @throws ScimException if an error occurs.
    */
   @Test
   public void testEmptyEntity() throws ScimException
   {
-    WebTarget target = target().register(
-        new JacksonJsonProvider(JsonUtils.createObjectMapper()));
+    Client client = client();
+    // Allow null request entities
+    client.property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true);
 
-    // No content-type header and no entity
-    Invocation.Builder b = target.path("SingletonUsers").
-        request("application/scim+json");
-    Response response = b.build("POST").invoke();
-    assertEquals(response.getStatus(), 400);
-    ErrorResponse error = response.readEntity(ErrorResponse.class);
-    assertTrue(error.getDetail().contains("No content provided"));
-    response.close();
+    try
+    {
+      WebTarget target = client.target(getBaseUri()).register(
+          new JacksonJsonProvider(JsonUtils.createObjectMapper()));
 
-    b = target.path("SingletonUsers").path("123").
-        request("application/scim+json");
-    response = b.build("PATCH").invoke();
-    assertEquals(response.getStatus(), 400);
-    assertEquals(response.getMediaType(), ServerUtils.MEDIA_TYPE_SCIM_TYPE);
-    error = response.readEntity(ErrorResponse.class);
-    assertTrue(error.getDetail().contains("No content provided"));
-    response.close();
+      // No content-type header and no entity
+      Invocation.Builder b = target.path("SingletonUsers").
+          request("application/scim+json");
+      Response response = b.build("POST").invoke();
+      assertEquals(response.getStatus(), 400);
+      ErrorResponse error = response.readEntity(ErrorResponse.class);
+      assertTrue(error.getDetail().contains("No content provided"));
+      response.close();
 
-    // Content-type header set but no entity
-    b = target.path("SingletonUsers").
-        request("application/scim+json").
-        header(HttpHeaders.CONTENT_TYPE, "application/scim+json");
-    response = b.build("POST").invoke();
-    assertEquals(response.getStatus(), 400);
-    assertEquals(response.getMediaType(), ServerUtils.MEDIA_TYPE_SCIM_TYPE);
-    error = response.readEntity(ErrorResponse.class);
-    assertTrue(error.getDetail().contains("No content provided"));
-    response.close();
+      b = target.path("SingletonUsers").path("123").
+          request("application/scim+json");
+      response = b.build("PUT").invoke();
+      assertEquals(response.getStatus(), 400);
+      assertEquals(response.getMediaType(), ServerUtils.MEDIA_TYPE_SCIM_TYPE);
+      error = response.readEntity(ErrorResponse.class);
+      assertTrue(error.getDetail().contains("No content provided"));
+      response.close();
 
-    b = target.path("SingletonUsers").path("123").
-        request("application/scim+json").
-        header(HttpHeaders.CONTENT_TYPE, "application/scim+json");
-    response = b.build("PATCH").invoke();
-    assertEquals(response.getStatus(), 400);
-    assertEquals(response.getMediaType(), ServerUtils.MEDIA_TYPE_SCIM_TYPE);
-    error = response.readEntity(ErrorResponse.class);
-    assertTrue(error.getDetail().contains("No content provided"));
-    response.close();
+      b = target.path("SingletonUsers").path("123").
+          request("application/scim+json");
+      response = b.build("PATCH").invoke();
+      assertEquals(response.getStatus(), 400);
+      assertEquals(response.getMediaType(), ServerUtils.MEDIA_TYPE_SCIM_TYPE);
+      error = response.readEntity(ErrorResponse.class);
+      assertTrue(error.getDetail().contains("No content provided"));
+      response.close();
+
+      // Content-type header set but no entity
+      b = target.path("SingletonUsers").
+          request("application/scim+json").
+          header(HttpHeaders.CONTENT_TYPE, "application/scim+json");
+      response = b.build("POST").invoke();
+      assertEquals(response.getStatus(), 400);
+      assertEquals(response.getMediaType(), ServerUtils.MEDIA_TYPE_SCIM_TYPE);
+      error = response.readEntity(ErrorResponse.class);
+      assertTrue(error.getDetail().contains("No content provided"));
+      response.close();
+
+      b = target.path("SingletonUsers").path("123").
+          request("application/scim+json").
+                    header(HttpHeaders.CONTENT_TYPE, "application/scim+json");
+      response = b.build("PUT").invoke();
+      assertEquals(response.getStatus(), 400);
+      assertEquals(response.getMediaType(), ServerUtils.MEDIA_TYPE_SCIM_TYPE);
+      error = response.readEntity(ErrorResponse.class);
+      assertTrue(error.getDetail().contains("No content provided"));
+      response.close();
+
+      b = target.path("SingletonUsers").path("123").
+          request("application/scim+json").
+          header(HttpHeaders.CONTENT_TYPE, "application/scim+json");
+      response = b.build("PATCH").invoke();
+      assertEquals(response.getStatus(), 400);
+      assertEquals(response.getMediaType(), ServerUtils.MEDIA_TYPE_SCIM_TYPE);
+      error = response.readEntity(ErrorResponse.class);
+      assertTrue(error.getDetail().contains("No content provided"));
+      response.close();
+    }
+    finally
+    {
+      client.property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, false);
+    }
   }
 
   /**

--- a/scim2-ubid-extensions/pom.xml
+++ b/scim2-ubid-extensions/pom.xml
@@ -136,7 +136,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
         <executions>
           <execution>
             <id>create-javadoc-archive</id>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This set of changes removes the SCIM 2 SDK's usages of deprecated Jackson APIs, particularly dateTime data type handling that relies on Jackson's ISO8601-related classes. The SCIM 2 dateTime type follows the xsd:dateType format specified by the W3C XML Schema standard, so all SCIM 2 dateTime handling is now delegated to javax.xml.bind.DatatypeConverter via a new DateTimeUtils
class. Because javax.xml is not bundled with recent versions of the JDK, javax.xml.bind:jaxb-api was added to scim2-sdk-common as a dependency.

The ScimDateFormat class was updated with alternatives to using it now that it is deprecated. This class will be removed in the future — probably when a future Jackson upgrade removes its superclass.

This also includes changes to ensure that the project builds without errors on Java 11.

Does this close any currently open issues?
------------------------------------------
No, but this is related to issue #120.
