### PR TITLE
Update empty javadocs

### DIFF
--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
@@ -497,7 +497,11 @@ public abstract class BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this BaseScimResource.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this
+   *            BaseScimResource, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -541,7 +545,9 @@ public abstract class BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this BaseScimResource.
+   *
+   * @return  A hash code for this BaseScimResource.
    */
   @Override
   public int hashCode()
@@ -556,7 +562,9 @@ public abstract class BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a string representation of this BaseScimResource.
+   *
+   * @return  A string representation of this BaseScimResource.
    */
   @Override
   public String toString()
@@ -571,5 +579,4 @@ public abstract class BaseScimResource
       throw new RuntimeException(e);
     }
   }
-
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
@@ -463,7 +463,9 @@ public final class GenericScimResource implements ScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a string representation of this generic SCIM resource.
+   *
+   * @return  A string representation of this generic SCIM resource.
    */
   @Override
   public String toString()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
@@ -82,7 +82,11 @@ public final class Path implements Iterable<Path.Element>
     }
 
     /**
-     * {@inheritDoc}
+     * Indicates whether the provided object is equal to this path element.
+     *
+     * @param o   The object to compare.
+     * @return    {@code true} if the provided object is equal to this path
+     *            element, or {@code false} if not.
      */
     @Override
     public boolean equals(final Object o)
@@ -113,7 +117,9 @@ public final class Path implements Iterable<Path.Element>
     }
 
     /**
-     * {@inheritDoc}
+     * Retrieves a hash code for this path element.
+     *
+     * @return  A hash code for this path element.
      */
     @Override
     public int hashCode()
@@ -124,7 +130,9 @@ public final class Path implements Iterable<Path.Element>
     }
 
     /**
-     * {@inheritDoc}
+     * Retrieves a string representation of this path element.
+     *
+     * @return  A string representation of this path element.
      */
     @Override
     public String toString()
@@ -416,6 +424,13 @@ public final class Path implements Iterable<Path.Element>
     return schemaUrn;
   }
 
+  /**
+   * Indicates whether the provided object is equal to this attribute path.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this attribute
+   *            path, or {@code false} if not.
+   */
   @Override
   public boolean equals(final Object o)
   {
@@ -439,6 +454,11 @@ public final class Path implements Iterable<Path.Element>
 
   }
 
+  /**
+   * Retrieves a hash code for this Path.
+   *
+   * @return  A hash code for this Path.
+   */
   @Override
   public int hashCode()
   {
@@ -449,7 +469,9 @@ public final class Path implements Iterable<Path.Element>
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a string representation of this Path.
+   *
+   * @return  A string representation of this Path.
    */
   @Override
   @JsonValue

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/AndFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/AndFilter.java
@@ -55,7 +55,11 @@ public final class AndFilter extends CombiningFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this AND filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -80,7 +84,9 @@ public final class AndFilter extends CombiningFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this AND filter.
+   *
+   * @return  A hash code for this AND filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ComplexValueFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ComplexValueFilter.java
@@ -103,7 +103,12 @@ public final class ComplexValueFilter extends Filter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this complex
+   * multi-valued attribute filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -132,7 +137,9 @@ public final class ComplexValueFilter extends Filter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this complex multi-valued attribute filter.
+   *
+   * @return  A hash code for this complex multi-valued attribute filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ContainsFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ContainsFilter.java
@@ -56,7 +56,11 @@ public final class ContainsFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this contains filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -85,7 +89,9 @@ public final class ContainsFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this contains filter.
+   *
+   * @return  A hash code for this contains filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EndsWithFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EndsWithFilter.java
@@ -56,7 +56,11 @@ public final class EndsWithFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this "ends with" filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -85,7 +89,9 @@ public final class EndsWithFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this "ends with" filter".
+   *
+   * @return  A hash code for this "ends with" filter".
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EndsWithFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EndsWithFilter.java
@@ -89,9 +89,9 @@ public final class EndsWithFilter extends ComparisonFilter
   }
 
   /**
-   * Retrieves a hash code for this "ends with" filter".
+   * Retrieves a hash code for this "ends with" filter.
    *
-   * @return  A hash code for this "ends with" filter".
+   * @return  A hash code for this "ends with" filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EqualFilter.java
@@ -56,7 +56,11 @@ public final class EqualFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this equality filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this equality
+   *            filter, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -85,7 +89,9 @@ public final class EqualFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this equality filter.
+   *
+   * @return  A hash code for this equality filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/Filter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/Filter.java
@@ -170,7 +170,9 @@ public abstract class Filter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a string representation of this filter.
+   *
+   * @return  A string representation of this filter.
    */
   @Override
   public String toString()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanFilter.java
