### PR TITLE
Update Maven plugins

### DIFF
--- a/config/scim2-parent-checkstyle.xml
+++ b/config/scim2-parent-checkstyle.xml
@@ -35,19 +35,37 @@
 
 
   <module name="TreeWalker">
-    <property name="cacheFile" value="${cacheFile}"/>
     <!-- Ensure that all methods have Javadoc documentation. -->
     <module name="JavadocMethod">
-      <property name="scope"                       value="protected" />
-      <property name="allowUndeclaredRTE"          value="false"   />
+      <property name="accessModifiers"  value="package, protected, public" />
       <property name="allowMissingParamTags"       value="false"   />
-      <property name="allowMissingThrowsTags"      value="false"   />
       <property name="allowMissingReturnTag"       value="false"   />
-      <property name="allowMissingJavadoc"         value="false"   />
-      <property name="allowMissingPropertyJavadoc" value="false"   />
-      <property name="suppressLoadErrors"          value="true"    />
+    </module>
+    <module name="MissingJavadocMethod"/>
+
+    <!-- Enforce ordering of Javadoc clauses. Ignore @deprecated clauses. -->
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@author, @exception, @param, @return,
+          @see, @serial, @serialData, @serialField, @since, @throws, @version" />
     </module>
 
+    <!-- Ensure that Javadocs are placed before any method annotations. -->
+    <module name="InvalidJavadocPosition"/>
+
+    <!-- Ensure that a newline exists after the /** characters. -->
+    <module name="JavadocContentLocationCheck"/>
+
+    <!-- Every new line between the /** and */ must begin with an asterisk. -->
+    <module name="JavadocMissingLeadingAsterisk"/>
+
+    <!-- Every Javadoc line must contain a space after the asterisk. -->
+    <module name="JavadocMissingWhitespaceAfterAsterisk"/>
+
+    <!-- Forbid empty Javadoc clauses (e.g., @param with no description). -->
+    <module name="NonEmptyAtclauseDescription" />
+
+    <!-- Ensure that descriptions always have an empty line before Javadoc clauses. -->
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
 
     <!-- Ensure that all non-private variables have Javadoc documentation. -->
     <module name="JavadocVariable">
@@ -84,18 +102,8 @@
     <module name="UnusedImports" />
 
 
-    <!-- Ensure that there are no lines longer than 120 characters. -->
-    <module name="LineLength">
-      <property name="max" value="120" />
-    </module>
-
-
     <!-- Ensure that modifiers are provided in the correct order. -->
     <module name="ModifierOrder" />
-
-
-    <!-- Check to ensure there are no redundant modifiers. -->
-    <module name="RedundantModifier" />
 
 
     <!-- Check to ensure that all code blocks include curly braces. -->
@@ -180,5 +188,20 @@
     <!-- Ensure that all method/constructor/catch parameters are final. -->
     <module name="FinalParameters" />
   </module>
-</module>
 
+  <!-- Ensure that there are no lines longer than 100 characters. -->
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="100"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
+
+  <!-- Ensure no tab characters are used. -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+
+  <!-- Ensure that each Java package has a package-info.java file. -->
+  <module name="JavadocPackage"/>
+
+</module>

--- a/config/scim2-parent-unit-checkstyle.xml
+++ b/config/scim2-parent-unit-checkstyle.xml
@@ -35,19 +35,34 @@
 
 
   <module name="TreeWalker">
-    <property name="cacheFile" value="${cacheFile}"/>
     <!-- Ensure that all methods have Javadoc documentation. -->
     <module name="JavadocMethod">
-      <property name="scope"                       value="package" />
-      <property name="allowUndeclaredRTE"          value="false"   />
+      <property name="accessModifiers"  value="package, protected, public" />
       <property name="allowMissingParamTags"       value="false"   />
-      <property name="allowMissingThrowsTags"      value="false"   />
       <property name="allowMissingReturnTag"       value="false"   />
-      <property name="allowMissingJavadoc"         value="false"   />
-      <property name="allowMissingPropertyJavadoc" value="false"   />
-      <property name="suppressLoadErrors"          value="true"    />
+    </module>
+    <module name="MissingJavadocMethod"/>
+
+    <!-- Enforce ordering of Javadoc clauses. Ignore @deprecated clauses. -->
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@author, @exception, @param, @return,
+          @see, @serial, @serialData, @serialField, @since, @throws, @version" />
     </module>
 
