### PR TITLE
Add system property to allow empty container in patch operation

### DIFF
--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -46,6 +46,8 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
+import static com.unboundid.scim2.common.utils.ScimOptionConstants.PATCH_OP_ALLOW_EMPTY_CONTAINER_VALUE;
+
 /**
  * An individual patch operation.
  */
@@ -81,7 +83,7 @@ public abstract class PatchOperation
     {
       super(path);
       if(value == null || value.isNull() ||
-           ((value.isArray() || value.isObject()) && value.size() == 0))
+           ((value.isArray() || value.isObject()) && value.size() == 0 && isEmptyContainerNotAllowed()))
        {
          throw BadRequestException.invalidSyntax(
              "value field must not be null or an empty container");
@@ -303,7 +305,7 @@ public abstract class PatchOperation
     {
       super(path);
       if(value == null || value.isNull() ||
-           ((value.isArray() || value.isObject()) && value.size() == 0))
+           ((value.isArray() || value.isObject()) && value.size() == 0 && isEmptyContainerNotAllowed()))
        {
          throw BadRequestException.invalidSyntax(
              "value field must not be null or an empty container");
@@ -1370,5 +1372,9 @@ public abstract class PatchOperation
       default:
         throw new IllegalArgumentException("Unknown patch op type " + opType);
     }
+  }
+
+  private static boolean isEmptyContainerNotAllowed() {
+    return !Boolean.parseBoolean(System.getProperty(PATCH_OP_ALLOW_EMPTY_CONTAINER_VALUE, "false"));
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimOptionConstants.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimOptionConstants.java
@@ -1,0 +1,5 @@
+package com.unboundid.scim2.common.utils;
+
+public interface ScimOptionConstants {
+    String PATCH_OP_ALLOW_EMPTY_CONTAINER_VALUE = "SCIM_PATCH_OP_ALLOW_EMPTY_CONTAINER_VALUE";
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR add support for allowing empty array value in patch add and replace operations.
This is needed to support Okta SCIM client which may sync an empty group in such a way.

I chose to use Java system property to enable and disable this support to avoid breaking the current API.

Does this close any currently open issues?
------------------------------------------
No