### PR TITLE
Resolve error with copying SCIM SDK ObjectMapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Added a `type` field to the `Member` class as defined by RFC 7643 section 8.7.1.
 Fixed an issue with the attribute definitions of the `members` field of a GroupResource. The
 attribute definitions now indicate that the sub-attributes of `members` are all immutable.
 
+Fixed an issue where calling `ObjectMapper.copy()` failed for object mappers that were created with
+`JsonUtils.createObjectMapper()`.
+
 ## v2.3.8 - 2023-05-17
 Updated the deserialized form of ListResponse objects so that the `itemsPerPage` and `startIndex`
 fields are listed at the top with `totalResults`. This matches the form of ListResponses shown in

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
@@ -1024,13 +1024,14 @@ public class JsonUtils
   }
 
   /**
-   * Creates an configured SCIM compatible Jackson ObjectMapper. Creating new
-   * ObjectMapper instances are expensive so instances should be shared if
-   * possible. Alternatively, consider using one of the getObjectReader,
-   * getObjectWriter, getJsonNodeFactory, or valueToTree methods which uses the
-   * SDK's ObjectMapper singleton.
+   * Creates a configured SCIM-compatible Jackson ObjectMapper. Creating new
+   * ObjectMapper instances are expensive, so instances should be shared if
+   * possible. Alternatively, consider using one of the
+   * {@link #getObjectReader}, {@link #getObjectWriter},
+   * {@link #getJsonNodeFactory}, or {@link #valueToNode} methods, which use the
+   * SCIM 2 SDK's ObjectMapper singleton.
    *
-   * @return an Object Mapper with the correct options set for seirializing
+   * @return an Object Mapper with the correct options set for serializing
    *     and deserializing SCIM JSON objects.
    */
   public static ObjectMapper createObjectMapper()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimJsonFactory.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimJsonFactory.java
@@ -20,6 +20,7 @@ package com.unboundid.scim2.common.utils;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.io.IOContext;
 
 import java.io.IOException;
@@ -29,8 +30,29 @@ import java.io.Reader;
 /**
  * Custom JsonFactory implementation for SCIM.
  */
-public class ScimJsonFactory extends JsonFactory {
+public class ScimJsonFactory extends JsonFactory
+{
+  /**
+   * Creates a new SCIM-compatible JsonFactory instance.
+   */
+  public ScimJsonFactory()
+  {
+    super();
+  }
 
+  /**
+   * A constructor used when copying an existing SCIM JsonFactory instance.
+   *
+   * @param sourceFactory   The original ScimJsonFactory.
+   * @param codec           The codec that defines the way that objects should
+   *                        be serialized and deserialized. This may be
+   *                        {@code null}.
+   */
+  protected ScimJsonFactory(final ScimJsonFactory sourceFactory,
+                            final ObjectCodec codec)
+  {
+    super(sourceFactory, codec);
+  }
 
   /**
    * Create a parser that can be used for parsing JSON objects contained
@@ -40,11 +62,21 @@ public class ScimJsonFactory extends JsonFactory {
    * @throws IOException on parse error
    */
   JsonParser createScimFilterParser(final Reader r)
-      throws IOException {
-
+      throws IOException
+  {
     IOContext ctxt = _createContext(r, false);
     return new ScimFilterJsonParser(ctxt, _parserFeatures, r, _objectCodec,
         _rootCharSymbols.makeChild(_factoryFeatures));
   }
 
+  /**
+   * Provides another instance of this factory object.
+   *
+   * @return A new ScimJsonFactory instance.
+   */
+  @Override
+  public ScimJsonFactory copy()
+  {
+    return new ScimJsonFactory(this, _objectCodec);
+  }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
@@ -1217,5 +1218,24 @@ public class JsonUtilsTestCase
     Assert.assertFalse(objectNode.path("hasValue").isMissingNode());
     Assert.assertEquals(objectNode.path("hasValue").textValue(), "value1");
     Assert.assertTrue(objectNode.path("isNull").isMissingNode());
+  }
+
+  /**
+   * Test that a SCIM 2 SDK ObjectMapper can be copied without an exception
+   * thrown.
+   * <p>
+   * This test does not check if the copy is equivalent to the original because
+   * the ObjectMapper class does not have an {@code equals} method.
+   */
+  @Test
+  public void testScimObjectMapperCopy()
+  {
+    ObjectMapper mapper = JsonUtils.createObjectMapper();
+
+    // Copying the object mapper should not cause an exception.
+    ObjectMapper copy = mapper.copy();
+
+    // The copy should be a different object.
+    assertThat(mapper == copy).isFalse();
   }
 }


### PR DESCRIPTION
This commit resolves an error with copying an ObjectMapper that was created with 'JsonUtils.createObjectMapper()'. This presented as an IllegalStateException from Jackson's 'ObjectMapper._checkInvalidCopy()' method.

Part of this commit includes adding a new constructor for ScimJsonFactory since there is a dedicated constructor used for copies in the superclass (JsonFactory#JsonFactory(JsonFactory, ObjectCodec)). ScimJsonFactory will explicitly call this "copy constructor" when making a copy, even though the behavior is (currently) identical to using the default constructor.

JiraIssue: DS-47635
