### PR TITLE
Prevent possibility of template variable injection in SCIM2 SDK POST search

### DIFF
--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/DotSearchFilter.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/DotSearchFilter.java
@@ -138,7 +138,7 @@ public class DotSearchFilter implements ContainerRequestFilter
    * @param s the string with zero or more template parameters names
    * @return the string with encoded template parameters names.
    */
-  private static String encodeTemplateNames(final String s)
+  static String encodeTemplateNames(final String s)
   {
     String s1 = s;
     int i = s1.indexOf('{');

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/DotSearchFilter.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/DotSearchFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 Ping Identity Corporation
+ * Copyright 2015-2020 Ping Identity Corporation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPLv2 only)
@@ -92,28 +92,29 @@ public class DotSearchFilter implements ContainerRequestFilter
       if(searchRequest.getAttributes() != null)
       {
         builder.queryParam(QUERY_PARAMETER_ATTRIBUTES,
-            StaticUtils.collectionToString(searchRequest.getAttributes(), ","));
+            encodeTemplateNames(StaticUtils.collectionToString(
+                searchRequest.getAttributes(), ",")));
       }
       if(searchRequest.getExcludedAttributes() != null)
       {
         builder.queryParam(QUERY_PARAMETER_EXCLUDED_ATTRIBUTES,
-            StaticUtils.collectionToString(
-                searchRequest.getExcludedAttributes(), ","));
+            encodeTemplateNames(StaticUtils.collectionToString(
+                searchRequest.getExcludedAttributes(), ",")));
       }
       if(searchRequest.getFilter() != null)
       {
         builder.queryParam(QUERY_PARAMETER_FILTER,
-            searchRequest.getFilter());
+            encodeTemplateNames(searchRequest.getFilter()));
       }
       if(searchRequest.getSortBy() != null)
       {
         builder.queryParam(QUERY_PARAMETER_SORT_BY,
-            searchRequest.getSortBy());
+            encodeTemplateNames(searchRequest.getSortBy()));
       }
       if(searchRequest.getSortOrder() != null)
       {
         builder.queryParam(QUERY_PARAMETER_SORT_ORDER,
-            searchRequest.getSortOrder().getName());
+            encodeTemplateNames(searchRequest.getSortOrder().getName()));
       }
       if(searchRequest.getStartIndex() != null)
       {
@@ -129,4 +130,29 @@ public class DotSearchFilter implements ContainerRequestFilter
       requestContext.setMethod(HttpMethod.GET);
     }
   }
+
+  /**
+   * Encodes a string with template parameters names present, specifically the
+   * characters '{' and '}' will be percent-encoded.
+   *
+   * @param s the string with zero or more template parameters names
+   * @return the string with encoded template parameters names.
+   */
+  private static String encodeTemplateNames(final String s)
+  {
+    String s1 = s;
+    int i = s1.indexOf('{');
+    if (i != -1)
+    {
+      s1 = s1.replace("{", "%7B");
+    }
+    i = s1.indexOf('}');
+    if (i != -1)
+    {
+      s1 = s1.replace("}", "%7D");
+    }
+
+    return s1;
+  }
+
 }

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/providers/DotSearchFilterTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/providers/DotSearchFilterTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+
+package com.unboundid.scim2.server.providers;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test coverage for DotSearchFilter.
+ */
+public class DotSearchFilterTestCase
+{
+  /**
+   * Retrieves a set of strings to test encodeTemplateNames.
+   *
+   * @return  A set of input strings with expected output.
+   */
+  @DataProvider(name = "testEncodeTemplateNamesStrings")
+  public Object[][] getTestEncodeTemplateNames()
+  {
+    return new Object[][]
+        {
+            new Object[] { "cn eq \"{xx}\"", "cn eq \"%7Bxx%7D\"" },
+            new Object[] { "{a}{b}", "%7Ba%7D%7Bb%7D" },
+            new Object[] { "%7B%7D", "%7B%7D" },
+            new Object[] { "{{a}}", "%7B%7Ba%7D%7D" },
+            new Object[] { "}}}}{{{{", "%7D%7D%7D%7D%7B%7B%7B%7B" },
+            new Object[] { "{", "%7B" },
+            new Object[] { "}", "%7D" },
+            new Object[] { "", "" },
+        };
+  }
+
+  /**
+   * Test the encodeTemplateNames method.
+   *
+   * @param input The string to evaluate.
+   * @param output The expected result.
+   */
+  @Test(dataProvider = "testEncodeTemplateNamesStrings")
+  public void testFilter(String input, String output)
+  {
+    final String actualOutput = DotSearchFilter.encodeTemplateNames(input);
+    assertEquals(actualOutput, output);
+  }
+}


### PR DESCRIPTION
Prevent possibility of template variable injection in SCIM2 SDK POST search

JiraIssue: DS-41106
Product: ds
Product: proxy
Product: broker

What does this implement/fix? Explain your changes.
---------------------------------------------------
See DS-41106

Does this close any currently open issues?
------------------------------------------
DS-41106
