### PR TITLE
performance improvement for consecutive client requests:

### DIFF
--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/CreateRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/CreateRequestBuilder.java
@@ -75,6 +75,11 @@ public final class CreateRequestBuilder<T extends ScimResource>
       if(response.getStatusInfo().getFamily() ==
           Response.Status.Family.SUCCESSFUL)
       {
+        response.bufferEntity();
+        /* fully read and close the input stream, allowing the buffered result
+           to be used while still keeping the TCP connection open for subsequent
+           requests
+         */
         return response.readEntity(cls);
       }
       else

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ReplaceRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ReplaceRequestBuilder.java
@@ -104,6 +104,11 @@ public final class ReplaceRequestBuilder<T extends ScimResource>
       if(response.getStatusInfo().getFamily() ==
           Response.Status.Family.SUCCESSFUL)
       {
+        response.bufferEntity();
+        /* fully read and close the input stream, allowing the buffered result
+           to be used while still keeping the TCP connection open for subsequent
+           requests
+         */
         return response.readEntity(cls);
       }
       else

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/SearchRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/SearchRequestBuilder.java
@@ -264,6 +264,11 @@ public final class SearchRequestBuilder
       if (response.getStatusInfo().getFamily() ==
           Response.Status.Family.SUCCESSFUL)
       {
+        response.bufferEntity();
+        /* fully read and close the input stream, allowing the buffered result
+           to be used while still keeping the TCP connection open for subsequent
+           requests
+         */
         InputStream inputStream = response.readEntity(InputStream.class);
         try
         {


### PR DESCRIPTION
 create, replace, search

This fix allows the client to reuse the underlying TCP stream and avoid creating
a new TCP connection for each request.  The effect of this is
especially noticeable when the connection to the SCIM server is using TLS or has
 significant latency.

Ok, I see that ping identity does not accept pull requests, but I suspect that you will want this fix.  The performance impact is quite significant under the conditions listed in issue #141 

Notes:
- I have tested this with GET, PUT and POST operations.  I have not tried it with PATCH requests, but I suspect there is probably a similar issue there that is not addressed by this PR.
- After implementing the fix, I noticed that the test class EndpointTestCase will fail in unpredictable ways.  However, it seems to me that this is somehow an artifact of how the test is constructed and not an issue with the fix in this PR itself.  I can supply the test case I use to verify this if it helps.  

_Please be aware that Ping Identity does not accept third-party contributions at this time! Please see our [contribution guidelines](https://github.com/pingidentity/scim2/blob/master/CONTRIBUTING.md)._

Does this close any currently open issues?
------------------------------------------
…
fixes #141 