@@ -90,9 +90,9 @@ public final class GreaterThanFilter extends ComparisonFilter
   }
 
   /**
-   * Retrieves a hash code for this "greater than" filter".
+   * Retrieves a hash code for this "greater than" filter.
    *
-   * @return  A hash code for this "greater than" filter".
+   * @return  A hash code for this "greater than" filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanFilter.java
@@ -56,7 +56,12 @@ public final class GreaterThanFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this "greater than"
+   * filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -85,7 +90,9 @@ public final class GreaterThanFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this "greater than" filter".
+   *
+   * @return  A hash code for this "greater than" filter".
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanOrEqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanOrEqualFilter.java
@@ -57,7 +57,12 @@ public final class GreaterThanOrEqualFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this "greater than or
+   * equal" filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -86,7 +91,9 @@ public final class GreaterThanOrEqualFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this "greater than or equal" filter.
+   *
+   * @return  A hash code for this "greater than or equal" filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanFilter.java
@@ -89,9 +89,9 @@ public final class LessThanFilter extends ComparisonFilter
   }
 
   /**
-   * Retrieves a hash code for this "less than" filter".
+   * Retrieves a hash code for this "less than" filter.
    *
-   * @return  A hash code for this "less than" filter".
+   * @return  A hash code for this "less than" filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanFilter.java
@@ -56,7 +56,11 @@ public final class LessThanFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this "less than" filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -85,7 +89,9 @@ public final class LessThanFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this "less than" filter".
+   *
+   * @return  A hash code for this "less than" filter".
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanOrEqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanOrEqualFilter.java
@@ -90,9 +90,9 @@ public final class LessThanOrEqualFilter extends ComparisonFilter
   }
 
   /**
-   * Retrieves a hash code for this "less than or equal" filter".
+   * Retrieves a hash code for this "less than or equal" filter.
    *
-   * @return  A hash code for this "less than or equal" filter".
+   * @return  A hash code for this "less than or equal" filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanOrEqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanOrEqualFilter.java
@@ -56,7 +56,12 @@ public final class LessThanOrEqualFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this "less than or equal"
+   * filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -85,7 +90,9 @@ public final class LessThanOrEqualFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this "less than or equal" filter".
+   *
+   * @return  A hash code for this "less than or equal" filter".
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotEqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotEqualFilter.java
@@ -89,9 +89,9 @@ public final class NotEqualFilter extends ComparisonFilter
   }
 
   /**
-   * Retrieves a hash code for this "not equal" filter".
+   * Retrieves a hash code for this "not equal" filter.
    *
-   * @return  A hash code for this "not equal" filter".
+   * @return  A hash code for this "not equal" filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotEqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotEqualFilter.java
@@ -56,7 +56,11 @@ public final class NotEqualFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this "not equal" filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -85,7 +89,9 @@ public final class NotEqualFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this "not equal" filter".
+   *
+   * @return  A hash code for this "not equal" filter".
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotFilter.java
@@ -88,7 +88,11 @@ public final class NotFilter extends Filter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this NOT filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -112,6 +116,11 @@ public final class NotFilter extends Filter
     return true;
   }
 
+  /**
+   * Retrieves a hash code for this NOT filter.
+   *
+   * @return  A hash code for this NOT filter.
+   */
   @Override
   public int hashCode()
   {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/OrFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/OrFilter.java
@@ -55,7 +55,11 @@ public final class OrFilter extends CombiningFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this OR filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this OR filter,
+   *            or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -80,7 +84,9 @@ public final class OrFilter extends CombiningFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this OR filter.
+   *
+   * @return  A hash code for this OR filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/PresentFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/PresentFilter.java
@@ -78,7 +78,11 @@ public final class PresentFilter extends Filter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this presence filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -103,7 +107,9 @@ public final class PresentFilter extends Filter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this presence filter.
+   *
+   * @return  A hash code for this presence filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/StartsWithFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/StartsWithFilter.java
@@ -56,7 +56,12 @@ public final class StartsWithFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this "starts with"
+   * filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -85,7 +90,9 @@ public final class StartsWithFilter extends ComparisonFilter
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this "starts with" filter".
+   *
+   * @return  A hash code for this "starts with" filter".
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/StartsWithFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/StartsWithFilter.java
@@ -90,9 +90,9 @@ public final class StartsWithFilter extends ComparisonFilter
   }
 
   /**
-   * Retrieves a hash code for this "starts with" filter".
+   * Retrieves a hash code for this "starts with" filter.
    *
-   * @return  A hash code for this "starts with" filter".
+   * @return  A hash code for this "starts with" filter.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ErrorResponse.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ErrorResponse.java
@@ -110,7 +110,11 @@ public final class ErrorResponse extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this error response.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this error
+   *            response, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -148,7 +152,9 @@ public final class ErrorResponse extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this error response.
+   *
+   * @return  A hash code for this error response.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ListResponse.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ListResponse.java
@@ -200,7 +200,11 @@ public final class ListResponse<T> extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this list response.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this list
+   *            response, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -243,7 +247,9 @@ public final class ListResponse<T> extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this list response.
+   *
+   * @return  A hash code for this list response.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -159,7 +159,11 @@ public abstract class PatchOperation
     }
 
     /**
-     * {@inheritDoc}
+     * Indicates whether the provided object is equal to this add operation.
+     *
+     * @param o   The object to compare.
+     * @return    {@code true} if the provided object is equal to this
+     *            operation, or {@code false} if not.
      */
     @Override
     public boolean equals(final Object o)
