### PR TITLE
Add varargs helper methods for multi-valued fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 
-## v2.3.9 - TBD
+## v2.4.0 - TBD
 Fixed an issue with PatchOperations that prevented setting the `value` field to an empty array. The
 constructor would previously reject this kind of operation with a BadRequestException.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 Fixed an issue with PatchOperations that prevented setting the `value` field to an empty array. The
 constructor would previously reject this kind of operation with a BadRequestException.
 
+Added a variety of methods for providing multi-valued parameters directly into a method without
+needing to wrap the arguments into a List. For example, setting a single email on a UserResource used
+to be done with `user.setEmails(Collections.singletonList(email))`, but this can now be shortened to
+`user.setEmails(email)`. Note that the existing methods are still available and have not been
+deprecated. Other examples include `BaseScimResource.setSchemaUrns()`,
+`GenericScimResource.addStringValues()`, `PatchOperation.addDoubleValues()`, and the `PatchRequest`
+constructor.
+
 
 ## v2.3.8 - 2023-05-17
 Updated the deserialized form of ListResponse objects so that the `itemsPerPage` and `startIndex`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ deprecated. Other examples include `BaseScimResource.setSchemaUrns()`,
 `GenericScimResource.addStringValues()`, `PatchOperation.addDoubleValues()`, and the `PatchRequest`
 constructor.
 
+Updated the schema URNs field of `BaseScimResource` to use a `LinkedHashSet` instead of a generic
+`HashSet`. This allows for a SCIM resource with multiple schema URNs to have a predictable order
+when the resource is deserialized into JSON.
+
 
 ## v2.3.8 - 2023-05-17
 Updated the deserialized form of ListResponse objects so that the `itemsPerPage` and `startIndex`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Updated the schema URNs field of `BaseScimResource` to use a `LinkedHashSet` ins
 `HashSet`. This allows for a SCIM resource with multiple schema URNs to have a predictable order
 when the resource is deserialized into JSON.
 
+Deprecated methods of the form `addBooleanValues()` and `getBooleanValueList()` on the
+`GenericScimResource` and `PatchOperation` classes. These methods provided an interface for
+so-called "multi-valued boolean arrays", but boolean data is always single-valued in nature.
+Updating a boolean value should always be done with a `replace` operation type rather than an `add`.
+
 
 ## v2.3.8 - 2023-05-17
 Updated the deserialized form of ListResponse objects so that the `itemsPerPage` and `startIndex`

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Email email = new Email()
   .setType("home")
   .setPrimary(true)
   .setValue("babs@example.com");
-user.setEmails(Collections.singletonList(email));
+user.setEmails(email);
 user = scimService.create("Users", user);
 
 // Retrieve the user as a UserResource and replace with a modified instance using PUT
@@ -87,7 +87,7 @@ user = scimService.replace(user);
 // Retrieve the user as a GenericScimResource and replace with a modified instance using PUT
 GenericScimResource genericUser =
     scimService.retrieve("Users", user.getId(), GenericScimResource.class);
-genericUser.replaceValue("displayName", TextNode.valueOf("Babs Jensen"));
+genericUser.replace("displayName", "Babs Jensen");
 genericUser = scimService.replaceRequest(genericUser).invoke();
 
 // Perform a partial modification of the user using PATCH

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.unboundid.product.scim2</groupId>
   <artifactId>scim2-parent</artifactId>
-  <version>2.3.9-SNAPSHOT</version>
+  <version>2.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>UnboundID SCIM2 SDK Parent</name>
   <description>

--- a/scim2-assembly/pom.xml
+++ b/scim2-assembly/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>2.3.9-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-assembly</artifactId>
   <packaging>pom</packaging>

