### PR TITLE
Update ListResponse#getTotalResults() to return int instead of long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## v2.3.0 - unreleased
 The SCIM 2 DateTime handling code has been updated to rely on xsd:dateTime code provided by JAXB rather than on Jackson APIs that are deprecated as of version 2.9.x. A DateTimeUtils class has been added to perform conversions between SCIM 2 DateTime strings and Java Date and Calendar objects. The ScimDateFormat class is now deprecated and should not be used.
 
-The Version class is no longer generated at build time for each module, and is now only generated for  scim2-sdk-common. Because all other modules include scim2-sdk-common as a dependency, the Version class will continue to be available for all modules. This should eliminate duplicate class warnings when the SCIM 2 SDK is included in projects built using (for example) the Maven Shade Plugin.
+The Version class is no longer generated at build time for each module, and is now only generated for scim2-sdk-common. Because all other modules include scim2-sdk-common as a dependency, the Version class will continue to be available for all modules. This should eliminate duplicate class warnings when the SCIM 2 SDK is included in projects built using (for example) the Maven Shade Plugin.
+
+The `ListResponse#getTotalResults()` method has been updated to return a value of type int rather than long.
 
 
 ## v2.2.2 - 2019-06-24

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ListResponse.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ListResponse.java
@@ -150,7 +150,7 @@ public final class ListResponse<T> extends BaseScimResource
    * @return The total number of results returned by the list or query
    * operation.
    */
-  public long getTotalResults()
+  public int getTotalResults()
   {
     return totalResults;
   }


### PR DESCRIPTION
Align the return type of ListResponse#getTotalResults() with the class's constructor.

What does this implement/fix? Explain your changes.
---------------------------------------------------
The ListResponse totalResults property has type int, and the constructor requires an int, but the accessor method (getTotalResults()) returns a long. Updated getTotalResults() to return an int.

Does this close any currently open issues?
------------------------------------------
This closes #117.
