### PR TITLE
Update Member attribute definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Updating a boolean value should always be done with a `replace` operation type r
 Fixed an issue where `AttributeDefinition.toString()` would not print the mutability of an
 attribute.
 
+Added a `type` field to the `Member` class as defined by RFC 7643 section 8.7.1.
+
 ## v2.3.8 - 2023-05-17
 Updated the deserialized form of ListResponse objects so that the `itemsPerPage` and `startIndex`
 fields are listed at the top with `totalResults`. This matches the form of ListResponses shown in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ attribute.
 
 Added a `type` field to the `Member` class as defined by RFC 7643 section 8.7.1.
 
+Fixed an issue with the attribute definitions of the `members` field of a GroupResource. The
+attribute definitions now indicate that the sub-attributes of `members` are all immutable.
+
 ## v2.3.8 - 2023-05-17
 Updated the deserialized form of ListResponse objects so that the `itemsPerPage` and `startIndex`
 fields are listed at the top with `totalResults`. This matches the form of ListResponses shown in

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/annotations/Attribute.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/annotations/Attribute.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
 public @interface Attribute
 {
   /**
-   * Determines if the attribute value is case sensitive.
+   * Determines if the attribute value is case-sensitive.
    *
    * @return A flag indicating the attribute value's case sensitivity.
    */

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/GroupResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/GroupResource.java
@@ -44,7 +44,7 @@ public class GroupResource extends BaseScimResource
       isRequired = false,
       mutability = AttributeDefinition.Mutability.READ_WRITE,
       returned = AttributeDefinition.Returned.DEFAULT,
-      multiValueClass = Group.class)
+      multiValueClass = Member.class)
   private List<Member> members;
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Member.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Member.java
@@ -35,6 +35,16 @@ public class Member
       uniqueness = AttributeDefinition.Uniqueness.NONE)
   private String value;
 
+  @Attribute(description = "A label indicating the type of resource, e.g.,"
+          + " 'User' or 'Group'",
+      canonicalValues = { "User", "Group" },
+      isCaseExact = false,
+      mutability = AttributeDefinition.Mutability.IMMUTABLE,
+      returned = AttributeDefinition.Returned.DEFAULT,
+      uniqueness = AttributeDefinition.Uniqueness.NONE)
+  @JsonProperty("type")
+  private String type;
+
   @Attribute(description = "The URI of the member resource.",
       isRequired = true,
       referenceTypes = { "User", "Group" },
@@ -72,6 +82,28 @@ public class Member
   public Member setValue(final String value)
   {
     this.value = value;
+    return this;
+  }
+
+  /**
+   * Retrieves the type of the group member.
+   *
+   * @return The type of the group member.
+   */
+  public String getType()
+  {
+    return type;
+  }
+
+  /**
+   * Specifies the type of the group member.
+   *
+   * @param type The type of the group member.
+   * @return This object.
+   */
+  public Member setType(final String type)
+  {
+    this.type = type;
     return this;
   }
 
@@ -136,6 +168,7 @@ public class Member
     final Member member = (Member) o;
     return value.equals(member.value) &&
         ref.equals(member.ref) &&
+        Objects.equals(type, member.type) &&
         Objects.equals(display, member.display);
   }
 
@@ -145,6 +178,6 @@ public class Member
   @Override
   public int hashCode()
   {
-    return Objects.hash(value, ref, display);
+    return Objects.hash(value, ref, type, display);
   }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GroupResourceTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GroupResourceTestCase.java
@@ -16,13 +16,19 @@
  */
 package com.unboundid.scim2.common;
 
+import com.unboundid.scim2.common.types.AttributeDefinition;
+import com.unboundid.scim2.common.types.AttributeDefinition.Mutability;
 import com.unboundid.scim2.common.types.GroupResource;
 import com.unboundid.scim2.common.types.Member;
 import com.unboundid.scim2.common.utils.JsonUtils;
+import com.unboundid.scim2.common.utils.SchemaUtils;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
@@ -168,5 +174,29 @@ public class GroupResourceTestCase
     GroupResource groupResource2 = JsonUtils.nodeToValue(gsr.getObjectNode(),
         GroupResource.class);
     assertEquals(groupResource1, groupResource2);
+  }
+
+
+  /**
+   * Ensures that the {@code members} field of a {@link GroupResource} contains
+   * immutable sub-attributes.
+   *
+   * @throws Exception  If an unexpected error occurs.
+   */
+  @Test
+  public void testMembersImmutable() throws Exception
+  {
+    Collection<AttributeDefinition> groupSchema =
+            SchemaUtils.getAttributes(GroupResource.class);
+    List<AttributeDefinition> memberDefinition =
+            groupSchema.stream().filter(
+                    attribute -> attribute.getName().equalsIgnoreCase("members")
+            ).collect(Collectors.toList());
+    assertThat(memberDefinition).hasSize(1);
+
+    for (AttributeDefinition a : memberDefinition.get(0).getSubAttributes())
+    {
+      assertThat(a.getMutability()).isEqualTo(Mutability.IMMUTABLE);
+    }
   }
 }


### PR DESCRIPTION
This is broken into two parts. One resolved a typo, and the other included a missing sub-attribute definition.

This change may have to wait for after the 2.4.0 release.

JiraIssue: DS-47600
Resolves #189