@@ -188,7 +192,9 @@ public abstract class PatchOperation
     }
 
     /**
-     * {@inheritDoc}
+     * Retrieves a hash code for this add operation.
+     *
+     * @return  A hash code for this add operation.
      */
     @Override
     public int hashCode()
@@ -239,7 +245,11 @@ public abstract class PatchOperation
     }
 
     /**
-     * {@inheritDoc}
+     * Indicates whether the provided object is equal to this remove operation.
+     *
+     * @param o   The object to compare.
+     * @return    {@code true} if the provided object is equal to this
+     *            operation, or {@code false} if not.
      */
     @Override
     public boolean equals(final Object o)
@@ -265,7 +275,9 @@ public abstract class PatchOperation
     }
 
     /**
-     * {@inheritDoc}
+     * Retrieves a hash code for this remove operation.
+     *
+     * @return  A hash code for this remove operation.
      */
     @Override
     public int hashCode()
@@ -357,7 +369,11 @@ public abstract class PatchOperation
     }
 
     /**
-     * {@inheritDoc}
+     * Indicates whether the provided object is equal to this replace operation.
+     *
+     * @param o   The object to compare.
+     * @return    {@code true} if the provided object is equal to this
+     *            operation, or {@code false} if not.
      */
     @Override
     public boolean equals(final Object o)
@@ -387,7 +403,9 @@ public abstract class PatchOperation
     }
 
     /**
-     * {@inheritDoc}
+     * Retrieves a hash code for this replace operation.
+     *
+     * @return  A hash code for this replace operation.
      */
     @Override
     public int hashCode()
@@ -511,7 +529,9 @@ public abstract class PatchOperation
   public abstract void apply(final ObjectNode node) throws ScimException;
 
   /**
-   * {@inheritDoc}
+   * Retrieves a string representation of this patch operation.
+   *
+   * @return  A string representation of this patch operation.
    */
   @Override
   public String toString()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