+    <!-- Ensure that Javadocs are placed before any method annotations. -->
+    <module name="InvalidJavadocPosition"/>
+
+    <!-- Ensure that a newline exists after the /** characters. -->
+    <module name="JavadocContentLocationCheck"/>
+
+    <!-- Every new line between the /** and */ must begin with an asterisk. -->
+    <module name="JavadocMissingLeadingAsterisk"/>
+
+    <!-- Every Javadoc line must contain a space after the asterisk. -->
+    <module name="JavadocMissingWhitespaceAfterAsterisk"/>
+
+    <!-- Forbid empty Javadoc clauses (e.g., @param with no description). -->
+    <module name="NonEmptyAtclauseDescription" />
 
     <!-- Ensure that all non-private variables have Javadoc documentation. -->
     <module name="JavadocVariable">
@@ -84,18 +99,8 @@
     <module name="UnusedImports" />
 
 
-    <!-- Ensure that there are no lines longer than 120 characters. -->
-    <module name="LineLength">
-      <property name="max" value="120" />
-    </module>
-
-
     <!-- Ensure that modifiers are provided in the correct order. -->
     <module name="ModifierOrder" />
-
-
-    <!-- Check to ensure there are no redundant modifiers. -->
-    <module name="RedundantModifier" />
 
 
     <!-- Check to ensure that all code blocks include curly braces. -->
@@ -162,5 +167,18 @@
     <!-- Ensure that all long constants are followed by a capital L. -->
     <module name="UpperEll" />
   </module>
-</module>
 
+  <!-- Ensure that there are no lines longer than 120 characters in the test
+       code. -->
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="120"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
+
+  <!-- Ensure no tab characters are used. -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -163,48 +163,48 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.11.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.7</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.4</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.17</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.9</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.3.1</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-source-plugin</artifactId>
-          <version>2.1.2</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.7</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.2.2</version>
+          <version>3.0.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.3.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimInterface.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimInterface.java
@@ -136,8 +136,9 @@ public interface ScimInterface
 
   /**
    * Modify a SCIM resource by updating one or more attributes using a sequence
-   * of operations to "{@code add}", "{@code remove}", or "{@code replace}" values. The service provider
-   * configuration maybe used to discover service provider support for PATCH.
+   * of operations to "{@code add}", "{@code remove}", or "{@code replace}"
+   * values. The service provider configuration may be used to discover service
+   * provider support for PATCH.
    *
    * @param endpoint The resource endpoint such as: "{@code Users}" or "{@code Groups}" as
    *                 defined by the associated resource type.
@@ -155,8 +156,9 @@ public interface ScimInterface
 
   /**
    * Modify a SCIM resource by updating one or more attributes using a sequence
-   * of operations to "{@code add}", "{@code remove}", or "{@code replace}" values. The service provider
-   * configuration maybe used to discover service provider support for PATCH.
+   * of operations to "{@code add}", "{@code remove}", or "{@code replace}"
+   * values. The service provider configuration may be used to discover service
+   * provider support for PATCH.
    *
    * @param resource The resource to modify.
    * @param patchRequest the patch request to use for the update.
@@ -170,14 +172,14 @@ public interface ScimInterface
   /**
    * Delete a SCIM resource at the service provider.
    *
-   * @param endpoint The resource endpoint such as: "{@code Users}" or "{@code Groups}" as
-   *                 defined by the associated resource type.
+   * @param endpoint The resource endpoint such as: "{@code Users}" or
+   *                 "{@code Groups}" as defined by the associated resource
+   *                 type.
    * @param id The resource identifier (for example the value of the "{@code id}"
    *           attribute).
    * @throws ScimException if an error occurs.
    */
-  void delete(String endpoint, String id)
-                                          throws ScimException;
+  void delete(String endpoint, String id) throws ScimException;
 
   /**
    * Delete a SCIM resource at the service provider.
@@ -186,8 +188,7 @@ public interface ScimInterface
    * @param <T> The Java type of the resource.
    * @throws ScimException if an error occurs.
    */
