### PR TITLE
Changed the mutability of the UserResource groups attribute to 'readOnly'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The Version class is no longer generated at build time for each module, and is n
 
 The `ListResponse#getTotalResults()` method has been updated to return a value of type int rather than long.
 
+Changed the mutability value of the UserResource groups attribute to 'readOnly' for conformance with RFC 7643.
+
 
 ## v2.2.2 - 2019-06-24
 Updated the Jackson dependencies to 2.9.9, which addresses a potential security issue found in earlier versions of that library.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/UserResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/UserResource.java
@@ -196,6 +196,7 @@ public class UserResource extends BaseScimResource
       "either thorough direct membership, nested groups, or dynamically " +
       "calculated.",
       isRequired = false,
+      mutability = AttributeDefinition.Mutability.READ_ONLY,
       returned = AttributeDefinition.Returned.DEFAULT,
       multiValueClass = Group.class)
   private List<Group> groups;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Changed the mutability of UserResource's groups attribute to 'readOnly' for conformance with the spec. Previously, this attribute used the default mutability value of 'readWrite'.

Does this close any currently open issues?
------------------------------------------
This closes #116.