@@ -106,7 +106,11 @@ public final class PatchRequest
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this patch request.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this patch
+   *            request, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -135,7 +139,9 @@ public final class PatchRequest
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this patch request.
+   *
+   * @return  A hash code for this patch request.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/SearchRequest.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/SearchRequest.java
@@ -193,7 +193,11 @@ public final class SearchRequest extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this search request.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this search
+   *            request, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -250,7 +254,9 @@ public final class SearchRequest extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this search request.
+   *
+   * @return  A hash code for this search request.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Address.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Address.java
@@ -288,7 +288,11 @@ public class Address
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this address.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this address, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -344,7 +348,9 @@ public class Address
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this address.
+   *
+   * @return  A hash code for this address.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/AttributeDefinition.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/AttributeDefinition.java
@@ -1002,7 +1002,12 @@ public class AttributeDefinition
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this attribute
+   * definition.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this attribute
+   *            definition, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -1079,7 +1084,9 @@ public class AttributeDefinition
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this attribute definition.
+   *
+   * @return  A hash code for this attribute definition.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/AuthenticationScheme.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/AuthenticationScheme.java
@@ -162,7 +162,12 @@ public class AuthenticationScheme
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this authentication
+   * scheme.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this
+   *            authentication scheme, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -210,7 +215,9 @@ public class AuthenticationScheme
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this authentication scheme.
+   *
+   * @return  A hash code for this authentication scheme.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/BulkConfig.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/BulkConfig.java
@@ -100,7 +100,11 @@ public class BulkConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this bulk configuration.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this bulk
+   *            configuration, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -133,7 +137,9 @@ public class BulkConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this bulk configuration.
+   *
+   * @return  A hash code for this bulk configuration.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/ChangePasswordConfig.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/ChangePasswordConfig.java
@@ -60,7 +60,12 @@ public class ChangePasswordConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this Change Password
+   * configuration.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this Change
+   *            Password configuration, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -85,7 +90,9 @@ public class ChangePasswordConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this Change Password configuration.
+   *
+   * @return  A hash code for this Change Password configuration.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/ETagConfig.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/ETagConfig.java
@@ -58,7 +58,11 @@ public class ETagConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this ETag configuration.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this ETag
+   *            configuration, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -83,7 +87,9 @@ public class ETagConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this ETag configuration.
+   *
+   * @return  A hash code for this ETag configuration.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Email.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Email.java
@@ -156,7 +156,11 @@ public class Email
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this email.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this email, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -191,7 +195,9 @@ public class Email
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this email.
+   *
+   * @return  A hash code for this email.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/EnterpriseUserExtension.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/EnterpriseUserExtension.java
@@ -210,7 +210,12 @@ public class EnterpriseUserExtension
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this enterprise user
+   * extension.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this enterprise
+   *            user extension, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -257,7 +262,9 @@ public class EnterpriseUserExtension
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this enterprise user extension.
+   *
+   * @return  A hash code for this enterprise user extension.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Entitlement.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Entitlement.java
@@ -151,7 +151,11 @@ public class Entitlement
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this entitlement.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this
+   *            entitlement, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -185,7 +189,9 @@ public class Entitlement
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this entitlement.
+   *
+   * @return  A hash code for this entitlement.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/FilterConfig.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/FilterConfig.java
@@ -79,7 +79,12 @@ public class FilterConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this filter
+   * configuration.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter
+   *            configuration, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -108,7 +113,9 @@ public class FilterConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this filter configuration.
+   *
+   * @return  A hash code for this filter configuration.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Group.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Group.java
@@ -157,7 +157,12 @@ public class Group
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this group membership
+   * identifier.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this group
+   *            membership identifier, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -191,7 +196,9 @@ public class Group
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this group membership identifier.
+   *
+   * @return  A hash code for this group membership identifier.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/GroupResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/GroupResource.java
@@ -92,7 +92,11 @@ public class GroupResource extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this group resource.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this group
+   *            resource, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -115,7 +119,9 @@ public class GroupResource extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this group resource.
+   *
+   * @return  A hash code for this group resource.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/InstantMessagingAddress.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/InstantMessagingAddress.java
@@ -154,7 +154,12 @@ public class InstantMessagingAddress
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this instant messaging
+   * address.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this instant
+   *            messaging address, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -188,7 +193,9 @@ public class InstantMessagingAddress
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this instant messaging address.
+   *
+   * @return  A hash code for this instant messaging address.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/JsonReference.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/JsonReference.java
@@ -88,6 +88,13 @@ public class JsonReference<T>
     return set ? obj : null;
   }
 
+  /**
+   * Indicates whether the provided object is equal to this JSON reference.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this JSON
+   *            reference, or {@code false} if not.
+   */
   @Override
   public boolean equals(final Object o)
   {
@@ -111,6 +118,11 @@ public class JsonReference<T>
 
   }
 
