### PR TITLE
Update jackson-databind to 2.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v2.3.2 - unreleased
+Updated the jackson-databind dependency to 2.9.10, which addresses latest known potential security issues.
 
 
 ## v2.3.1 - 201-08-16

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <main.basedir>${project.basedir}</main.basedir>
     <ignore.test.failures>false</ignore.test.failures>
     <jackson.version>2.9.9</jackson.version>
-    <jackson-databind.version>2.9.9.3</jackson-databind.version>
+    <jackson-databind.version>2.9.10</jackson-databind.version>
     <jaxb.version>2.3.1</jaxb.version>
     <jax-rs.version>2.0.1</jax-rs.version>
     <jersey.version>2.28</jersey.version>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Updates jackson-databind dependency to 2.9.10, to pick up fixes for security vulnerabilities
CVE-2019-14540
CVE-2019-16335

Does this close any currently open issues?
------------------------------------------
No