-  <T extends ScimResource> void delete(T resource)
-                                              throws ScimException;
+  <T extends ScimResource> void delete(T resource) throws ScimException;
 
   /**
    * Search for SCIM resources matching the SCIM filter provided.

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimService.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimService.java
@@ -404,11 +404,13 @@ public class ScimService implements ScimInterface
 
   /**
    * Modify a SCIM resource by updating one or more attributes using a sequence
-   * of operations to "{@code add}", "{@code remove}", or "{@code replace}" values. The service provider
-   * configuration maybe used to discover service provider support for PATCH.
+   * of operations to "{@code add}", "{@code remove}", or "{@code replace}"
+   * values. The service provider configuration may be used to discover service
+   * provider support for PATCH.
    *
-   * @param endpoint The resource endpoint such as: "{@code Users}" or "{@code Groups}" as
-   *                 defined by the associated resource type.
+   * @param endpoint The resource endpoint such as: "{@code Users}" or
+   *                 "{@code Groups}" as defined by the associated resource
+   *                 type.
    * @param id The resource identifier (for example the value of the "{@code id}"
    *           attribute).
    * @return The request builder that may be used to specify additional request
@@ -424,8 +426,9 @@ public class ScimService implements ScimInterface
 
   /**
    * Modify a SCIM resource by updating one or more attributes using a sequence
-   * of operations to "{@code add}", "{@code remove}", or "{@code replace}" values. The service provider
-   * configuration maybe used to discover service provider support for PATCH.
+   * of operations to "{@code add}", "{@code remove}", or "{@code replace}"
+   * values. The service provider configuration may be used to discover service
+   * provider support for PATCH.
    *
    * @param url The URL of the resource to modify.
    * @return The request builder that may be used to specify additional request
@@ -457,8 +460,9 @@ public class ScimService implements ScimInterface
 
   /**
    * Modify a SCIM resource by updating one or more attributes using a sequence
-   * of operations to "{@code add}", "{@code remove}", or "{@code replace}" values. The service provider
-   * configuration maybe used to discover service provider support for PATCH.
+   * of operations to "{@code add}", "{@code remove}", or "{@code replace}"
+   * values. The service provider configuration may be used to discover service
+   * provider support for PATCH.
    *
    * @param resource The resource to modify.
    * @param <T> The Java type of the resource.
@@ -475,8 +479,9 @@ public class ScimService implements ScimInterface
   /**
    * Build a request to delete a SCIM resource at the service provider.
    *
-   * @param endpoint The resource endpoint such as: "{@code Users}" or "{@code Groups}" as
-   *                 defined by the associated resource type.
+   * @param endpoint The resource endpoint such as: "{@code Users}" or
+   *                 "{@code Groups}" as defined by the associated resource
+   *                 type.
    * @param id The resource identifier (for example the value of the "{@code id}"
    *           attribute).
    * @return The request builder that may be used to specify additional request

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ModifyRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ModifyRequestBuilder.java
@@ -376,7 +376,7 @@ public abstract class ModifyRequestBuilder<T extends ModifyRequestBuilder<T>>
    * Remove all values of the attribute specified by the path.
    *
    * @param path The path to the attribute whose value to remove.
-
+   *
    * @return This patch operation request.
    * @throws ScimException If the path is invalid.
    */
@@ -391,7 +391,7 @@ public abstract class ModifyRequestBuilder<T extends ModifyRequestBuilder<T>>
    * Remove all values of the attribute specified by the path.
    *
    * @param path The path to the attribute whose value to remove.
