### PR TITLE
Downgrade maven-javadoc-plugin version to 2.10.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>2.10.4</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This should resolve a build failure in the scim2-assembly component that occurs when executing the "UnboundID" profile.

Does this close any currently open issues?
------------------------------------------
no