+  /**
+   * Retrieves a hash code for this JSON reference.
+   *
+   * @return  A hash code for this JSON reference.
+   */
   @Override
   public int hashCode()
   {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Manager.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Manager.java
@@ -123,7 +123,12 @@ public class Manager
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this manager (i.e., an
+   * employee's manager).
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this manager, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -153,7 +158,9 @@ public class Manager
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this manager.
+   *
+   * @return  A hash code for this manager.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Member.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Member.java
@@ -152,7 +152,11 @@ public class Member
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this group member.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this member, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -173,7 +177,9 @@ public class Member
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this group member.
+   *
+   * @return  A hash code for this group member.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Meta.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Meta.java
@@ -151,7 +151,11 @@ public final class Meta
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this SCIM metadata.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this metadata,
+   *            or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -195,7 +199,9 @@ public final class Meta
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this SCIM metadata.
+   *
+   * @return  A hash code for this SCIM metadata.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Name.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Name.java
@@ -240,7 +240,11 @@ public class Name
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this user's name.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this name, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -287,7 +291,9 @@ public class Name
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this name object.
+   *
+   * @return  A hash code for this name object.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/PatchConfig.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/PatchConfig.java
@@ -57,7 +57,11 @@ public class PatchConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this PATCH configuration.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this PATCH
+   *            configuration, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -82,7 +86,9 @@ public class PatchConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this PATCH configuration.
+   *
+   * @return  A hash code for this PATCH configuration.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/PhoneNumber.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/PhoneNumber.java
@@ -153,7 +153,11 @@ public class PhoneNumber
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this phone number.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this phone
+   *            number, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -187,7 +191,9 @@ public class PhoneNumber
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this phone number.
+   *
+   * @return  A hash code for this phone number.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Photo.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Photo.java
@@ -155,7 +155,11 @@ public class Photo
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this photo URI.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this photo, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -190,7 +194,9 @@ public class Photo
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this photo URI.
+   *
+   * @return  A hash code for this photo URI.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/ResourceTypeResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/ResourceTypeResource.java
@@ -257,7 +257,11 @@ public class ResourceTypeResource extends BaseScimResource
     }
 
     /**
-     * {@inheritDoc}
+     * Indicates whether the provided object is equal to this schema extension.
+     *
+     * @param o   The object to compare.
+     * @return    {@code true} if the provided object is equal to this schema
+     *            extension, or {@code false} if not.
      */
     @Override
     public boolean equals(final Object o)
@@ -286,7 +290,9 @@ public class ResourceTypeResource extends BaseScimResource
     }
 
     /**
-     * {@inheritDoc}
+     * Retrieves a hash code for this schema extension.
+     *
+     * @return  A hash code for this schema extension.
      */
     @Override
     public int hashCode()
@@ -297,6 +303,14 @@ public class ResourceTypeResource extends BaseScimResource
     }
   }
 
+  /**
+   * Indicates whether the provided object is equal to this resource type
+   * definition.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this resource
+   *            type definition, or {@code false} if not.
+   */
   @Override
   public boolean equals(final Object o)
   {
@@ -343,6 +357,11 @@ public class ResourceTypeResource extends BaseScimResource
     return true;
   }
 