-
+   *
    * @return This patch operation request.
    * @throws ScimException If the path is invalid.
    */

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RequestBuilder.java
@@ -90,6 +90,7 @@ public class RequestBuilder<T extends RequestBuilder>
   /**
    * Sets the media type for any content sent to the server.  The default
    * value is ApiConstants.MEDIA_TYPE_SCIM ("application/scim+json").
+   *
    * @param contentType a string describing the media type of content
    *                    sent to the server.
    * @return This builder.
@@ -105,6 +106,7 @@ public class RequestBuilder<T extends RequestBuilder>
    * The default accepted media types are
    * ApiConstants.MEDIA_TYPE_SCIM ("application/scim+json") and
    * MediaType.APPLICATION_JSON ("application/json")
+   *
    * @param acceptStrings a string (or strings) describing the media type that
    *                      will be accepted from the server.  This parameter may
    *                      not be null.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
@@ -104,8 +104,9 @@ public abstract class BaseScimResource
   }
 
   /**
-   * Gets the <code>ObjectNode</code> that contains all extension attributes.
-   * @return a <code>ObjectNode</code>.
+   * Gets the {@code ObjectNode} that contains all extension attributes.
+   *
+   * @return an {@code ObjectNode}.
    */
   @JsonIgnore
   public ObjectNode getExtensionObjectNode()
