### PR TITLE
Upgrade TestNG to 7.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
             <phase>package</phase>
             <configuration>
               <configLocation>config/scim2-parent-checkstyle.xml</configLocation>
-              <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+              <sourceDirectories>${project.build.sourceDirectory}</sourceDirectories>
             </configuration>
           </execution>
           <execution>
@@ -242,7 +242,7 @@
             <phase>package</phase>
             <configuration>
               <configLocation>config/scim2-parent-unit-checkstyle.xml</configLocation>
-              <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+              <sourceDirectories>${project.build.testSourceDirectory}</sourceDirectories>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,8 @@
     <jax-rs.version>2.0.1</jax-rs.version>
     <jersey.version>2.39.1</jersey.version>
     <guava.version>30.0-jre</guava.version>
-    <testng.version>7.4.0</testng.version>
+    <testng.version>7.5.1</testng.version>
+    <assertj.version>3.24.2</assertj.version>
   </properties>
 
   <profiles>
@@ -433,6 +434,12 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/scim2-sdk-common/pom.xml
+++ b/scim2-sdk-common/pom.xml
@@ -228,5 +228,10 @@
       <artifactId>testng</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/DiffTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/DiffTestCase.java
@@ -38,6 +38,7 @@ import java.net.URI;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -90,7 +91,7 @@ public class DiffTestCase
       op.apply(source);
     }
     removeNullNodes(target);
-    assertEquals(source, target);
+    assertThat(source).isEqualTo(target);
   }
 
   /**
@@ -324,7 +325,7 @@ public class DiffTestCase
             " not in target photo array " + targetPhotos);
       }
     }
-    assertEquals(source, target);
+    assertThat(source).isEqualTo(target);
   }
 
   /**
@@ -496,7 +497,7 @@ public class DiffTestCase
       op.apply(source);
     }
     removeNullNodes(target);
-    assertEquals(source, target);
+    assertThat(source).isEqualTo(target);
   }
 
   /**

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
@@ -52,7 +53,7 @@ public class JsonUtilsTestCase
    */
   public static final class ArrayValue
   {
-    private Map<String, Object> fields = new HashMap<String, Object>();
+    private final Map<String, Object> fields = new HashMap<>();
 
     /**
      * Set a field.
@@ -801,7 +802,7 @@ public class JsonUtilsTestCase
 
     JsonUtils.addValue(Path.root(), resource, value);
 
-    assertEquals(resource, expectedAddResult);
+    assertThat(resource).isEqualTo(expectedAddResult);
 
     JsonNode expectedReplaceResult = JsonUtils.getObjectReader().
         readTree("{\n" +
@@ -831,7 +832,7 @@ public class JsonUtilsTestCase
 
     JsonUtils.replaceValue(Path.root(), resource, value);
 
-    assertEquals(resource, expectedReplaceResult);
+    assertThat(resource).isEqualTo(expectedReplaceResult);
   }
 
 

--- a/scim2-sdk-server/pom.xml
+++ b/scim2-sdk-server/pom.xml
@@ -216,16 +216,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.inject</groupId>
-      <artifactId>jersey-hk2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.connectors</groupId>
       <artifactId>jersey-apache-connector</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Updated the test framework to the latest (JDK 8-compatible) supported
release in order to resolve a CVE warning.

The new TestNG version introduced some inconsistent behavior in the way
that 'assertEquals' behaves in the new release. Now, it appears that
iterables and collections must have their elements in the same order to
be considered equal. TestNG surprisingly does not call an object's
equals() method to determine this. This led to failures in some tests
that checked equivalency of JsonNodes, which should allow elements to
be out of order.

To remedy this, the project has added the AssertJ dependency. This
library helps with writing flexible assertion statements that will be
useful in the future, and correctly compares JsonNodes in an expected
and reliable fashion.