+  /**
+   * Retrieves a hash code for this resource type definition.
+   *
+   * @return  A hash code for this resource type definition.
+   */
   @Override
   public int hashCode()
   {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Role.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Role.java
@@ -151,7 +151,11 @@ public class Role
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this user role.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this role, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -185,7 +189,9 @@ public class Role
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this role.
+   *
+   * @return  A hash code for this role.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/SchemaResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/SchemaResource.java
@@ -104,7 +104,11 @@ public class SchemaResource extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this SCIM schema object.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this schema
+   *            resource, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -143,7 +147,9 @@ public class SchemaResource extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this SCIM schema object.
+   *
+   * @return  A hash code for this SCIM schema object.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/ServiceProviderConfigResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/ServiceProviderConfigResource.java
@@ -217,7 +217,12 @@ public class ServiceProviderConfigResource extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this service provider
+   * configuration definition.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this
+   *            ServiceProviderConfig, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -277,7 +282,9 @@ public class ServiceProviderConfigResource extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this service provider configuration definition.
+   *
+   * @return  A hash code for this service provider configuration definition.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/SortConfig.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/SortConfig.java
@@ -58,7 +58,11 @@ public class SortConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this sort configuration.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this sort
+   *            configuration, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -83,7 +87,9 @@ public class SortConfig
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this sort configuration.
+   *
+   * @return  A hash code for this sort configuration.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/UserResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/UserResource.java
@@ -852,7 +852,11 @@ public class UserResource extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this SCIM user resource.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this user
+   *            resource, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -969,7 +973,9 @@ public class UserResource extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this SCIM user resource.
+   *
+   * @return  A hash code for this SCIM user resource.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/X509Certificate.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/X509Certificate.java
@@ -22,7 +22,8 @@ import com.unboundid.scim2.common.annotations.Attribute;
 import java.util.Arrays;
 
 /**
- * Role for the user.
+ * A public key certificate in {@code X.509} form that can be assigned to a
+ * {@link UserResource}.
  */
 public class X509Certificate
 {
@@ -153,7 +154,12 @@ public class X509Certificate
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this X.509 public
+   * certificate.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this
+   *            certificate, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -187,7 +193,9 @@ public class X509Certificate
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this X.509 certificate.
+   *
+   * @return  A hash code for this X.509 certificate.
    */
   @Override
   public int hashCode()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/CaseIgnoreMap.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/CaseIgnoreMap.java
@@ -308,7 +308,11 @@ public class CaseIgnoreMap implements Map<String, JsonNode>
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this map.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this map, or
+   *            {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -329,7 +333,9 @@ public class CaseIgnoreMap implements Map<String, JsonNode>
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this map.
+   *
+   * @return  A hash code for this map.
    */
   @Override
   public int hashCode()
@@ -338,7 +344,9 @@ public class CaseIgnoreMap implements Map<String, JsonNode>
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a string representation of this map.
+   *
+   * @return  A string representation of this map.
    */
   @Override
   public String toString()

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
@@ -79,7 +79,11 @@ public class JsonUtilsTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * Indicates whether the provided object is equal to this array value.
+     *
+     * @param o   The object to compare.
+     * @return    {@code true} if the provided object is equal to this array
+     *            value, or {@code false} if not.
      */
     @Override
     public boolean equals(final Object o)
@@ -104,7 +108,9 @@ public class JsonUtilsTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * Retrieves a hash code for this array value.
+     *
+     * @return  A hash code for this array value.
      */
     @Override
     public int hashCode()
@@ -113,7 +119,9 @@ public class JsonUtilsTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * Retrieves a string representation of this array value.
+     *
+     * @return  A string representation of this array value.
      */
     @Override
     public String toString()

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/consent/Consent.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/consent/Consent.java
@@ -82,7 +82,11 @@ public final class Consent extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this consent object.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this consent
+   *            object, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -116,7 +120,9 @@ public final class Consent extends BaseScimResource
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this consent.
+   *
+   * @return  A hash code for this consent.
    */
   @Override
   public int hashCode()
@@ -126,6 +132,5 @@ public final class Consent extends BaseScimResource
     result = 31 * result + (scopes != null ? scopes.hashCode() : 0);
     return result;
   }
-
 }
 

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/consent/ConsentHistory.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/consent/ConsentHistory.java
@@ -86,6 +86,14 @@ public final class ConsentHistory extends BaseScimResource
     return scopes;
   }
 
+  /**
+   * Indicates whether the provided object is equal to this consent history
+   * object.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this consent
+   *            history object, or {@code false} if not.
+   */
   @Override
   public boolean equals(final Object o)
   {
@@ -113,6 +121,11 @@ public final class ConsentHistory extends BaseScimResource
         !scopes.equals(that.scopes) : that.scopes != null);
   }
 
+  /**
+   * Retrieves a hash code for this consent history.
+   *
+   * @return  A hash code for this consent history.
+   */
   @Override
   public int hashCode()
   {

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/consent/OAuth2Client.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/consent/OAuth2Client.java
@@ -219,6 +219,13 @@ public final class OAuth2Client
     this.lastAuthorization = lastAuthorization;
   }
 
+  /**
+   * Indicates whether the provided object is equal to this OAuth 2 client.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this OAuth 2
+   *            client, or {@code false} if not.
+   */
   @Override
   public boolean equals(final Object o)
   {
@@ -260,6 +267,11 @@ public final class OAuth2Client
         that.lastAuthorization == null;
   }
 
+  /**
+   * Retrieves a hash code for this OAuth 2 client.
+   *
+   * @return  A hash code for this OAuth 2 client.
+   */
   @Override
   public int hashCode()
   {

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/consent/Scope.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/consent/Scope.java
@@ -178,7 +178,11 @@ public final class Scope
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this scope object.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this scope, or
+   *            or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -213,7 +217,9 @@ public final class Scope
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this scope.
+   *
+   * @return  A hash code for this scope.
    */
   @Override
   public int hashCode()
@@ -223,5 +229,4 @@ public final class Scope
     result = 31 * result + (consent != null ? consent.hashCode() : 0);
     return result;
   }