@@ -221,6 +222,7 @@ public abstract class BaseScimResource
   /**
    * Used to get values that were deserialized from json where there was
    * no matching field in the class.
+   *
    * @return the value of the field.
    */
   @JsonAnyGetter

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
@@ -93,8 +93,9 @@ public final class GenericScimResource implements ScimResource
   }
 
   /**
-   * Gets the <code>ObjectNode</code> that backs this object.
-   * @return a <code>ObjectNode</code>.
+   * Gets the {@code ObjectNode} that backs this object.
+   *
+   * @return an {@code ObjectNode} representing this generic SCIM resource.
    */
   public ObjectNode getObjectNode()
   {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/ScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/ScimResource.java
@@ -29,18 +29,21 @@ public interface ScimResource
 
   /**
    * Gets metadata about the object.
-   * @return <code>Meta</code> containing metadata about the object.
+   *
+   * @return {@code Meta} containing metadata about the object.
    */
   Meta getMeta();
 
   /**
    * Sets metadata for the object.
-   * @param meta <code>Meta</code> containing metadata for the object.
+   *
+   * @param meta {@code Meta} containing metadata for the object.
    */
   void setMeta(Meta meta);
 
   /**
    * Gets the id of the object.
+   *
    * @return the id of the object.
    */
   String getId();
@@ -48,18 +51,21 @@ public interface ScimResource
 
   /**
    * Sets the id of the object.
+   *
    * @param id The object's id.
    */
   void setId(String id);
 
   /**
    * Gets the objects external id.
+   *
    * @return The external id of the object.
    */
   String getExternalId();
 
   /**
    * Sets the object's external id.
+   *
    * @param externalId The external id of the object.
    */
   void setExternalId(String externalId);

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ErrorResponse.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ErrorResponse.java
@@ -84,6 +84,7 @@ public final class ErrorResponse extends BaseScimResource
 
   /**
    * Gets the summary of the SCIM error.
+   *
    * @return the summary of the SCIM error.
    */
   public String getDetail()
@@ -93,6 +94,7 @@ public final class ErrorResponse extends BaseScimResource
 
   /**
    * Sets the summary of the SCIM error.
+   *
    * @param detail the summary of the SCIM error.
    */
   public void setDetail(final String detail)
@@ -102,6 +104,7 @@ public final class ErrorResponse extends BaseScimResource
 
   /**
    * Gets the HTTP status of the SCIM error.
+   *
    * @return the HTTP status of the SCIM error.
    */
   public Integer getStatus()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/AttributeDefinition.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/AttributeDefinition.java
@@ -85,6 +85,7 @@ public class AttributeDefinition
 
     /**
      * Constructs an attribute type object.
+     *
      * @param name the name (used in SCIM schemas) of the object.
      */
     Type(final String name)

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Meta.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Meta.java
@@ -54,6 +54,7 @@ public final class Meta
 
   /**
    * Gets the timestamp of when the SCIM object was created.
+   *
    * @return the date and time the SCIM object was created.
    */
   public Calendar getCreated()
@@ -73,6 +74,7 @@ public final class Meta
 
   /**
    * Gets the timestamp for the last modification.
+   *
    * @return the timestamp of the last modification.
    */
   public Calendar getLastModified()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/PatchConfig.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/PatchConfig.java
@@ -34,6 +34,7 @@ public class PatchConfig
 
   /**
    * Create a new complex type that specifies PATCH configuration options.
+   *
    * @param supported Boolean value specifying whether the operation is
    *                  supported.
    */

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/SchemaResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/SchemaResource.java
@@ -77,6 +77,7 @@ public class SchemaResource extends BaseScimResource
 
   /**
    * Gets the object's name.
+   *
    * @return objects name.
    */
   public String getName()
@@ -86,6 +87,7 @@ public class SchemaResource extends BaseScimResource
 
   /**
    * Gets the name of the SCIM object from the schema.
+   *
    * @return the name of the SCIM object.
    */
   public String getDescription()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/UserResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/UserResource.java
@@ -346,7 +346,7 @@ public class UserResource extends BaseScimResource
 
   /**
    * Retrieves the user's title, such as "{@code Vice President}".
-
+   *
    * @return The user's title.
    */
   public String getTitle()
@@ -738,7 +738,7 @@ public class UserResource extends BaseScimResource
   /**
    * Retrieves the list of entitlements for the User that represent a thing the
    * User has.
-
+   *
    * @return The list of entitlements for the User.
    */
   public List<Entitlement> getEntitlements()

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/FilterEvaluator.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/FilterEvaluator.java
@@ -408,6 +408,7 @@ public class FilterEvaluator implements FilterVisitor<Boolean, JsonNode>
 
   /**
    * Return true if the node is either {@code null} or an empty array.
+   *
    * @param node node to examine
    * @return boolean
    */
@@ -433,6 +434,7 @@ public class FilterEvaluator implements FilterVisitor<Boolean, JsonNode>
   /**
    * Return true if the specified node list contains nothing
    * but empty arrays and/or {@code null} nodes.
+   *
    * @param nodes list of nodes as returned from JsonUtils.findMatchingPaths
    * @return true if the list contains only empty array(s)
    */

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonDiff.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonDiff.java
@@ -207,6 +207,7 @@ public class JsonDiff
 
   /**
    * Compare the JSON value nodes at the specified path.
+   *
    * @param path path
    * @param sourceNode source node
    * @param targetNode target node
@@ -512,6 +513,7 @@ public class JsonDiff
 
   /**
    * Determines whether the provided JSON nodes have the same JSON data type.
+   *
    * @param n1  The first node.
    * @param n2  The second node.
    * @return  {@code true} iff the nodes have the same JSON data type.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
@@ -78,6 +78,8 @@ public class JsonUtils
         throws ScimException;
 
     /**
+     * Identifies the elements within an ArrayNode that match a filter. This
+     * method can optionally remove the elements/values that were matched.
      *
      * @param array The ArrayNode to filter.
      * @param valueFilter The value filter.
@@ -683,6 +685,7 @@ public class JsonUtils
    *     will be thrown.
    *   </li>
    * </ul>
+   *
    * @param path The path to the attribute.
    * @param node The JSON object node containing the attribute.
    * @param value The replacement value.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/SchemaUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/SchemaUtils.java
@@ -132,7 +132,7 @@ public class SchemaUtils
    * introspection errors.
    */
   public static Collection<PropertyDescriptor>
-  getPropertyDescriptors(final Class cls)
+  getPropertyDescriptors(final Class<?> cls)
       throws IntrospectionException
   {
     BeanInfo beanInfo = Introspector.getBeanInfo(cls, Object.class);
@@ -143,16 +143,17 @@ public class SchemaUtils
 
   /**
    * Gets schema attributes for the given class.
+   *
    * @param cls Class to get the schema attributes for.
    * @return a collection of attributes.
    * @throws IntrospectionException thrown if an introspection error occurs.
    */
   @Transient
   public static Collection<AttributeDefinition> getAttributes(
-      final Class cls)
+      final Class<?> cls)
       throws IntrospectionException
   {
-    Stack<String> classesProcessed = new Stack<String>();
+    Stack<String> classesProcessed = new Stack<>();
     return getAttributes(classesProcessed, cls);
   }
 
@@ -684,15 +685,15 @@ public class SchemaUtils
   }
 
   /**
-   * Gets the schema urn from a java <code>Class</code>.
-   * @param cls <code>Class</code> of the object.
+   * Fetches the schema urn from a {@code Class}.
+   *
+   * @param cls The class of the object.
    * @return The schema urn for the object.
    */
