### PR TITLE
Update to Jackson 2.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
     <compileSource>1.7</compileSource>
     <main.basedir>${project.basedir}</main.basedir>
     <ignore.test.failures>false</ignore.test.failures>
-    <jackson.version>2.9.9</jackson.version>
-    <jackson-databind.version>2.9.10</jackson-databind.version>
+    <jackson.version>2.10.2</jackson.version>
+    <jackson-databind.version>2.10.2</jackson-databind.version>
     <jaxb.version>2.3.1</jaxb.version>
     <jax-rs.version>2.0.1</jax-rs.version>
     <jersey.version>2.28</jersey.version>


### PR DESCRIPTION
_Please be aware that Ping Identity does not accept third-party contributions at this time! Please see our [contribution guidelines](https://github.com/pingidentity/scim2/blob/master/CONTRIBUTING.md)._

What does this implement/fix? Explain your changes.
---------------------------------------------------
Updates the Jackson dependencies from 2.9.x to 2.10.2.

The Jackson 2.10.x series is expected to have fewer recurring security issues compared to the 2.9.x series.

Does this close any currently open issues?
------------------------------------------
DS-41098 (a Ping internal issue)