-
 }

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/externalidentity/ExternalIdentity.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/externalidentity/ExternalIdentity.java
@@ -230,6 +230,14 @@ public final class ExternalIdentity extends BaseScimResource
     this.callbackParameters = callbackParameters;
   }
 
+  /**
+   * Indicates whether the provided object is equal to this external identity
+   * provider.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this external
+   *            identity provider, or {@code false} if not.
+   */
   @Override
   public boolean equals(final Object o)
   {
@@ -285,6 +293,11 @@ public final class ExternalIdentity extends BaseScimResource
 
   }
 
+  /**
+   * Retrieves a hash code for this external identity provider.
+   *
+   * @return  A hash code for this external identity provider.
+   */
   @Override
   public int hashCode()
   {

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/externalidentity/Provider.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/externalidentity/Provider.java
@@ -205,8 +205,13 @@ public final class Provider
     return samlResponseBinding;
   }
 
-
-
+  /**
+   * Indicates whether the provided object is equal to this Provider.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this Provider
+   *            or {@code false} if not.
+   */
   @Override
   public boolean equals(final Object o)
   {
@@ -246,6 +251,11 @@ public final class Provider
 
 
 
+  /**
+   * Retrieves a hash code for this Provider.
+   *
+   * @return  A hash code for this Provider.
+   */
   @Override
   public int hashCode()
   {

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/pwdmgmt/AccountState.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/pwdmgmt/AccountState.java
@@ -733,6 +733,13 @@ public class AccountState extends BaseScimResource
         new JsonReference<List<AccountUsabilityIssue>>(accountUsabilityErrors);
   }
 
+  /**
+   * Indicates whether the provided object is equal to this account state.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this account
+   *            state, or {@code false} if not.
+   */
   @Override
   public boolean equals(final Object o)
   {
@@ -919,6 +926,11 @@ public class AccountState extends BaseScimResource
 
   }
 
+  /**
+   * Retrieves a hash code for this account state.
+   *
+   * @return  A hash code for this account state.
+   */
   @Override
   public int hashCode()
   {

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/pwdmgmt/AccountUsabilityIssue.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/pwdmgmt/AccountUsabilityIssue.java
@@ -68,7 +68,12 @@ public class AccountUsabilityIssue
   }
 
   /**
-   * {@inheritDoc}
+   * Indicates whether the provided object is equal to this account usability
+   * issue.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this account
+   *            usability issue, or {@code false} if not.
    */
   @Override
   public boolean equals(final Object o)
@@ -94,7 +99,9 @@ public class AccountUsabilityIssue
   }
 
   /**
-   * {@inheritDoc}
+   * Retrieves a hash code for this account usability issue.
+   *
+   * @return  A hash code for this account usability issue.
    */
   @Override
   public int hashCode()

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/pwdmgmt/RetiredPassword.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/pwdmgmt/RetiredPassword.java
@@ -75,6 +75,13 @@ public class RetiredPassword
     this.passwordRetiredTime = passwordRetiredTime;
   }
 
+  /**
+   * Indicates whether the provided object is equal to this retired password.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this retired
+   *            password, or {@code false} if not.
+   */
   @Override
   public boolean equals(final Object o)
   {
@@ -103,6 +110,11 @@ public class RetiredPassword
 
   }
 
+  /**
+   * Retrieves a hash code for this retired password.
+   *
+   * @return  A hash code for this retired password.
+   */
   @Override
   public int hashCode()
   {

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/sessionmgmt/Session.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/sessionmgmt/Session.java
@@ -205,6 +205,13 @@ public class Session extends BaseScimResource
     return clients;
   }
 
+  /**
+   * Indicates whether the provided object is equal to this session.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this session, or
+   *            {@code false} if not.
+   */
   @Override
   public boolean equals(final Object o)
   {
@@ -261,6 +268,11 @@ public class Session extends BaseScimResource
         : session.clients == null;
   }
 
+  /**
+   * Retrieves a hash code for this session.
+   *
+   * @return  A hash code for this session.
+   */
   @Override
   public int hashCode()
   {


### PR DESCRIPTION
Resolved an issue where methods such as toString(), hashCode(), and equals() did not have any descriptions in the public Javadocs. This was due to our use of "inheritDoc", which does not inherit the text from the parent java.lang.Object class unless a class explicitly extends Object. To correct this behavior, this commit adds dedicated descriptions for these fields.