-  public static String getSchemaUrn(final Class cls)
+  public static String getSchemaUrn(final Class<?> cls)
   {
-    // the schemaid is the urn.  Just make sure it
-    // begins with urn: ... the field called name
-    // is just a human friendly name for the object.
+    // The 'schemaId' is the URN. Make sure it begins with the "urn:" prefix.
+    // The 'name' field is a human-friendly name for the object.
     String schemaId =
         SchemaUtils.getSchemaIdFromAnnotation(cls);
 
@@ -701,8 +702,8 @@ public class SchemaUtils
       schemaId = cls.getCanonicalName();
     }
 
-    // if this doesn't appear to be a urn, stick the "urn:" prefix
-    // on it, and use it as a urn anyway.
+    // If the schema ID doesn't appear to be a valid URN, append the data to an
+    // "urn:" prefix.
     return forceToBeUrn(schemaId);
   }
 

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimFilterJsonParser.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimFilterJsonParser.java
@@ -35,6 +35,7 @@ public class ScimFilterJsonParser extends ReaderBasedJsonParser {
 
   /**
    * Constructor.
+   *
    * @param ctxt  see superclass
    * @param features  see superclass
    * @param r see superclass

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimJsonFactory.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ScimJsonFactory.java
@@ -57,6 +57,7 @@ public class ScimJsonFactory extends JsonFactory
   /**
    * Create a parser that can be used for parsing JSON objects contained
    * within a SCIM filter specification.
+   *
    * @param r Reader to use for reading JSON content to parse
    * @return ScimFilterJsonParser object
    * @throws IOException on parse error

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/DotSearchFilter.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/DotSearchFilter.java
@@ -100,7 +100,7 @@ public class DotSearchFilter implements ContainerRequestFilter
       {
         builder.queryParam(QUERY_PARAMETER_EXCLUDED_ATTRIBUTES,
             ServerUtils.encodeTemplateNames(
-		StaticUtils.collectionToString(
+                    StaticUtils.collectionToString(
                     searchRequest.getExcludedAttributes(), ",")));
       }
       if(searchRequest.getFilter() != null)

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourceDiff.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourceDiff.java
@@ -29,12 +29,14 @@ import com.unboundid.scim2.common.utils.JsonUtils;
  * The comparison takes into account the SCIM schema of the resources
  * to be compared.
  */
-public class ResourceDiff extends JsonDiff {
+public class ResourceDiff extends JsonDiff
+{
 
   private ResourceTypeDefinition resourceTypeDefinition;
 
   /**
    * Construct a ResourceDiff instance.
+   *
    * @param resourceTypeDefinition the ResourceTypeDefinition of the
    *                               resources to be compared.
    */

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaCheckFilterVisitor.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaCheckFilterVisitor.java
@@ -77,6 +77,7 @@ public final class SchemaCheckFilterVisitor
    *
    * @param filter   The filter to check.
    * @param resourceTypeDefinition The schema to check the filter against.
+   * @param schemaChecker The object that will enforce schema constraints.
    * @param enabledOptions  The schema checker enabled options.
    * @param results  The results of checking the filter.
    * @throws ScimException If an exception occurs during the operation.
@@ -110,6 +111,7 @@ public final class SchemaCheckFilterVisitor
    * @param parentPath  The parent attribute associated with the value filter.
    * @param filter   The value filter to check.
    * @param resourceTypeDefinition The schema to check the filter against.
+   * @param schemaChecker The object that will enforce schema constraints.
    * @param enabledOptions  The schema checker enabled options.
    * @param results  The results of checking the filter.
    * @throws ScimException If an exception occurs during the operation.

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ScimResourceTrimmer.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ScimResourceTrimmer.java
@@ -38,6 +38,7 @@ public class ScimResourceTrimmer extends ResourceTrimmer
 
   /**
    * Create a new SCIMResourceTrimmer.
+   *
    * @param resourceType       The resource type definition for resources to
    *                           trim.
    * @param requestAttributes  The attributes in the request object or

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/contactvalidation/EmailValidationRequest.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/contactvalidation/EmailValidationRequest.java
@@ -84,6 +84,7 @@ public class EmailValidationRequest extends BaseScimResource
 
   /**
     * Retrieve the attribute path.
+   *
     * @return  The attribute path.
     */
    public String getAttributePath()
@@ -95,6 +96,7 @@ public class EmailValidationRequest extends BaseScimResource
 
    /**
     * Set the attribute path.
+    *
     * @param attributePath  The attribute path.
     */
    public void setAttributePath(final String attributePath)
@@ -106,6 +108,7 @@ public class EmailValidationRequest extends BaseScimResource
 
    /**
     * Retrieve the attribute value.
+    *
     * @return  The attribute value.
     */
    public String getAttributeValue()
@@ -117,6 +120,7 @@ public class EmailValidationRequest extends BaseScimResource
 
    /**
     * Set the attribute value.
+    *
     * @param attributeValue  The attribute value.
     */
    public void setAttributeValue(final String attributeValue)
@@ -128,6 +132,7 @@ public class EmailValidationRequest extends BaseScimResource
 
    /**
     * Indicates whether the attribute value is validated.
+    *
     * @return  {@code true} iff the attribute value is validated.
     */
    public Boolean getValidated()
@@ -139,6 +144,7 @@ public class EmailValidationRequest extends BaseScimResource
 
    /**
     * Specify whether the attribute value is validated.
+    *
     * @param validated  {@code true} iff the attribute value is validated.
     */
    public void setValidated(final Boolean validated)
@@ -150,6 +156,7 @@ public class EmailValidationRequest extends BaseScimResource
 
    /**
     * Retrieve the time at which the attribute value was validated.
+    *
     * @return  The time at which the attribute value was validated.
     */
    public Calendar getValidatedAt()
@@ -161,6 +168,7 @@ public class EmailValidationRequest extends BaseScimResource
 
    /**
     * Set the time at which the attribute value was validated.
+    *
     * @param validatedAt  The time at which the attribute value was validated.
     */
    public void setValidatedAt(final Calendar validatedAt)
@@ -173,6 +181,7 @@ public class EmailValidationRequest extends BaseScimResource
    /**
     * Indicates whether a verification code has been sent.
     * Only applicable in an intermediate response to update preferences.
+    *
     * @return  {@code true} iff a verification code has been sent.
     */
    public Boolean getCodeSent()
@@ -185,6 +194,7 @@ public class EmailValidationRequest extends BaseScimResource
    /**
     * Specify whether a verification code has been sent.
     * Only applicable in an intermediate response to update preferences.
+    *
     * @param codeSent  {@code true} iff a verification code has been sent.
     */
    public void setCodeSent(final Boolean codeSent)
@@ -196,6 +206,7 @@ public class EmailValidationRequest extends BaseScimResource
 
   /**
    * Retrieve the code to be verified against the delivered code.
+   *
    * @return  The code to be verified against the delivered code.
    */
   public String getVerifyCode()
@@ -207,6 +218,7 @@ public class EmailValidationRequest extends BaseScimResource
 
   /**
    * Specify the code to be verified against the delivered code.
+   *
    * @param verifyCode  The code to be verified against the delivered code.
    */
   public void setVerifyCode(final String verifyCode)

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/contactvalidation/TelephonyValidationRequest.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/contactvalidation/TelephonyValidationRequest.java
@@ -97,6 +97,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Retrieve the attribute path.
+   *
    * @return  The attribute path.
    */
   public String getAttributePath()
@@ -108,6 +109,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Set the attribute path.
+   *
    * @param attributePath  The attribute path.
    */
   public void setAttributePath(final String attributePath)
@@ -119,6 +121,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Retrieve the attribute value.
+   *
    * @return  The attribute value.
    */
   public String getAttributeValue()
@@ -130,6 +133,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Set the attribute value.
+   *
    * @param attributeValue  The attribute value.
    */
   public void setAttributeValue(final String attributeValue)
@@ -141,6 +145,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Indicates whether the attribute value is validated.
+   *
    * @return  {@code true} iff the attribute value is validated.
    */
   public Boolean getValidated()
@@ -152,6 +157,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Specify whether the attribute value is validated.
+   *
    * @param validated  {@code true} iff the attribute value is validated.
    */
   public void setValidated(final Boolean validated)
@@ -163,6 +169,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Retrieve the time at which the attribute value was validated.
+   *
    * @return  The time at which the attribute value was validated.
    */
   public Calendar getValidatedAt()
@@ -174,6 +181,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Set the time at which the attribute value was validated.
+   *
    * @param validatedAt  The time at which the attribute value was validated.
    */
   public void setValidatedAt(final Calendar validatedAt)
@@ -186,6 +194,7 @@ public class TelephonyValidationRequest extends BaseScimResource
   /**
    * Indicates whether a verification code has been sent.
    * Only applicable in an intermediate response to update preferences.
+   *
    * @return  {@code true} iff a verification code has been sent.
    */
   public Boolean getCodeSent()
@@ -198,6 +207,7 @@ public class TelephonyValidationRequest extends BaseScimResource
   /**
    * Specify whether a verification code has been sent.
    * Only applicable in an intermediate response to update preferences.
+   *
    * @param codeSent  {@code true} iff a verification code has been sent.
    */
   public void setCodeSent(final Boolean codeSent)
@@ -208,6 +218,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Retrieve the language and locale of the message.
+   *
    * @return  The language and locale of the message.
    */
   public String getLanguage()
@@ -218,6 +229,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Specify the language and locale of the message.
+   *
    * @param language  The language and locale of the message.
    */
   public void setLanguage(final String language)
@@ -228,6 +240,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Retrieve the selected messaging provider.
+   *
    * @return  The selected messaging provider.
    */
   public String getMessagingProvider()
@@ -237,6 +250,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Specify the selected messaging provider.
+   *
    * @param  messagingProvider  The selected messaging provider.
    */
   public void setMessagingProvider(
@@ -247,6 +261,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Retrieve the code to be verified against the delivered code.
+   *
    * @return  The code to be verified against the delivered code.
    */
   public String getVerifyCode()
@@ -258,6 +273,7 @@ public class TelephonyValidationRequest extends BaseScimResource
 
   /**
    * Specify the code to be verified against the delivered code.
+   *
    * @param verifyCode  The code to be verified against the delivered code.
    */
   public void setVerifyCode(final String verifyCode)

--- a/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/pwdmgmt/PasswordRequirementResult.java
+++ b/scim2-ubid-extensions/src/main/java/com/unboundid/scim2/extension/messages/pwdmgmt/PasswordRequirementResult.java
@@ -47,7 +47,7 @@ public class PasswordRequirementResult
         mutability = AttributeDefinition.Mutability.READ_ONLY)
   private String additionalInfo;
   private Map<String, JsonNode> properties =
-      new LinkedHashMap<String, JsonNode>();
+      new LinkedHashMap<>();
 
   /**
    * Gets the type of password requirement.
@@ -71,6 +71,7 @@ public class PasswordRequirementResult
 
   /**
    * Used to determine if the requirement is satisfied.
+   *
    * @return true if the requirement is satisfied, or false if not.
    */
   public Boolean isRequirementSatisfied()
@@ -80,6 +81,7 @@ public class PasswordRequirementResult
 
   /**
    * Sets whether or not the password requirement is satisfied.
+   *
    * @param requirementSatisfied boolean indicating if the password requirement
    *                             is satisfied or not.
    */
@@ -90,6 +92,7 @@ public class PasswordRequirementResult
 
   /**
    * Gets the additonal information for this password update error.
+   *
    * @return the additional information, such as the failure message
    * for this password update error.
    */
@@ -100,6 +103,7 @@ public class PasswordRequirementResult
 
   /**
    * Sets the additional information for this password update error.
+   *
    * @param additionalInfo additional information, such as the failure message
    *   for this password update error.
    */


### PR DESCRIPTION
Updated the maven-checkstyle-plugin to resolve a potential issue with
the build pipeline. The version of Checkstyle used by the plugin has
jumped from 6.19 to 9.3, so some rules in the checkstyle.xml were no
longer valid and required updates. The necessary project code changes
to accommodate the new ruleset will be reflected in another commit.

The Maven Assembly plugin also required an update to resolve a pipeline
build failure as a result of the Checkstyle update. To prevent similar
issues, other Maven plugins have been updated to the most recent
releases as well.