### PR TITLE
Fix issue where PATCH requests from Azure AD fail due to case-mismatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <compileSource>1.8</compileSource>
     <main.basedir>${project.basedir}</main.basedir>
     <ignore.test.failures>false</ignore.test.failures>
-    <jackson.version>2.10.2</jackson.version>
+    <jackson.version>2.14.2</jackson.version>
     <jackson-databind.version>2.10.5.1</jackson-databind.version>
     <jaxb.version>2.3.1</jaxb.version>
     <jax-rs.version>2.0.1</jax-rs.version>

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -54,11 +54,11 @@ import java.util.List;
     property = "op")
 @JsonSubTypes({
     @JsonSubTypes.Type(value = PatchOperation.AddOperation.class,
-        name="add"),
+        name="add", names= {"add", "Add", "ADD"}),
     @JsonSubTypes.Type(value = PatchOperation.RemoveOperation.class,
-        name="remove"),
+        name="remove", names= {"remove", "Remove", "REMOVE"}),
     @JsonSubTypes.Type(value = PatchOperation.ReplaceOperation.class,
-        name="replace")})
+        name="replace", names= {"replace", "Replace", "REPLACE"})})
 public abstract class PatchOperation
 {
   static final class AddOperation extends PatchOperation


### PR DESCRIPTION
JIRA issue: DS-46964

_Please be aware that Ping Identity does not accept third-party contributions at this time! Please see our [contribution guidelines](https://github.com/pingidentity/scim2/blob/master/CONTRIBUTING.md)._

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixed an issue where PATCH requests from Azure AD
fail due to a case-mismatch in the op type.

Does this close any currently open issues?
------------------------------------------
Closes DS-46964
