### PR TITLE
Issue 143: Update TestNG to 7.4.0 and clean up POMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v2.3.7 - TBD
-added ParserOptions class, which may be used to extend the set of characters allowed in filtered
+Added ParserOptions class, which may be used to extend the set of characters allowed in filtered
 attribute names.
+
+Updated the TestNG dependency to 7.4.0 and corrected its scope from the default 'compile' to 'test'.
 
 
 ## v2.3.6 - 2021-06-11

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <jax-rs.version>2.0.1</jax-rs.version>
     <jersey.version>2.28</jersey.version>
     <guava.version>29.0-jre</guava.version>
-    <testng.version>6.4</testng.version>
+    <testng.version>7.4.0</testng.version>
   </properties>
 
   <profiles>
@@ -335,6 +335,26 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.unboundid.product.scim2</groupId>
+        <artifactId>scim2-sdk-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.unboundid.product.scim2</groupId>
+        <artifactId>scim2-sdk-client</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.unboundid.product.scim2</groupId>
+        <artifactId>scim2-sdk-server</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.unboundid.product.scim2</groupId>
+        <artifactId>scim2-ubid-extensions</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${jackson.version}</version>
@@ -363,7 +383,6 @@
         <groupId>javax.ws.rs</groupId>
         <artifactId>javax.ws.rs-api</artifactId>
         <version>${jax-rs.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>
@@ -374,55 +393,46 @@
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.2</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-server</artifactId>
         <version>${jersey.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-client</artifactId>
         <version>${jersey.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.inject</groupId>
         <artifactId>jersey-hk2</artifactId>
         <version>${jersey.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.connectors</groupId>
         <artifactId>jersey-apache-connector</artifactId>
         <version>${jersey.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.test-framework</groupId>
         <artifactId>jersey-test-framework-core</artifactId>
         <version>${jersey.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
         <artifactId>jersey-test-framework-provider-jetty</artifactId>
         <version>${jersey.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
         <version>${testng.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/scim2-assembly/pom.xml
+++ b/scim2-assembly/pom.xml
@@ -73,12 +73,10 @@
     <dependency>
       <groupId>com.unboundid.product.scim2</groupId>
       <artifactId>scim2-sdk-server</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.unboundid.product.scim2</groupId>
       <artifactId>scim2-ubid-extensions</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/scim2-sdk-client/pom.xml
+++ b/scim2-sdk-client/pom.xml
@@ -163,7 +163,6 @@
     <dependency>
       <groupId>com.unboundid.product.scim2</groupId>
       <artifactId>scim2-sdk-common</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -180,7 +179,6 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/scim2-sdk-common/pom.xml
+++ b/scim2-sdk-common/pom.xml
@@ -215,16 +215,18 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/scim2-sdk-server/pom.xml
+++ b/scim2-sdk-server/pom.xml
@@ -174,12 +174,10 @@
     <dependency>
       <groupId>com.unboundid.product.scim2</groupId>
       <artifactId>scim2-sdk-common</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.unboundid.product.scim2</groupId>
       <artifactId>scim2-sdk-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -200,42 +198,52 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
       <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.connectors</groupId>
       <artifactId>jersey-apache-connector</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework</groupId>
       <artifactId>jersey-test-framework-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaAwareFilterEvaluatorTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaAwareFilterEvaluatorTestCase.java
@@ -106,7 +106,7 @@ public class SchemaAwareFilterEvaluatorTestCase
    * @param result The expected result.
    * @throws ScimException If the filter string is invalid.
    */
-  @Test(dataProvider = "getTestValidFilterStrings")
+  @Test(dataProvider = "testValidFilterStrings")
   public void testFilter(String filter, boolean result)
       throws ScimException
   {

--- a/scim2-ubid-extensions/pom.xml
+++ b/scim2-ubid-extensions/pom.xml
@@ -175,7 +175,6 @@
     <dependency>
       <groupId>com.unboundid.product.scim2</groupId>
       <artifactId>scim2-sdk-common</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -188,6 +187,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
_Please be aware that Ping Identity does not accept third-party contributions at this time! Please see our [contribution guidelines](https://github.com/pingidentity/scim2/blob/master/CONTRIBUTING.md)._

What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates TestNG to version 7.4.0, which addresses a potential vulnerability in version 6.4.

Also cleaned up the POMs. Most notably:

* Dependency scope is no longer declared in the parent POM's dependencyManagement section but is instead declared in the child POMs.
* Fixed a bug in which the TestNG dependency was not declared with "test" scope.

Does this close any currently open issues?
------------------------------------------
Resolves issue 143.