--- a/scim2-sdk-client/pom.xml
+++ b/scim2-sdk-client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>2.3.9-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>scim2-sdk-client</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-common/pom.xml
+++ b/scim2-sdk-common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>2.3.9-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>scim2-sdk-common</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
@@ -41,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.unboundid.scim2.common.utils.StaticUtils.toList;
+
 /**
  * <p>The base SCIM object.  This object contains all of the
  * attributes required of SCIM objects.</p>
@@ -176,7 +178,15 @@ public abstract class BaseScimResource
    */
   public void setSchemaUrns(final Collection<String> schemaUrns)
   {
-    this.schemaUrns = new HashSet<String>(schemaUrns);
+    this.schemaUrns = new HashSet<>(schemaUrns);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public void setSchemaUrns(final String schemaUrn, final String... schemaUrns)
+  {
+    setSchemaUrns(toList(schemaUrn, schemaUrns));
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
@@ -35,10 +35,11 @@ import com.unboundid.scim2.common.utils.SchemaUtils;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.unboundid.scim2.common.utils.StaticUtils.toList;
@@ -76,7 +77,7 @@ public abstract class BaseScimResource
   private Meta meta;
 
   @JsonProperty("schemas")
-  private Set<String> schemaUrns = new HashSet<String>();
+  private Set<String> schemaUrns = new LinkedHashSet<>();
 
   private final ObjectNode extensionObjectNode =
       JsonUtils.getJsonNodeFactory().objectNode();
@@ -165,11 +166,6 @@ public abstract class BaseScimResource
    */
   public Set<String> getSchemaUrns()
   {
-    if(schemaUrns == null)
-    {
-      schemaUrns = new HashSet<String>();
-    }
-
     return schemaUrns;
   }
 
@@ -178,7 +174,8 @@ public abstract class BaseScimResource
    */
   public void setSchemaUrns(final Collection<String> schemaUrns)
   {
-    this.schemaUrns = new HashSet<>(schemaUrns);
+    Objects.requireNonNull(schemaUrns);
+    this.schemaUrns = new LinkedHashSet<>(schemaUrns);
   }
 
   /**
@@ -535,8 +532,7 @@ public abstract class BaseScimResource
     {
       return false;
     }
-    if (schemaUrns != null ? !schemaUrns.equals(that.schemaUrns) :
-        that.schemaUrns != null)
+    if (!schemaUrns.equals(that.schemaUrns))
     {
       return false;
     }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
@@ -30,6 +30,7 @@ import com.unboundid.scim2.common.types.Meta;
 import com.unboundid.scim2.common.utils.GenericScimObjectDeserializer;
 import com.unboundid.scim2.common.utils.GenericScimObjectSerializer;
 import com.unboundid.scim2.common.utils.JsonUtils;
+import static com.unboundid.scim2.common.utils.StaticUtils.toList;
 
 import java.io.IOException;
 import java.net.URI;
@@ -40,6 +41,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * <p>A generic SCIM object.  This object can be used if you have no
@@ -213,6 +215,14 @@ public final class GenericScimResource implements ScimResource
       // This should never happen.
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public void setSchemaUrns(final String schemaUrn, final String... schemaUrns)
+  {
+    setSchemaUrns(toList(schemaUrn, schemaUrns));
   }
 
   /**
@@ -469,6 +479,42 @@ public final class GenericScimResource implements ScimResource
     }
   }
 
+  /**
+   * Indicates whether the provided object is equal to this generic SCIM
+   * resource.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this generic
+   *            SCIM resource, or {@code false} if not.
+   */
+  @Override
+  public boolean equals(final Object o)
+  {
+    if (!(o instanceof GenericScimResource))
+    {
+      return false;
+    }
+
+    ObjectNode otherNode = ((GenericScimResource) o).getObjectNode();
+    if (objectNode == null)
+    {
+      return (otherNode == null);
+    }
+
+    return objectNode.equals(otherNode);
+  }
+
+  /**
+   * Retrieves a hash code for this generic SCIM resource.
+   *
+   * @return  A hash code for this generic SCIM resource.
+   */
+  @Override
+  public int hashCode()
+  {
+    return Objects.hashCode(objectNode);
+  }
+
 
   /////////////////////////////////////
   // SCIM String methods
@@ -586,6 +632,24 @@ public final class GenericScimResource implements ScimResource
   }
 
   /**
+   * Alternate version of {@link #addStringValues(String, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addStringValues(final String path,
+      final String value1, final String... values)
+          throws ScimException
+  {
+    return addStringValues(path, toList(value1, values));
+  }
+
+  /**
    * Adds String values to an array node.  If no array node exists at the
    * specified path, a new array node will be created.
    *   <p>
@@ -627,6 +691,24 @@ public final class GenericScimResource implements ScimResource
     }
 
     return addValues(path, valuesArrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addStringValues(Path, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addStringValues(final Path path,
+      final String value1, final String... values)
+          throws ScimException
+  {
+    return addStringValues(path, toList(value1, values));
   }
 
   /**
@@ -752,7 +834,7 @@ public final class GenericScimResource implements ScimResource
   public List<String> getStringValueList(final Path path) throws ScimException
   {
     JsonNode valueNode = getValue(path);
-    List<String> values = new ArrayList<String>();
+    List<String> values = new ArrayList<>();
 
     Iterator<JsonNode> iterator = valueNode.iterator();
     while (iterator.hasNext())
@@ -1177,6 +1259,24 @@ public final class GenericScimResource implements ScimResource
   }
 
   /**
+   * Alternate version of {@link #addDoubleValues(String, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addDoubleValues(final String path,
+      final Double value1, final Double... values)
+          throws ScimException
+  {
+    return addDoubleValues(path, toList(value1, values));
+  }
+
+  /**
    * Adds Double values to an array node.  If no array node exists at the
    * specified path, a new array node will be created.
    *   <p>
@@ -1218,6 +1318,24 @@ public final class GenericScimResource implements ScimResource
     }
 
     return addValues(path, valuesArrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addDoubleValues(Path, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addDoubleValues(final Path path,
+      final Double value1, final Double... values)
+          throws ScimException
+  {
+    return addDoubleValues(path, toList(value1, values));
   }
 
   /**
@@ -1471,6 +1589,24 @@ public final class GenericScimResource implements ScimResource
   }
 
   /**
+   * Alternate version of {@link #addIntegerValues(String, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addIntegerValues(final String path,
+      final Integer value1, final Integer... values)
+          throws ScimException
+  {
+    return addIntegerValues(path, toList(value1, values));
+  }
+
+  /**
    * Adds Integer values to an array node.  If no array node exists at the
    * specified path, a new array node will be created.
    *   <p>
@@ -1512,6 +1648,24 @@ public final class GenericScimResource implements ScimResource
     }
 
     return addValues(path, valuesArrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addIntegerValues(Path, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addIntegerValues(final Path path,
+      final Integer value1, final Integer... values)
+          throws ScimException
+  {
+    return addIntegerValues(path, toList(value1, values));
   }
 
   /**
@@ -1766,6 +1920,24 @@ public final class GenericScimResource implements ScimResource
   }
 
   /**
+   * Alternate version of {@link #addLongValues(String, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addLongValues(
+      final String path, final Long value1, final Long... values)
+          throws ScimException
+  {
+    return addLongValues(path, toList(value1, values));
+  }
+
+  /**
    * Adds Long values to an array node.  If no array node exists at the
    * specified path, a new array node will be created.
    *   <p>
@@ -1807,6 +1979,24 @@ public final class GenericScimResource implements ScimResource
     }
 
     return addValues(path, valuesArrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addLongValues(Path, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addLongValues(
+      final Path path, final Long value1, final Long... values)
+          throws ScimException
+  {
+    return addLongValues(path, toList(value1, values));
   }
 
   /**
@@ -2060,6 +2250,24 @@ public final class GenericScimResource implements ScimResource
   }
 
   /**
+   * Alternate version of {@link #addDateValues(String, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addDateValues(
+      final String path, final Date value1, final Date... values)
+          throws ScimException
+  {
+    return addDateValues(path, toList(value1, values));
+  }
+
+  /**
    * Adds Date values to an array node.  If no array node exists at the
    * specified path, a new array node will be created.
    *   <p>
@@ -2101,6 +2309,24 @@ public final class GenericScimResource implements ScimResource
     }
 
     return addValues(path, valuesArrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addDateValues(Path, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addDateValues(
+      final Path path, final Date value1, final Date... values)
+          throws ScimException
+  {
+    return addDateValues(path, toList(value1, values));
   }
 
   /**
@@ -2397,6 +2623,24 @@ public final class GenericScimResource implements ScimResource
   }
 
   /**
+   * Alternate version of {@link #addBinaryValues(String, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addBinaryValues(
+      final String path, final byte[] value1, final byte[]... values)
+          throws ScimException
+  {
+    return addBinaryValues(path, toList(value1, values));
+  }
+
+  /**
    * Adds binary values to an array node.  If no array node exists at the
    * specified path, a new array node will be created.
    *   <p>
@@ -2438,6 +2682,24 @@ public final class GenericScimResource implements ScimResource
     }
 
     return addValues(path, valuesArrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addBinaryValues(Path, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addBinaryValues(
+      final Path path, final byte[] value1, final byte[]... values)
+          throws ScimException
+  {
+    return addBinaryValues(path, toList(value1, values));
   }
 
   /**
@@ -2723,6 +2985,24 @@ public final class GenericScimResource implements ScimResource
   }
 
   /**
+   * Alternate version of {@link #addURIValues(String, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addURIValues(
+      final String path, final URI value1, final URI... values)
+          throws ScimException
+  {
+    return addURIValues(path, toList(value1, values));
+  }
+
+  /**
    * Adds URI values to an array node.  If no array node exists at the
    * specified path, a new array node will be created.
    *   <p>
@@ -2767,6 +3047,24 @@ public final class GenericScimResource implements ScimResource
     }
 
     return addValues(path, valuesArrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addURIValues(Path, List)}.
+   *
+   * @param path    The path to the attribute that should be updated.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        This object.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public GenericScimResource addURIValues(
+      final Path path, final URI value1, final URI... values)
+          throws ScimException
+  {
+    return addURIValues(path, toList(value1, values));
   }
 
   /**
@@ -2925,5 +3223,4 @@ public final class GenericScimResource implements ScimResource
       throw new ServerErrorException(ex.getMessage());
     }
   }
-
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
@@ -955,7 +955,13 @@ public final class GenericScimResource implements ScimResource
    * @return returns the new generic SCIM resource (this).
    * @throws ScimException thrown if an error occurs (for example
    * if the path or value is "{@code null}" or invalid).
+   * @deprecated  Since 2.4.0. Boolean attributes represent data that has one of
+   *              two possible values, so they are single-valued in nature.
+   *              Thus, a multi-valued boolean array is not well-defined, since
+   *              arrays such as {@code [true, false]} do not contain meaningful
+   *              data. Use {@link #replaceValue(String, Boolean)} instead.
    */
+  @Deprecated
   public GenericScimResource addBooleanValues(final String path,
       final List<Boolean> values) throws ScimException
   {
@@ -993,7 +999,13 @@ public final class GenericScimResource implements ScimResource
    * @return returns the new generic SCIM resource (this).
    * @throws ScimException thrown if an error occurs (for example
    * if the path or value is "{@code null}" or invalid).
+   * @deprecated  Since 2.4.0. Boolean attributes represent data that has one of
+   *              two possible values, so they are single-valued in nature.
+   *              Thus, a multi-valued boolean array is not well-defined, since
+   *              arrays such as {@code [true, false]} do not contain meaningful
+   *              data. Use {@link #replaceValue(Path, Boolean)} instead.
    */
+  @Deprecated
   public GenericScimResource addBooleanValues(final Path path,
       final List<Boolean> values) throws ScimException
   {
@@ -1096,7 +1108,13 @@ public final class GenericScimResource implements ScimResource
    * @param path the path to get the value from.
    * @return the value at the path, or an empty list.
    * @throws ScimException thrown if an error occurs.
+   * @deprecated  Since 2.4.0. Boolean attributes represent data that has one of
+   *              two possible values, so they are single-valued in nature.
+   *              Thus, a multi-valued boolean array is not well-defined, since
+   *              arrays such as {@code [true, false]} do not contain meaningful
+   *              data. Use {@link #getBooleanValue(String)} instead.
    */
+  @Deprecated
   public List<Boolean> getBooleanValueList(final String path)
       throws ScimException
   {
@@ -1128,7 +1146,13 @@ public final class GenericScimResource implements ScimResource
    * @param path the path to get the value from.
    * @return the value at the path, or an empty list.
    * @throws ScimException thrown if an error occurs.
+   * @deprecated  Since 2.4.0. Boolean attributes represent data that has one of
+   *              two possible values, so they are single-valued in nature.
+   *              Thus, a multi-valued boolean array is not well-defined, since
+   *              arrays such as {@code [true, false]} do not contain meaningful
+   *              data. Use {@link #getBooleanValue(Path)} instead.
    */
+  @Deprecated
   public List<Boolean> getBooleanValueList(final Path path) throws ScimException
   {
     JsonNode valueNode = getValue(path);

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/ScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/ScimResource.java
@@ -76,10 +76,21 @@ public interface ScimResource
   /**
    * Sets the schema urns for this object.  This set should contain
    * all schema urns including the one for this object and all
-   * extensions.
-   * @param schemaUrns a set containing the schema urns for this object.
+   * extensions.  The value must not be {@code null}.
+   *
+   * @param schemaUrns A Collection containing the schema urns for this object.
    */
   void setSchemaUrns(Collection<String> schemaUrns);
+
+  /**
+   * An alternate version of {@link #setSchemaUrns(Collection)}.
+   *
+   * @param schemaUrn  A schema URN that will be listed first. This must not be
+   *                   {@code null}.
+   * @param schemaUrns An optional parameter for additional schema URNs. Any
+   *                   {@code null} values will be ignored.
+   */
+  void setSchemaUrns(String schemaUrn, String... schemaUrns);
 
   /**
    * Returns the GenericScimResource representation of this ScimResource. If

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -46,6 +46,8 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
+import static com.unboundid.scim2.common.utils.StaticUtils.toList;
+
 /**
  * An individual patch operation.
  */
@@ -642,6 +644,25 @@ public abstract class PatchOperation
   }
 
   /**
+   * Alternate version of {@link #addStringValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public static PatchOperation addStringValues(
+      final String path, final String value1, final String... values)
+          throws ScimException
+  {
+    return addStringValues(path, toList(value1, values));
+  }
+
+  /**
    * Create a new add patch operation.
    *
    * @param path The path targeted by this patch operation.  The path
@@ -659,6 +680,22 @@ public abstract class PatchOperation
       arrayNode.add(value);
     }
     return add(path, arrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addStringValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   */
+  public static PatchOperation addStringValues(
+      final Path path, final String value1, final String... values)
+  {
+    return addStringValues(path, toList(value1, values));
   }
 
   /**
@@ -792,6 +829,25 @@ public abstract class PatchOperation
   }
 
   /**
+   * Alternate version of {@link #addDoubleValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public static PatchOperation addDoubleValues(
+      final String path, final Double value1, final Double... values)
+          throws ScimException
+  {
+    return addDoubleValues(path, toList(value1, values));
+  }
+
+  /**
    * Create a new add patch operation.
    *
    * @param path The path targeted by this patch operation.  The path
@@ -809,6 +865,22 @@ public abstract class PatchOperation
       arrayNode.add(value);
     }
     return add(path, arrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addDoubleValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   */
+  public static PatchOperation addDoubleValues(
+      final Path path, final Double value1, final Double... values)
+  {
+    return addDoubleValues(path, toList(value1, values));
   }
 
   /**
@@ -866,6 +938,25 @@ public abstract class PatchOperation
   }
 
   /**
+   * Alternate version of {@link #addIntegerValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public static PatchOperation addIntegerValues(
+      final String path, final Integer value1, final Integer... values)
+          throws ScimException
+  {
+    return addIntegerValues(path, toList(value1, values));
+  }
+
+  /**
    * Create a new add patch operation.
    *
    * @param path The path targeted by this patch operation.  The path
@@ -883,6 +974,22 @@ public abstract class PatchOperation
       arrayNode.add(value);
     }
     return add(path, arrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addIntegerValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   */
+  public static PatchOperation addIntegerValues(
+      final Path path, final Integer value1, final Integer... values)
+  {
+    return addIntegerValues(path, toList(value1, values));
   }
 
   /**
@@ -940,6 +1047,25 @@ public abstract class PatchOperation
   }
 
   /**
+   * Alternate version of {@link #addLongValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public static PatchOperation addLongValues(
+      final String path, final Long value1, final Long... values)
+          throws ScimException
+  {
+    return addLongValues(path, toList(value1, values));
+  }
+
+  /**
    * Create a new add patch operation.
    *
    * @param path The path targeted by this patch operation.  The path
@@ -957,6 +1083,22 @@ public abstract class PatchOperation
       arrayNode.add(value);
     }
     return add(path, arrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addLongValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   */
+  public static PatchOperation addLongValues(
+      final Path path, final Long value1, final Long... values)
+  {
+    return addLongValues(path, toList(value1, values));
   }
 
   /**
@@ -1014,6 +1156,25 @@ public abstract class PatchOperation
   }
 
   /**
+   * Alternate version of {@link #addDateValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public static PatchOperation addDateValues(
+      final String path, final Date value1, final Date... values)
+          throws ScimException
+  {
+    return addDateValues(path, toList(value1, values));
+  }
+
+  /**
    * Create a new add patch operation.
    *
    * @param path The path targeted by this patch operation.  The path
@@ -1032,6 +1193,25 @@ public abstract class PatchOperation
       arrayNode.add(GenericScimResource.getDateJsonNode(value).textValue());
     }
     return add(path, arrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addDateValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public static PatchOperation addDateValues(
+      final Path path, final Date value1, final Date... values)
+          throws ScimException
+  {
+    return addDateValues(path, toList(value1, values));
   }
 
   /**
@@ -1094,6 +1274,25 @@ public abstract class PatchOperation
   }
 
   /**
+   * Alternate version of {@link #addBinaryValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public static PatchOperation addBinaryValues(
+      final String path, final byte[] value1, final byte[]... values)
+          throws ScimException
+  {
+    return addBinaryValues(path, toList(value1, values));
+  }
+
+  /**
    * Create a new add patch operation.
    *
    * @param path The path targeted by this patch operation.  The path
@@ -1111,6 +1310,22 @@ public abstract class PatchOperation
       arrayNode.add(Base64Variants.getDefaultVariant().encode(value));
     }
     return add(path, arrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addBinaryValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   */
+  public static PatchOperation addBinaryValues(
+      final Path path, final byte[] value1, final byte[]... values)
+  {
+    return addBinaryValues(path, toList(value1, values));
   }
 
   /**
@@ -1170,6 +1385,25 @@ public abstract class PatchOperation
   }
 
   /**
+   * Alternate version of {@link #addURIValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   *
+   * @throws ScimException  If the path is invalid.
+   */
+  public static PatchOperation addURIValues(
+      final String path, final URI value1, final URI... values)
+          throws ScimException
+  {
+    return addURIValues(path, toList(value1, values));
+  }
+
+  /**
    * Create a new add patch operation.
    *
    * @param path The path targeted by this patch operation.  The path
@@ -1187,6 +1421,22 @@ public abstract class PatchOperation
       arrayNode.add(value.toString());
     }
     return add(path, arrayNode);
+  }
+
+  /**
+   * Alternate version of {@link #addURIValues(String, List)}.
+   *
+   * @param path    The attribute path targeted by this patch operation. The
+   *                path must not be {@code null}.
+   * @param value1  The first value. This must not be {@code null}.
+   * @param values  An optional field for additional values. Any {@code null}
+   *                values will be ignored.
+   * @return        A new PatchOperation with an opType of {@code "add"}.
+   */
+  public static PatchOperation addURIValues(
+      final Path path, final URI value1, final URI... values)
+  {
+    return addURIValues(path, toList(value1, values));
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -736,6 +736,12 @@ public abstract class PatchOperation
   /**
    * Create a new add patch operation.
    *
+   * @deprecated  Since 2.4.0. Boolean attributes represent data that has one of
+   *              two possible values, so they are single-valued in nature.
+   *              Thus, a multi-valued boolean array is not well-defined, since
+   *              arrays such as {@code [true, false]} do not contain meaningful
+   *              data. Use {@link #replace(String, Boolean)} instead.
+   *
    * @param path The path targeted by this patch operation.  The path
    *             must not be {@code null}.
    *             Path string examples:
@@ -746,6 +752,7 @@ public abstract class PatchOperation
    * @return The new add patch operation.
    * @throws ScimException If the path is invalid.
    */
+  @Deprecated
   public static PatchOperation addBooleanValues(
       final String path, final List<Boolean> values) throws ScimException
   {
@@ -755,12 +762,19 @@ public abstract class PatchOperation
   /**
    * Create a new add patch operation.
    *
+   * @deprecated  Since 2.4.0. Boolean attributes represent data that has one of
+   *              two possible values, so they are single-valued in nature.
+   *              Thus, a multi-valued boolean array is not well-defined, since
+   *              arrays such as {@code [true, false]} do not contain meaningful
+   *              data. Use {@link #replace(Path, Boolean)} instead.
+   *
    * @param path The path targeted by this patch operation.  The path
    *             must not be {@code null}.
    * @param values The values to add.
    *
    * @return The new add patch operation.
    */
+  @Deprecated
   public static PatchOperation addBooleanValues(
       final Path path, final List<Boolean> values)
   {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
@@ -29,6 +29,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import static com.unboundid.scim2.common.utils.StaticUtils.toList;
+
 /**
  * Class representing a SCIM 2 patch request.
  */
@@ -43,7 +45,7 @@ public final class PatchRequest
   private final List<PatchOperation> operations;
 
   /**
-   * Create a new Patch Operation Request.
+   * Create a new Patch Request.
    *
    * @param operations The list of operations to include.
    */
@@ -53,6 +55,20 @@ public final class PatchRequest
       final List<PatchOperation> operations)
   {
     this.operations = Collections.unmodifiableList(operations);
+  }
+
+  /**
+   * Create a new Patch Request.
+   *
+   * @param operation   The first operation in the patch request. This must not
+   *                    be {@code null}.
+   * @param operations  An optional field for additional patch operations. Any
+   *                    {@code null} values will be ignored.
+   */
+  public PatchRequest(final PatchOperation operation,
+                      final PatchOperation... operations)
+  {
+    this(toList(operation, operations));
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/UserResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/UserResource.java
@@ -24,11 +24,14 @@ import com.unboundid.scim2.common.annotations.Attribute;
 import java.net.URI;
 import java.util.List;
 
+import static com.unboundid.scim2.common.utils.StaticUtils.toList;
+
 /**
  * SCIM provides a resource type for "{@code User}" resources.  The core schema
  * for "{@code User}" is identified using the URI:
  * "{@code urn:ietf:params:scim:schemas:core:2.0:User}".
  */
+@SuppressWarnings("UnusedReturnValue")
 @Schema(id="urn:ietf:params:scim:schemas:core:2.0:User",
     name="User", description = "User Account")
 public class UserResource extends BaseScimResource
@@ -534,6 +537,20 @@ public class UserResource extends BaseScimResource
   }
 
   /**
+   * Alternate version of {@link #setEmails(List)}.
+   *
+   * @param email   A non-null email.
+   * @param emails  An optional set of additional arguments. Any
+   *                {@code null} values will be ignored.
+   * @return This object.
+   */
+  public UserResource setEmails(final Email email, final Email... emails)
+  {
+    setEmails(toList(email, emails));
+    return this;
+  }
+
+  /**
    * Retrieves the phone numbers for the User.
    *
    * @return The Phone numbers for the User.
@@ -552,6 +569,21 @@ public class UserResource extends BaseScimResource
   public UserResource setPhoneNumbers(final List<PhoneNumber> phoneNumbers)
   {
     this.phoneNumbers = phoneNumbers;
+    return this;
+  }
+
+  /**
+   * Alternate version of {@link #setPhoneNumbers(List)}.
+   *
+   * @param phoneNumber   A non-null phone number.
+   * @param phoneNumbers  An optional set of additional arguments. Any
+   *                      {@code null} values will be ignored.
+   * @return This object.
+   */
+  public UserResource setPhoneNumbers(final PhoneNumber phoneNumber,
+                                      final PhoneNumber... phoneNumbers)
+  {
+    setPhoneNumbers(toList(phoneNumber, phoneNumbers));
     return this;
   }
 
@@ -578,6 +610,21 @@ public class UserResource extends BaseScimResource
   }
 
   /**
+   * Alternate version of {@link #setIms(List)}.
+   *
+   * @param ims1   A non-null instant messaging address.
+   * @param ims    An optional set of additional arguments. Any
+   *               {@code null} values will be ignored.
+   * @return This object.
+   */
+  public UserResource setIms(final InstantMessagingAddress ims1,
+                             final InstantMessagingAddress... ims)
+  {
+    setIms(toList(ims1, ims));
+    return this;
+  }
+
+  /**
    * Retrieves the URIs of photos of the User.
    *
    * @return The URIs of photos of the User.
@@ -600,6 +647,20 @@ public class UserResource extends BaseScimResource
   }
 
   /**
+   * Alternate version of {@link #setPhotos(List)}.
+   *
+   * @param photo   A non-null photo.
+   * @param photos  An optional set of additional arguments. Any
+   *                {@code null}  values will be ignored.
+   * @return This object.
+   */
+  public UserResource setPhotos(final Photo photo, final Photo... photos)
+  {
+    setPhotos(toList(photo, photos));
+    return this;
+  }
+
+  /**
    * Retrieves the physical mailing addresses for this User.
    *
    * @return The physical mailing addresses for this User.
@@ -618,6 +679,21 @@ public class UserResource extends BaseScimResource
   public UserResource setAddresses(final List<Address> addresses)
   {
     this.addresses = addresses;
+    return this;
+  }
+
+  /**
+   * Alternate version of {@link #setAddresses(List)}.
+   *
+   * @param address    A non-null address.
+   * @param addresses  An optional set of additional arguments. Any
+   *                   {@code null} values will be ignored.
+   * @return This object.
+   */
+  public UserResource setAddresses(final Address address,
+                                   final Address... addresses)
+  {
+    setAddresses(toList(address, addresses));
     return this;
   }
 
@@ -646,6 +722,20 @@ public class UserResource extends BaseScimResource
   }
 
   /**
+   * Alternate version of {@link #setGroups(List)}.
+   *
+   * @param group1   A non-null group.
+   * @param groups   An optional set of additional arguments. Any
+   *                 {@code null} values will be ignored.
+   * @return This object.
+   */
+  public UserResource setGroups(final Group group1, final Group... groups)
+  {
+    setGroups(toList(group1, groups));
+    return this;
+  }
+
+  /**
    * Retrieves the list of entitlements for the User that represent a thing the
    * User has.
 
@@ -666,6 +756,21 @@ public class UserResource extends BaseScimResource
   public UserResource setEntitlements(final List<Entitlement> entitlements)
   {
     this.entitlements = entitlements;
+    return this;
+  }
+
+  /**
+   * Alternate version of {@link #setEntitlements(List)}.
+   *
+   * @param entitlement1   A non-null entitlement.
+   * @param entitlements   An optional set of additional arguments. Any
+   *                       {@code null} values will be ignored.
+   * @return This object.
+   */
+  public UserResource setEntitlements(final Entitlement entitlement1,
+                                      final Entitlement... entitlements)
+  {
+    setEntitlements(toList(entitlement1, entitlements));
     return this;
   }
 
@@ -694,6 +799,20 @@ public class UserResource extends BaseScimResource
   }
 
   /**
+   * Alternate version of {@link #setRoles(List)}.
+   *
+   * @param role1  A non-null role.
+   * @param roles  An optional set of additional arguments. Any
+   *               {@code null} values will be ignored.
+   * @return This object.
+   */
+  public UserResource setRoles(final Role role1, final Role... roles)
+  {
+    setRoles(toList(role1, roles));
+    return this;
+  }
+
+  /**
    * Retrieves the list of certificates issued to the User.
    *
    * @return The list of certificates issued to the User.
@@ -713,6 +832,22 @@ public class UserResource extends BaseScimResource
       final List<X509Certificate> x509Certificates)
   {
     this.x509Certificates = x509Certificates;
+    return this;
+  }
+
+  /**
+   * Alternate version of {@link #setX509Certificates(List)}.
+   *
+   * @param x509Certificate1  A non-null certificate.
+   * @param x509Certificates  An optional set of additional arguments. Any
+   *                          {@code null} values will be ignored.
+   * @return This object.
+   */
+  public UserResource setX509Certificates(
+      final X509Certificate x509Certificate1,
+      final X509Certificate... x509Certificates)
+  {
+    setX509Certificates(toList(x509Certificate1, x509Certificates));
     return this;
   }
 

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StaticUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StaticUtils.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -430,4 +431,38 @@ public final class StaticUtils
     }
   }
 
+
+  /**
+   * Converts an array of objects into a List form. This method is primarily
+   * used by the SDK for converting arrays into lists used by multi-valued
+   * parameters.
+   *
+   * @param <T>           The Java type of the elements.
+   * @param firstElement  The initial element in the array. This field is
+   *                      guaranteed to be first in the list returned by this
+   *                      method. This must not be {@code null}.
+   * @param elements      An optional array of additional objects to be included
+   *                      in the list. Any {@code null} values will be ignored.
+   *
+   * @return  A list of the elements. All entries in this list will be non-null.
+   */
+  public static <T> List<T> toList(final T firstElement, final T[] elements)
+  {
+    Objects.requireNonNull(firstElement);
+
+    List<T> list = new ArrayList<>();
+    list.add(firstElement);
+    if (elements != null)
+    {
+      for (T element : elements)
+      {
+        if (element != null)
+        {
+          list.add(element);
+        }
+      }
+    }
+
+    return list;
+  }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GenericScimResourceObjectTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GenericScimResourceObjectTest.java
@@ -191,12 +191,6 @@ public class GenericScimResourceObjectTest
     Boolean value1 = Boolean.TRUE;
     String path2 = "path2";
     Boolean value2 = Boolean.FALSE;
-    String path3 = "path3";
-    Boolean arrayValue1 = Boolean.TRUE;
-    Boolean arrayValue2 = Boolean.FALSE;
-    String path4 = "path4";
-    Boolean arrayValue3 = Boolean.FALSE;
-    Boolean arrayValue4 = Boolean.TRUE;
 
     GenericScimResource gsr = new GenericScimResource();
     Assert.assertEquals(gsr.replaceValue(path1, value1).
@@ -204,25 +198,8 @@ public class GenericScimResourceObjectTest
     Assert.assertEquals(gsr.replaceValue(Path.fromString(path2), value2).
         getBooleanValue(path2), value2);
 
-    List<Boolean> list1 = gsr.addBooleanValues(path3,
-        Lists.<Boolean>newArrayList(arrayValue1, arrayValue2)).
-        getBooleanValueList(Path.fromString(path3));
-    Assert.assertEquals(list1.size(), 2);
-    Assert.assertTrue(list1.contains(arrayValue1));
-    Assert.assertTrue(list1.contains(arrayValue2));
-
-     List<Boolean> list2 = gsr.addBooleanValues(Path.fromString(path4),
-         Lists.<Boolean>newArrayList(arrayValue3, arrayValue4)).
-        getBooleanValueList(path4);
-    Assert.assertEquals(list2.size(), 2);
-    Assert.assertTrue(list2.contains(arrayValue3));
-    Assert.assertTrue(list2.contains(arrayValue4));
-
     Assert.assertNull(gsr.getBooleanValue("bogusPath"));
     Assert.assertNull(gsr.getBooleanValue(Path.fromString("bogusPath")));
-    Assert.assertTrue(gsr.getBooleanValueList("bogusPath").isEmpty());
-    Assert.assertTrue(gsr.getBooleanValueList(
-        Path.fromString("bogusPath")).isEmpty());
   }
 
   /**

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/PatchOpTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/PatchOpTestCase.java
@@ -815,4 +815,69 @@ public class PatchOpTestCase
     PatchOperation.create(PatchOpType.ADD, "myArray", EMPTY_ARRAY);
     PatchOperation.create(PatchOpType.REPLACE, "myArray", EMPTY_ARRAY);
   }
+
+
+  /**
+   * Tests methods that accept varargs on the PatchOperation class, such as
+   * {@link PatchOperation#addIntegerValues(String, Integer, Integer...)}.
+   * Methods with varargs parameters should behave identically to their
+   * counterparts that accept a List as an input parameter.
+   *
+   * @throws Exception  If an unexpected error occurs.
+   */
+  @Test
+  public void testVarArgs() throws Exception
+  {
+    PatchOperation operation;
+    PatchOperation operation2;
+
+    operation = PatchOperation.addStringValues("backupEmails",
+            Arrays.asList("shady@example.com", "rabbit@example.com"));
+    operation2 = PatchOperation.addStringValues("backupEmails",
+            "shady@example.com", "rabbit@example.com");
+    assertEquals(operation, operation2);
+
+    operation = PatchOperation.addDoubleValues("weightHistoryLbs",
+            Arrays.asList(162.1, 165.0, 164.2));
+    operation2 = PatchOperation.addDoubleValues("weightHistoryLbs",
+            162.1, 165.0, 164.2);
+    assertEquals(operation, operation2);
+
+    operation = PatchOperation.addIntegerValues("siblingAges",
+            Arrays.asList(13, 13, 24));
+    operation2 = PatchOperation.addIntegerValues("siblingAges",
+            13, 13, 24);
+    assertEquals(operation, operation2);
+
+    operation = PatchOperation.addLongValues("favoritePrimes",
+            Arrays.asList(11L, 19L, 83L));
+    operation2 = PatchOperation.addLongValues("favoritePrimes",
+            11L, 19L, 83L);
+    assertEquals(operation, operation2);
+
+    operation = PatchOperation.addDateValues("commitTimestamps",
+            Arrays.asList(new Date(1426901922000L), new Date(1440085206000L)));
+    operation2 = PatchOperation.addDateValues("commitTimestamps",
+            new Date(1426901922000L), new Date(1440085206000L));
+    assertEquals(operation, operation2);
+
+    operation = PatchOperation.addBinaryValues("easterEgg",
+            Arrays.asList(
+                    new byte[] { 69, 97, 115, 116, 101, 114 },
+                    new byte[] { 101, 103, 103, 33 }
+            ));
+    operation2 = PatchOperation.addBinaryValues("easterEgg",
+            new byte[] { 69, 97, 115, 116, 101, 114 },
+            new byte[] { 101, 103, 103, 33 }
+    );
+    assertEquals(operation, operation2);
+
+    operation = PatchOperation.addURIValues("personalSites",
+            Arrays.asList(URI.create("https://example.com/"),
+                          URI.create("https://example.com/cool")));
+    operation2 = PatchOperation.addURIValues("personalSites",
+            URI.create("https://example.com/"),
+            URI.create("https://example.com/cool"));
+    assertEquals(operation, operation2);
+  }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/PatchOpTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/PatchOpTestCase.java
@@ -482,31 +482,7 @@ public class PatchOpTestCase
   @Test
   public void testBooleanPatchOps() throws Exception
   {
-    PatchOperation patchOp = PatchOperation.addBooleanValues("path1",
-        Lists.newArrayList(Boolean.TRUE, Boolean.FALSE));
-    Assert.assertEquals(patchOp.getOpType(), PatchOpType.ADD);
-    JsonNode jsonNode = patchOp.getJsonNode();
-    Assert.assertTrue(jsonNode.isArray());
-    Assert.assertEquals(jsonNode.size(), 2);
-    Assert.assertEquals(
-        jsonNode.get(0).booleanValue(), Boolean.TRUE.booleanValue());
-    Assert.assertEquals(
-        jsonNode.get(1).booleanValue(), Boolean.FALSE.booleanValue());
-    Assert.assertEquals(patchOp.getPath(), Path.fromString("path1"));
-
-    patchOp = PatchOperation.addBooleanValues(Path.fromString("path1"),
-        Lists.newArrayList(Boolean.FALSE, Boolean.TRUE));
-    Assert.assertEquals(patchOp.getOpType(), PatchOpType.ADD);
-    jsonNode = patchOp.getJsonNode();
-    Assert.assertTrue(jsonNode.isArray());
-    Assert.assertEquals(jsonNode.size(), 2);
-    Assert.assertEquals(
-        jsonNode.get(0).booleanValue(), Boolean.FALSE.booleanValue());
-    Assert.assertEquals(
-        jsonNode.get(1).booleanValue(), Boolean.TRUE.booleanValue());
-    Assert.assertEquals(patchOp.getPath(), Path.fromString("path1"));
-
-    patchOp = PatchOperation.replace(
+    PatchOperation patchOp = PatchOperation.replace(
         Path.fromString("path1"), Boolean.TRUE);
     Assert.assertEquals(patchOp.getOpType(), PatchOpType.REPLACE);
     Assert.assertEquals(patchOp.getValue(Boolean.class), Boolean.TRUE);

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/PatchRequestTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/PatchRequestTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+
+package com.unboundid.scim2.common;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.unboundid.scim2.common.messages.PatchOperation;
+import com.unboundid.scim2.common.messages.PatchRequest;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class PatchRequestTest
+{
+  /**
+   * Test the {@link PatchRequest} constructors.
+   *
+   * @throws Exception  If an unexpected error occurs.
+   */
+  @Test
+  public void testConstructors() throws Exception
+  {
+    PatchRequest listRequest = new PatchRequest(Collections.singletonList(
+            PatchOperation.add("nickName", TextNode.valueOf("G"))
+    ));
+    PatchRequest argsRequest = new PatchRequest(
+            PatchOperation.add("nickName", TextNode.valueOf("G"))
+    );
+    assertEquals(listRequest, argsRequest);
+
+    listRequest = new PatchRequest(Arrays.asList(
+            PatchOperation.add("displayName", TextNode.valueOf("myName")),
+            PatchOperation.replace("displayName", TextNode.valueOf("yourName"))
+    ));
+    argsRequest = new PatchRequest(
+            PatchOperation.add("displayName", TextNode.valueOf("myName")),
+            PatchOperation.replace("displayName", TextNode.valueOf("yourName"))
+    );
+    assertEquals(listRequest, argsRequest);
+
+    // Providing a null operations list should not be permitted.
+    assertThrows(NullPointerException.class, () -> new PatchRequest(null));
+
+    // The first parameter of the method should not accept null.
+    assertThrows(NullPointerException.class,
+            () -> new PatchRequest(null, PatchOperation.remove("invalid")));
+
+    // Null arguments in the varargs method should be ignored.
+    PatchRequest singleOperation = new PatchRequest(
+            PatchOperation.remove("password"), null, null
+    );
+    assertEquals(singleOperation.getOperations().size(), 1);
+  }
+}

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/SetSchemaTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/SetSchemaTest.java
@@ -118,4 +118,33 @@ public class SetSchemaTest
             "urn:pingidentity:proprietaryObject", null, null);
     assertEquals(genericObject.getSchemaUrns().size(), 1);
   }
+
+
+  /**
+   * Ensure that the requested order is preserved when an ordered Collection is
+   * used to initialize the schema URN set of a BaseScimResource.
+   */
+  @Test
+  public void testSchemaUrnOrder()
+  {
+    final String urn0 = "urn:ietf:params:scim:schemas:core:2.0:User";
+    final String urn1 = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+    final String urn2 = "urn:pingidentity:proprietaryObject";
+    final String urn3 = "urn:pingidentity:specialObject";
+    final String urn4 = "urn:pingidentity:veryParticularObject";
+    final String urn5 = "urn:pingidentity:aVeryVeryParticularObject";
+    final List<String> urns = Arrays.asList(urn0, urn1, urn2, urn3, urn4, urn5);
+    BaseScimResource resource = new UserResource();
+    resource.setSchemaUrns(urns);
+
+    String[] resourceSchemaUrns = resource.getSchemaUrns().toArray(new String[0]);
+    assertEquals(resourceSchemaUrns.length, 6);
+
+    assertEquals(resourceSchemaUrns[0], urn0);
+    assertEquals(resourceSchemaUrns[1], urn1);
+    assertEquals(resourceSchemaUrns[2], urn2);
+    assertEquals(resourceSchemaUrns[3], urn3);
+    assertEquals(resourceSchemaUrns[4], urn4);
+    assertEquals(resourceSchemaUrns[5], urn5);
+  }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/SetSchemaTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/SetSchemaTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+
+package com.unboundid.scim2.common;
+
+
+import com.unboundid.scim2.common.types.UserResource;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+
+/**
+ * Ensures that setting schema URNs on a SCIM object behaves identically,
+ * regardless of the version of {@link ScimResource#setSchemaUrns} that is used.
+ */
+public class SetSchemaTest
+{
+  /**
+   * Test {@link BaseScimResource#setSchemaUrns}.
+   */
+  @Test
+  public void testBaseScimResourceSchemaUrns()
+  {
+    BaseScimResource scimObject = new UserResource();
+    BaseScimResource scimObject2 = new UserResource();
+
+    // Set a single value.
+    List<String> singleUrn =
+            Collections.singletonList("urn:pingidentity:specialObject");
+    scimObject.setSchemaUrns(singleUrn);
+    scimObject2.setSchemaUrns("urn:pingidentity:specialObject");
+    assertEquals(scimObject, scimObject2);
+
+    // Set two values.
+    List<String> schemaArray = Arrays.asList(
+            "urn:pingidentity:proprietaryObject",
+            "urn:pingidentity:specialObject"
+    );
+    scimObject.setSchemaUrns(schemaArray);
+    scimObject2.setSchemaUrns("urn:pingidentity:proprietaryObject",
+            "urn:pingidentity:specialObject"
+    );
+    assertEquals(scimObject, scimObject2);
+
+    // On a BaseScimResource, the objects should be considered equivalent
+    // regardless of the order of the parameters.
+    scimObject2.setSchemaUrns("urn:pingidentity:specialObject",
+            "urn:pingidentity:proprietaryObject");
+    assertEquals(scimObject, scimObject2);
+
+    // Setting schema URNs to null should not be allowed.
+    assertThrows(NullPointerException.class, () -> scimObject.setSchemaUrns(null));
+
+    // The first parameter of the method should not accept null.
+    assertThrows(NullPointerException.class,
+            () -> scimObject.setSchemaUrns(null, "urn:pingidentity:specialObject"));
+
+    // Null arguments in the varargs method should be ignored.
+    scimObject.setSchemaUrns(
+            "urn:pingidentity:proprietaryObject", null, null);
+    assertEquals(scimObject.getSchemaUrns().size(), 1);
+  }
+
+
+  /**
+   * Test {@link GenericScimResource#setSchemaUrns}.
+   */
+  @Test
+  public void testGenericScimResourceSchemaUrns()
+  {
+    GenericScimResource genericObject = new GenericScimResource();
+    GenericScimResource genericObject2 = new GenericScimResource();
+
+    // Set a single value.
+    List<String> singleUrn =
+            Collections.singletonList("urn:pingidentity:specialObject");
+    genericObject.setSchemaUrns(singleUrn);
+    genericObject2.setSchemaUrns("urn:pingidentity:specialObject");
+    assertEquals(genericObject, genericObject2);
+
+    // Set two values.
+    List<String> twoUrns = Arrays.asList(
+            "urn:pingidentity:proprietaryObject",
+            "urn:pingidentity:specialObject"
+    );
+    genericObject.setSchemaUrns(twoUrns);
+    genericObject2.setSchemaUrns("urn:pingidentity:proprietaryObject",
+            "urn:pingidentity:specialObject"
+    );
+    assertEquals(genericObject, genericObject2);
+
+    // The first parameter of the method should not accept null.
+    assertThrows(NullPointerException.class,
+            () -> genericObject.setSchemaUrns(null, "urn:pingidentity:specialObject"));
+
+    // Null arguments in the varargs method should be ignored.
+    genericObject.setSchemaUrns(
+            "urn:pingidentity:proprietaryObject", null, null);
+    assertEquals(genericObject.getSchemaUrns().size(), 1);
+  }
+}

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/UserResourceVarargsTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/UserResourceVarargsTestCase.java
@@ -1,0 +1,563 @@
+/*
+ * Copyright 2023 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+package com.unboundid.scim2.common;
+
+import com.unboundid.scim2.common.types.Address;
+import com.unboundid.scim2.common.types.Email;
+import com.unboundid.scim2.common.types.Entitlement;
+import com.unboundid.scim2.common.types.Group;
+import com.unboundid.scim2.common.types.InstantMessagingAddress;
+import com.unboundid.scim2.common.types.PhoneNumber;
+import com.unboundid.scim2.common.types.Photo;
+import com.unboundid.scim2.common.types.Role;
+import com.unboundid.scim2.common.types.UserResource;
+import com.unboundid.scim2.common.types.X509Certificate;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertThrows;
+
+/**
+ * Tests for the varargs methods in the {@link UserResource} class.
+ */
+public class UserResourceVarargsTestCase
+{
+  /**
+   * Test the varargs methods on the {@link UserResource} class.
+   */
+  @Test
+  public void testEmailVarArgs()
+  {
+    final UserResource user1 = new UserResource();
+    final UserResource user2 = new UserResource();
+    user1.setUserName("Kratos");
+    user2.setUserName("Kratos");
+
+    // Set a single email.
+    user1.setEmails(Collections.singletonList(new Email().setValue("kratos@example.com")));
+    user2.setEmails(new Email().setValue("kratos@example.com"));
+    assertEquals(user1, user2);
+
+    // Set two values.
+    user1.setEmails(Arrays.asList(
+            new Email().setValue("kratos@example.com"),
+            new Email().setValue("kratos2@example.com")
+    ));
+    user2.setEmails(
+            new Email().setValue("kratos@example.com"),
+            new Email().setValue("kratos2@example.com")
+    );
+    assertEquals(user1, user2);
+
+    // Set two values in a different order.
+    user1.setEmails(Arrays.asList(
+            new Email().setValue("kratos2@example.com"),
+            new Email().setValue("kratos@example.com")
+    ));
+    user2.setEmails(
+            new Email().setValue("kratos@example.com"),
+            new Email().setValue("kratos2@example.com")
+    );
+    assertNotEquals(user1, user2);
+
+    // Set three values.
+    user1.setEmails(Arrays.asList(
+            new Email().setValue("kratos@example.com"),
+            new Email().setValue("kratos2@example.com"),
+            new Email().setValue("kratos3@example.com")
+    ));
+    user2.setEmails(
+            new Email().setValue("kratos@example.com"),
+            new Email().setValue("kratos2@example.com"),
+            new Email().setValue("kratos3@example.com")
+    );
+    assertEquals(user1, user2);
+
+    // Set three values in a different order.
+    user1.setEmails(Arrays.asList(
+            new Email().setValue("kratos@example.com"),
+            new Email().setValue("kratos2@example.com"),
+            new Email().setValue("kratos3@example.com")
+    ));
+    user2.setEmails(
+            new Email().setValue("kratos@example.com"),
+            new Email().setValue("kratos3@example.com"),
+            new Email().setValue("kratos2@example.com")
+    );
+    assertNotEquals(user1, user2);
+
+    // The method should not accept 'null' as a parameter.
+    assertThrows(NullPointerException.class,
+            () -> user2.setEmails((Email) null));
+
+    // Null values in the varargs should be filtered out.
+    user2.setEmails(new Email().setValue("kratos@example.com"),
+                    null,
+                    new Email().setValue("kratos2#example.com"),
+                    null);
+    assertEquals(user2.getEmails().size(), 2);
+
+    user1.setEmails(Arrays.asList(
+            new Email().setValue("kratos@example.com"),
+            new Email().setValue("kratos2@example.com")
+    ));
+    user2.setEmails(new Email().setValue("kratos@example.com"),
+            null, null, new Email().setValue("kratos2@example.com"), null);
+    assertEquals(user1, user2);
+  }
+
+
+  /**
+   * Tests the {@link UserResource#setPhoneNumbers} varargs method.
+   */
+  @Test
+  public void testPhoneNumberVarArgs()
+  {
+    final UserResource user1 = new UserResource();
+    final UserResource user2 = new UserResource();
+    user1.setUserName("Atreus");
+    user2.setUserName("Atreus");
+    final PhoneNumber pi = new PhoneNumber().setValue("+1 314-159-2653");
+    final PhoneNumber euler = new PhoneNumber().setValue("+2 718-281-828");
+    final PhoneNumber one = new PhoneNumber().setValue("+3 111-111-1111");
+
+    // Set a single value.
+    user1.setPhoneNumbers(Collections.singletonList(pi));
+    user2.setPhoneNumbers(pi);
+    assertEquals(user1, user2);
+
+    // Set two values.
+    user1.setPhoneNumbers(Arrays.asList(pi, euler));
+    user2.setPhoneNumbers(pi, euler);
+    assertEquals(user1, user2);
+
+    // Set two values in a different order.
+    user1.setPhoneNumbers(Arrays.asList(euler, pi));
+    user2.setPhoneNumbers(pi, euler);
+    assertNotEquals(user1, user2);
+
+    // Set three values.
+    user1.setPhoneNumbers(Arrays.asList(pi, euler, one));
+    user2.setPhoneNumbers(pi, euler, one);
+    assertEquals(user1, user2);
+
+    // Set three values in a different order.
+    user1.setPhoneNumbers(Arrays.asList(pi, euler, one));
+    user2.setPhoneNumbers(pi, one, euler);
+    assertNotEquals(user1, user2);
+
+    // The method should not accept 'null' as a parameter.
+    assertThrows(NullPointerException.class,
+            () -> user2.setPhoneNumbers((PhoneNumber) null));
+
+    // Null values in the varargs should be filtered out.
+    user2.setPhoneNumbers(pi, null, one, null);
+    assertEquals(user2.getPhoneNumbers().size(), 2);
+
+    user1.setPhoneNumbers(Arrays.asList(pi, euler));
+    user2.setPhoneNumbers(pi, null, null, euler, null);
+    assertEquals(user1, user2);
+  }
+
+
+  /**
+   * Tests the {@link UserResource#setIms}} varargs method.
+   */
+  @Test
+  public void testImsVarArgs()
+  {
+    final UserResource user1 = new UserResource();
+    final UserResource user2 = new UserResource();
+    user1.setUserName("Mimir");
+    user2.setUserName("Mimir");
+    final InstantMessagingAddress ims1 =
+            new InstantMessagingAddress().setValue("@brother");
+    final InstantMessagingAddress ims2 =
+            new InstantMessagingAddress().setValue("@treebeard");
+    final InstantMessagingAddress ims3 =
+            new InstantMessagingAddress().setValue("@head");
+
+    // Set a single value.
+    user1.setIms(Collections.singletonList(ims1));
+    user2.setIms(ims1);
+    assertEquals(user1, user2);
+
+    // Set two values.
+    user1.setIms(Arrays.asList(ims1, ims2));
+    user2.setIms(ims1, ims2);
+    assertEquals(user1, user2);
+
+    // Set two values in a different order.
+    user1.setIms(Arrays.asList(ims2, ims1));
+    user2.setIms(ims1, ims2);
+    assertNotEquals(user1, user2);
+
+    // Set three values.
+    user1.setIms(Arrays.asList(ims1, ims2, ims3));
+    user2.setIms(ims1, ims2, ims3);
+    assertEquals(user1, user2);
+
+    // Set three values in a different order.
+    user1.setIms(Arrays.asList(ims1, ims2, ims3));
+    user2.setIms(ims1, ims3, ims2);
+    assertNotEquals(user1, user2);
+
+    // The method should not accept 'null' as a parameter.
+    assertThrows(NullPointerException.class,
+            () -> user2.setIms((InstantMessagingAddress) null));
+
+    // Null values in the varargs should be filtered out.
+    user2.setIms(ims1, null, ims2, null);
+    assertEquals(user2.getIms().size(), 2);
+
+    user1.setIms(Arrays.asList(ims1, ims2));
+    user2.setIms(ims1, null, null, ims2, null);
+    assertEquals(user1, user2);
+  }
+
+
+  /**
+   * Tests the {@link UserResource#setPhotos}} varargs method.
+   */
+  @Test
+  public void testPhotosVarArgs()
+  {
+    final UserResource user1 = new UserResource();
+    final UserResource user2 = new UserResource();
+    user1.setUserName("Freya");
+    user2.setUserName("Freya");
+    final Photo photo1 =
+            new Photo().setValue(URI.create("https://example.com/1.png"));
+    final Photo photo2 =
+            new Photo().setValue(URI.create("https://example.com/2.png"));
+    final Photo photo3 =
+            new Photo().setValue(URI.create("https://example.com/3.png"));
+
+    // Set a single value.
+    user1.setPhotos(Collections.singletonList(photo1));
+    user2.setPhotos(photo1);
+    assertEquals(user1, user2);
+
+    // Set two values.
+    user1.setPhotos(Arrays.asList(photo1, photo2));
+    user2.setPhotos(photo1, photo2);
+    assertEquals(user1, user2);
+
+    // Set two values in a different order.
+    user1.setPhotos(Arrays.asList(photo2, photo1));
+    user2.setPhotos(photo1, photo2);
+    assertNotEquals(user1, user2);
+
+    // Set three values.
+    user1.setPhotos(Arrays.asList(photo1, photo2, photo3));
+    user2.setPhotos(photo1, photo2, photo3);
+    assertEquals(user1, user2);
+
+    // Set three values in a different order.
+    user1.setPhotos(Arrays.asList(photo1, photo2, photo3));
+    user2.setPhotos(photo1, photo3, photo2);
+    assertNotEquals(user1, user2);
+
+    // The method should not accept 'null' as a parameter.
+    assertThrows(NullPointerException.class,
+            () -> user2.setPhotos((Photo) null));
+
+    // Null values in the varargs should be filtered out.
+    user2.setPhotos(photo1, null, photo2, null);
+    assertEquals(user2.getPhotos().size(), 2);
+
+    user1.setPhotos(Arrays.asList(photo1, photo2));
+    user2.setPhotos(photo1, null, null, photo2, null);
+    assertEquals(user1, user2);
+  }
+
+
+  /**
+   * Tests the {@link UserResource#setAddresses} varargs method.
+   */
+  @Test
+  public void testAddressesVarArgs()
+  {
+    final UserResource user1 = new UserResource();
+    final UserResource user2 = new UserResource();
+    user1.setUserName("Brok");
+    user2.setUserName("Brok");
+    final Address address1 =
+            new Address().setStreetAddress("10001 Tyr's Temple");
+    final Address address2 =
+            new Address().setStreetAddress("100 Yggdrasil Plaza");
+    final Address address3 =
+            new Address().setStreetAddress("1234 Svartelfheim Ave.");
+
+    // Set a single value.
+    user1.setAddresses(Collections.singletonList(address1));
+    user2.setAddresses(address1);
+    assertEquals(user1, user2);
+
+    // Set two values.
+    user1.setAddresses(Arrays.asList(address1, address2));
+    user2.setAddresses(address1, address2);
+    assertEquals(user1, user2);
+
+    // Set two values in a different order.
+    user1.setAddresses(Arrays.asList(address2, address1));
+    user2.setAddresses(address1, address2);
+    assertNotEquals(user1, user2);
+
+    // Set three values.
+    user1.setAddresses(Arrays.asList(address1, address2, address3));
+    user2.setAddresses(address1, address2, address3);
+    assertEquals(user1, user2);
+
+    // Set three values in a different order.
+    user1.setAddresses(Arrays.asList(address1, address2, address3));
+    user2.setAddresses(address1, address3, address2);
+    assertNotEquals(user1, user2);
+
+    // The method should not accept 'null' as a parameter.
+    assertThrows(NullPointerException.class,
+            () -> user2.setAddresses((Address) null));
+
+    // Null values in the varargs should be filtered out.
+    user2.setAddresses(address1, null, address2, null);
+    assertEquals(user2.getAddresses().size(), 2);
+
+    user1.setAddresses(Arrays.asList(address1, address2));
+    user2.setAddresses(address1, null, null, address2, null);
+    assertEquals(user1, user2);
+  }
+
+
+  /**
+   * Tests the {@link UserResource#setGroups} varargs method.
+   */
+  @Test
+  public void testGroupsVarArgs()
+  {
+    final UserResource user1 = new UserResource();
+    final UserResource user2 = new UserResource();
+    user1.setUserName("Sindri");
+    user2.setUserName("Sindri");
+    final Group dwarves = new Group().setValue("Dwarves");
+    final Group giants = new Group().setValue("Giants");
+    final Group elves = new Group().setValue("Elves");
+
+    // Set a single value.
+    user1.setGroups(Collections.singletonList(dwarves));
+    user2.setGroups(dwarves);
+    assertEquals(user1, user2);
+
+    // Set two values.
+    user1.setGroups(Arrays.asList(dwarves, giants));
+    user2.setGroups(dwarves, giants);
+    assertEquals(user1, user2);
+
+    // Set two values in a different order.
+    user1.setGroups(Arrays.asList(giants, dwarves));
+    user2.setGroups(dwarves, giants);
+    assertNotEquals(user1, user2);
+
+    // Set three values.
+    user1.setGroups(Arrays.asList(dwarves, giants, elves));
+    user2.setGroups(dwarves, giants, elves);
+    assertEquals(user1, user2);
+
+    // Set three values in a different order.
+    user1.setGroups(Arrays.asList(dwarves, giants, elves));
+    user2.setGroups(dwarves, elves, giants);
+    assertNotEquals(user1, user2);
+
+    // The method should not accept 'null' as a parameter.
+    assertThrows(NullPointerException.class,
+            () -> user2.setGroups((Group) null));
+
+    // Null values in the varargs should be filtered out.
+    user2.setGroups(dwarves, null, elves, null);
+    assertEquals(user2.getGroups().size(), 2);
+
+    user1.setGroups(Arrays.asList(dwarves, giants));
+    user2.setGroups(dwarves, null, null, giants, null);
+    assertEquals(user1, user2);
+  }
+
+
+  /**
+   * Tests the {@link UserResource#setEntitlements} varargs method.
+   */
+  @Test
+  public void testEntitlementsVarArgs()
+  {
+    final UserResource user1 = new UserResource();
+    final UserResource user2 = new UserResource();
+    user1.setUserName("Faye");
+    user2.setUserName("Faye");
+    final Entitlement magic = new Entitlement().setValue("Magic");
+    final Entitlement prophecy = new Entitlement().setValue("Prophetic");
+    final Entitlement healing = new Entitlement().setValue("Healing");
+
+    // Set a single value.
+    user1.setEntitlements(Collections.singletonList(magic));
+    user2.setEntitlements(magic);
+    assertEquals(user1, user2);
+
+    // Set two values.
+    user1.setEntitlements(Arrays.asList(magic, prophecy));
+    user2.setEntitlements(magic, prophecy);
+    assertEquals(user1, user2);
+
+    // Set two values in a different order.
+    user1.setEntitlements(Arrays.asList(prophecy, magic));
+    user2.setEntitlements(magic, prophecy);
+    assertNotEquals(user1, user2);
+
+    // Set three values.
+    user1.setEntitlements(Arrays.asList(magic, prophecy, healing));
+    user2.setEntitlements(magic, prophecy, healing);
+    assertEquals(user1, user2);
+
+    // Set three values in a different order.
+    user1.setEntitlements(Arrays.asList(magic, prophecy, healing));
+    user2.setEntitlements(magic, healing, prophecy);
+    assertNotEquals(user1, user2);
+
+    // The method should not accept 'null' as a parameter.
+    assertThrows(NullPointerException.class,
+            () -> user2.setEntitlements((Entitlement) null));
+
+    // Null values in the varargs should be filtered out.
+    user2.setEntitlements(magic, null, prophecy, null);
+    assertEquals(user2.getEntitlements().size(), 2);
+
+    user1.setEntitlements(Arrays.asList(magic, prophecy));
+    user2.setEntitlements(magic, null, null, prophecy, null);
+    assertEquals(user1, user2);
+  }
+
+
+  /**
+   * Tests the {@link UserResource#setRoles} varargs method.
+   */
+  @Test
+  public void testRolesVarArgs()
+  {
+    final UserResource user1 = new UserResource();
+    final UserResource user2 = new UserResource();
+    user1.setUserName("Odin");
+    user2.setUserName("Odin");
+    final Role allFather = new Role().setValue("Father");
+    final Role leader = new Role().setValue("Leadership");
+    final Role seeker = new Role().setValue("Knowledge seeker");
+
+    // Set a single value.
+    user1.setRoles(Collections.singletonList(allFather));
+    user2.setRoles(allFather);
+    assertEquals(user1, user2);
+
+    // Set two values.
+    user1.setRoles(Arrays.asList(allFather, leader));
+    user2.setRoles(allFather, leader);
+    assertEquals(user1, user2);
+
+    // Set two values in a different order.
+    user1.setRoles(Arrays.asList(leader, allFather));
+    user2.setRoles(allFather, leader);
+    assertNotEquals(user1, user2);
+
+    // Set three values.
+    user1.setRoles(Arrays.asList(allFather, leader, seeker));
+    user2.setRoles(allFather, leader, seeker);
+    assertEquals(user1, user2);
+
+    // Set three values in a different order.
+    user1.setRoles(Arrays.asList(allFather, leader, seeker));
+    user2.setRoles(allFather, seeker, leader);
+    assertNotEquals(user1, user2);
+
+    // The method should not accept 'null' as a parameter.
+    assertThrows(NullPointerException.class,
+            () -> user2.setRoles((Role) null));
+
+    // Null values in the varargs should be filtered out.
+    user2.setRoles(allFather, null, seeker, null);
+    assertEquals(user2.getRoles().size(), 2);
+
+    user1.setRoles(Arrays.asList(allFather, leader));
+    user2.setRoles(allFather, null, null, leader, null);
+    assertEquals(user1, user2);
+  }
+
+
+  /**
+   * Tests the {@link UserResource#setX509Certificates} varargs method.
+   */
+  @Test
+  public void testX509CertificatesVarArgs()
+  {
+    final UserResource user1 = new UserResource();
+    final UserResource user2 = new UserResource();
+    user1.setUserName("Thor");
+    user2.setUserName("Thor");
+    final X509Certificate cert1 =
+            new X509Certificate().setValue("cert1".getBytes());
+    final X509Certificate cert2 =
+            new X509Certificate().setValue("cert2".getBytes());
+    final X509Certificate cert3 =
+            new X509Certificate().setValue("cert3".getBytes());
+
+    // Set a single value.
+    user1.setX509Certificates(Collections.singletonList(cert1));
+    user2.setX509Certificates(cert1);
+    assertEquals(user1, user2);
+
+    // Set two values.
+    user1.setX509Certificates(Arrays.asList(cert1, cert2));
+    user2.setX509Certificates(cert1, cert2);
+    assertEquals(user1, user2);
+
+    // Set two values in a different order.
+    user1.setX509Certificates(Arrays.asList(cert2, cert1));
+    user2.setX509Certificates(cert1, cert2);
+    assertNotEquals(user1, user2);
+
+    // Set three values.
+    user1.setX509Certificates(Arrays.asList(cert1, cert2, cert3));
+    user2.setX509Certificates(cert1, cert2, cert3);
+    assertEquals(user1, user2);
+
+    // Set three values in a different order.
+    user1.setX509Certificates(Arrays.asList(cert1, cert2, cert3));
+    user2.setX509Certificates(cert1, cert3, cert2);
+    assertNotEquals(user1, user2);
+
+    // The method should not accept 'null' as a parameter.
+    assertThrows(NullPointerException.class,
+            () -> user2.setX509Certificates((X509Certificate) null));
+
+    // Null values in the varargs should be filtered out.
+    user2.setX509Certificates(cert1, null, cert2, null);
+    assertEquals(user2.getX509Certificates().size(), 2);
+
+    user1.setX509Certificates(Arrays.asList(cert1, cert2));
+    user2.setX509Certificates(cert1, null, null, cert2, null);
+    assertEquals(user1, user2);
+  }
+}

--- a/scim2-sdk-server/pom.xml
+++ b/scim2-sdk-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>2.3.9-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-sdk-server</artifactId>
   <packaging>jar</packaging>

--- a/scim2-ubid-extensions/pom.xml
+++ b/scim2-ubid-extensions/pom.xml
@@ -19,7 +19,7 @@
   <parent>
       <artifactId>scim2-parent</artifactId>
       <groupId>com.unboundid.product.scim2</groupId>
-      <version>2.3.9-SNAPSHOT</version>
+      <version>2.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-ubid-extensions</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
The SDK has many methods where an attribute can be set to multiple
values (e.g., setEmails() on UserResource allows a user to have
multiple emails). These methods typically take in an attribute name and
a list of values. There is sometimes some friction with always
requiring a list, however. For example, if a Patch request should have
a single patch operation, then the operation must be wrapped in a
Collections.singletonList() call, which can be clunky.

To remedy this, new methods have been added that allow passing in the
values directly into a method without requiring the caller to wrap the
values in a list first. This is done by adding some overloaded methods
that accept a varargs parameter, and perform the list conversion for
the caller.

These methods always require a single non-null value to avoid breaking
backward compatibility for calls like
'new UserResource().setEmails(null)'.

JiraIssue: DS-47088