### PR TITLE
Fix ability to customize Json mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.unboundid.product.scim2</groupId>
   <artifactId>scim2-parent</artifactId>
-  <version>2.3.8-SNAPSHOT</version>
+  <version>2.3.7.identity.2</version>
   <packaging>pom</packaging>
   <name>UnboundID SCIM2 SDK Parent</name>
   <description>
@@ -76,52 +76,21 @@
 
   <profiles>
     <profile>
-      <id>TravisCI</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <useFile>false</useFile>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>UnboundID</id>
       <distributionManagement>
         <repository>
           <id>releases</id>
-          <name>Engineering Releases Repo</name>
-          <url>${releaseRepoUrl}</url>
+          <name>Engineering Snapshots Repo</name>
+          <url>https://artifactory.grammarly.io/artifactory/common-maven</url>
         </repository>
         <snapshotRepository>
           <id>snapshots</id>
           <name>Engineering Snapshots Repo</name>
-          <url>${snapshotRepoUrl}</url>
+          <url>https://artifactory.grammarly.io/artifactory/common-maven</url>
         </snapshotRepository>
       </distributionManagement>
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <executions>
-              <execution>
-                <id>sign-resources</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <configuration>
-                  <passphrase>${env.GPG_PASSPHRASE}</passphrase>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
@@ -329,6 +298,27 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-sonatype-bundle</id>
+            <phase>install</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>${main.basedir}/assemblies/sonatype-bundle.xml</descriptor>
+              </descriptors>
+              <attach>false</attach>
+              <appendAssemblyId>false</appendAssemblyId>
+              <finalName>sonatype-bundle</finalName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -436,4 +426,16 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <distributionManagement>
+    <repository>
+      <id>releases</id>
+      <name>Engineering Snapshots Repo</name>
+      <url>https://artifactory.grammarly.io/artifactory/common-maven</url>
+    </repository>
+    <snapshotRepository>
+      <id>snapshots</id>
+      <name>Engineering Snapshots Repo</name>
+      <url>https://artifactory.grammarly.io/artifactory/common-maven</url>
+    </snapshotRepository>
+  </distributionManagement>
 </project>

--- a/scim2-assembly/pom.xml
+++ b/scim2-assembly/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>2.3.8-SNAPSHOT</version>
+    <version>2.3.7.identity.2</version>
   </parent>
   <artifactId>scim2-assembly</artifactId>
   <packaging>pom</packaging>

--- a/scim2-sdk-client/pom.xml
+++ b/scim2-sdk-client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>2.3.8-SNAPSHOT</version>
+        <version>2.3.7.identity.2</version>
     </parent>
     <artifactId>scim2-sdk-client</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-common/pom.xml
+++ b/scim2-sdk-common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>2.3.8-SNAPSHOT</version>
+        <version>2.3.7.identity.2</version>
     </parent>
     <artifactId>scim2-sdk-common</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -302,11 +302,10 @@ public abstract class PatchOperation
         throws ScimException
     {
       super(path);
-      if(value == null || value.isNull() ||
-           ((value.isArray() || value.isObject()) && value.size() == 0))
+      if(value == null || value.isNull())
        {
          throw BadRequestException.invalidSyntax(
-             "value field must not be null or an empty container");
+             "value field must not be null");
        }
       if(path == null && !value.isObject())
       {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/MapperFactory.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/MapperFactory.java
@@ -36,15 +36,15 @@ import java.util.Map;
  */
 public class MapperFactory
 {
-  private static Map<DeserializationFeature, Boolean> deserializationCustomFeatures =
+  private Map<DeserializationFeature, Boolean> deserializationCustomFeatures =
       Collections.<DeserializationFeature, Boolean>emptyMap();
-  private static Map<JsonParser.Feature, Boolean> jsonParserCustomFeatures =
+  private Map<JsonParser.Feature, Boolean> jsonParserCustomFeatures =
       Collections.<JsonParser.Feature, Boolean>emptyMap();
-  private static Map<JsonGenerator.Feature, Boolean> jsonGeneratorCustomFeatures =
+  private Map<JsonGenerator.Feature, Boolean> jsonGeneratorCustomFeatures =
       Collections.<JsonGenerator.Feature, Boolean>emptyMap();
-  private static Map<MapperFeature, Boolean> mapperCustomFeatures =
+  private Map<MapperFeature, Boolean> mapperCustomFeatures =
       Collections.<MapperFeature, Boolean>emptyMap();
-  private static Map<SerializationFeature, Boolean> serializationCustomFeatures =
+  private Map<SerializationFeature, Boolean> serializationCustomFeatures =
       Collections.<SerializationFeature, Boolean>emptyMap();
 
   /**
@@ -136,7 +136,7 @@ public class MapperFactory
    * @return an Object Mapper with the correct options set for serializing
    *     and deserializing SCIM JSON objects.
    */
-  public static ObjectMapper createObjectMapper()
+  public ObjectMapper createObjectMapper()
   {
     ObjectMapper mapper = new ObjectMapper(new ScimJsonFactory());
 

--- a/scim2-sdk-server/pom.xml
+++ b/scim2-sdk-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>2.3.8-SNAPSHOT</version>
+    <version>2.3.7.identity.2</version>
   </parent>
   <artifactId>scim2-sdk-server</artifactId>
   <packaging>jar</packaging>

--- a/scim2-ubid-extensions/pom.xml
+++ b/scim2-ubid-extensions/pom.xml
@@ -19,7 +19,7 @@
   <parent>
       <artifactId>scim2-parent</artifactId>
       <groupId>com.unboundid.product.scim2</groupId>
-      <version>2.3.8-SNAPSHOT</version>
+      <version>2.3.7.identity.2</version>
   </parent>
   <artifactId>scim2-ubid-extensions</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
_Please be aware that Ping Identity does not accept third-party contributions at this time! Please see our [contribution guidelines](https://github.com/pingidentity/scim2/blob/master/CONTRIBUTING.md)._

What does this implement/fix? Explain your changes.
---------------------------------------------------
Removes static from MapperFactory so JSON serialization could be customized. Right now it is incompatible with Okta's version of SCIM messages. Namely, fields `roles` and `entitlements`. This fix allows customized json payload so the library is compatible

Does this close any currently open issues?
------------------------------------------
Issue #147 
