### PR TITLE
Overhaul class-level documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## v2.4.1 - TBD
-Placeholder for the next release.
+Overhauled many of the class-level Javadocs in the scim2-sdk-common package. This provides better
+descriptions for SCIM entities, SDK-specific constructs (e.g., `ScimResource`), and more background
+on SCIM conventions such as filtering. The new documentation also provides better descriptions for
+how certain classes in the SDK should be used, such as the `Filter` class.
+
+Added new constructors for some exception types involving the `scimType` field. This field is empty
+in many cases, so these new constructors set the `scimType` value to be `null` with the goal of
+simplifying the process of creating exceptions.
 
 ## v2.4.0 - 2023-Jul-28
 Fixed an issue with PatchOperations that prevented setting the `value` field to an empty array. The

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimService.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimService.java
@@ -41,11 +41,9 @@ import java.net.URI;
 
 import static com.unboundid.scim2.common.utils.ApiConstants.MEDIA_TYPE_SCIM;
 import static com.unboundid.scim2.common.utils.ApiConstants.ME_ENDPOINT;
-import static com.unboundid.scim2.common.utils.ApiConstants.
-    RESOURCE_TYPES_ENDPOINT;
+import static com.unboundid.scim2.common.utils.ApiConstants.RESOURCE_TYPES_ENDPOINT;
 import static com.unboundid.scim2.common.utils.ApiConstants.SCHEMAS_ENDPOINT;
-import static com.unboundid.scim2.common.utils.ApiConstants.
-    SERVICE_PROVIDER_CONFIG_ENDPOINT;
+import static com.unboundid.scim2.common.utils.ApiConstants.SERVICE_PROVIDER_CONFIG_ENDPOINT;
 
 /**
  * The main entry point to the client API used to access a SCIM 2 service

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimServiceException.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimServiceException.java
@@ -20,7 +20,7 @@ package com.unboundid.scim2.client;
 import com.unboundid.scim2.common.exceptions.ScimException;
 
 /**
- * This exception is thrown when problems occur in the ScimService.  This
+ * This exception is thrown when problems occur in the {@link ScimService}. This
  * class allows a client application to differentiate between errors that
  * arise on the client side from errors that come from the server.
  */
@@ -32,9 +32,9 @@ public class ScimServiceException extends ScimException
    * @param statusCode    The HTTP status code for this exception.
    * @param errorMessage  The error message for this SCIM exception.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
 
   public ScimServiceException(final int statusCode,

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
@@ -189,7 +189,7 @@ public abstract class BaseScimResource
 
   /**
    * This method is used during json deserialization.  It will be called
-   * in the event that a value is given for an field that is not defined
+   * in the event that a value is given for a field that is not defined
    * in the class.
    *
    * @param key name of the field.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
@@ -400,7 +400,7 @@ public final class Path implements Iterable<Path.Element>
    * Creates a path to the root of the JSON object that contains all the
    * extension attributes of an extension schema defined by the provided class.
    *
-   * @param extensionClass The the extension class that defines the extension
+   * @param extensionClass The extension class that defines the extension
    *                       schema.
    * @param <T> The generic type parameter of the Java class used to represent
    *            the extension.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/ScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/ScimResource.java
@@ -22,11 +22,34 @@ import com.unboundid.scim2.common.types.Meta;
 import java.util.Collection;
 
 /**
- * Interface that can be used to access data from all SCIM objects.
+ * This class represents the core interface for all SCIM objects. This interface
+ * helps ensure that all SCIM resources contain the following properties:
+ * <ul>
+ *   <li> A {@code schemas} field containing a list of URIs that represent the
+ *        type of the SCIM resource.
+ *   <li> An {@code id} field representing a unique identifier for the resource.
+ *        This is typically in {@link java.util.UUID} form.
+ *   <li> A {@link Meta} attribute that stores metadata relating to the SCIM
+ *        resource, such as the time the resource was created and last updated.
+ *   <li> An {@code externalID} field. This is an optional field whose meaning
+ *        is determined by a SCIM client. This is particularly useful for
+ *        provisioning use cases, where a client is importing users from another
+ *        system but still wants to store a resource's old unique ID in the new
+ *        system. The {@code externalID} field can later be used by the client
+ *        to search for resources on the new SCIM endpoints by referencing their
+ *        old IDs.
+ * </ul>
+ *
+ * The SCIM SDK provides two core implementations of ScimResource. These are the
+ * {@link BaseScimResource} and {@link GenericScimResource} classes. In general,
+ * a SCIM resource should be represented as a BaseScimResource if a well-defined
+ * schema is known ahead of time, and a dedicated Java object is desired.
+ * Alternatively, a SCIM resource should be represented as a GenericScimResource
+ * if it is easier to work with a class that is a wrapper for a JSON object.
+ * See the class-level documentation of these subclasses for more information.
  */
 public interface ScimResource
 {
-
   /**
    * Gets metadata about the object.
    *

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/annotations/Attribute.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/annotations/Attribute.java
@@ -19,6 +19,7 @@ package com.unboundid.scim2.common.annotations;
 
 
 import com.unboundid.scim2.common.types.AttributeDefinition;
+import com.unboundid.scim2.common.types.UserResource;
 
 import javax.lang.model.type.NullType;
 import java.lang.annotation.ElementType;
@@ -27,7 +28,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for getter methods of a SCIM object.
+ * This annotation is used to record useful properties about attributes on SCIM
+ * resources. This helps display attribute definitions directly on member
+ * variables of a class, where the class represents a SCIM resource type. For
+ * example, if an attribute must be provided when a resource type is created,
+ * the {@link #isRequired} field should be {@code true}.
+ * <br><br>
+ * The {@link UserResource} class uses this annotation to highlight attribute
+ * definitions that are defined in RFC 7643.
  */
 @Retention(value = RetentionPolicy.RUNTIME)
 @Target(value = ElementType.FIELD)
@@ -89,8 +97,8 @@ public @interface Attribute
    *
    * @return The mutability constraint for the attribute.
    */
-  AttributeDefinition.Mutability mutability() default
-      AttributeDefinition.Mutability.READ_WRITE;
+  AttributeDefinition.Mutability mutability()
+      default AttributeDefinition.Mutability.READ_WRITE;
 
   /**
    * If the attribute is multi-value, this holds the type of the
@@ -98,5 +106,5 @@ public @interface Attribute
    *
    * @return For a multi-valued attribute, the type of the child object.
    */
-  Class multiValueClass() default NullType.class;
+  Class<?> multiValueClass() default NullType.class;
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/annotations/Schema.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/annotations/Schema.java
@@ -44,8 +44,7 @@ public @interface Schema
   String description();
 
   /**
-   * The name for the object.  This is a human readable
-   * name.
+   * The human-readable name for the object.
    *
    * @return The object's human-readable name.
    */

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/BadRequestException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/BadRequestException.java
@@ -20,9 +20,48 @@ package com.unboundid.scim2.common.exceptions;
 import com.unboundid.scim2.common.messages.ErrorResponse;
 
 /**
- * Signals an error while looking up resources and attributes.
+ * This class represents a SCIM exception pertaining to the {@code HTTP 400}
+ * error response code. This exception type should be thrown when a client sends
+ * a JSON payload that cannot be parsed, is syntactically incorrect, or violates
+ * the schema.
+ * <br><br>
+ * BadRequestExceptions, as well as {@link ResourceConflictException} objects,
+ * are unique types of SCIM exceptions since they sometimes include an optional
+ * {@code scimType} field. A {@code scimType} represents a "SCIM detail error
+ * keyword", which succinctly describes the reason for the failure in camelcase
+ * (e.g., {@code "noTarget"}). See the constants defined on this class, such as
+ * {@link #NO_TARGET}, for more detail on what situations a given
+ * {@code scimType} is typically used for.
+ * <br><br>
+ * The following is an example of a BadRequestException presented to a SCIM
+ * client. This example error response indicates that the client tried to modify
+ * an attribute that is defined as read-only in the schema.
+ * <pre>
+ *   {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
+ *     "status": "400",
+ *     "scimType": "mutability",
+ *     "detail": "Read-only attributes cannot be modified."
+ *   }
+ * </pre>
  *
- * This exception corresponds to HTTP response code 400 BAD REQUEST.
+ * The BadRequestException in the above example can be created with the
+ * following Java code. Note that this uses a static method to populate the
+ * {@code scimType} field.
+ * <pre>
+ *   throw BadRequestException.mutability(
+ *           "Read-only attributes cannot be modified.");
+ * </pre>
+ *
+ * The following shows more examples for creating a BadRequestException:
+ * <pre>
+ *   throw BadRequestException.invalidPath("Null paths are not permitted.");
+ *   throw BadRequestException.tooMany(
+ *          "Too many results returned. Narrow the scope of the search.");
+ *
+ *   // Create a generic BadRequestException without a 'scimType'.
+ *   throw new BadRequestException("Detailed message explaining the error.");
+ * </pre>
  */
 public class BadRequestException extends ScimException
 {
@@ -57,7 +96,7 @@ public class BadRequestException extends ScimException
   public static final String INVALID_SYNTAX = "invalidSyntax";
 
   /**
-   * The SCIM detailed error keyword that indicates the the path attribute was
+   * The SCIM detailed error keyword that indicates the path attribute was
    * invalid or malformed.
    */
   public static final String INVALID_PATH = "invalidPath";
@@ -81,56 +120,82 @@ public class BadRequestException extends ScimException
    */
   public static final String INVALID_VERSION = "invalidVersion";
 
+
   /**
-   * Create a new <code>BadRequestException</code> from the provided
-   * information.
+   * Create a generic BadRequestException without a {@code} scimType field.
+   *
+   * @param errorMessage  The error message for this SCIM exception.
+   */
+  public BadRequestException(final String errorMessage)
+  {
+    this(errorMessage, (String) null);
+  }
+
+  /**
+   * Create a new {@code BadRequestException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    * @param scimType      The SCIM detailed error keyword.
    */
   public BadRequestException(final String errorMessage,
-                             final String scimType) {
+                             final String scimType)
+  {
     super(400, scimType, errorMessage);
   }
 
   /**
-   * Create a new <code>BadRequestException</code> from the provided
-   * information.
+   * Create a new {@code BadRequestException} from the provided information.
+   *
+   * @param errorMessage  The error message for this SCIM exception.
+   * @param cause         The cause (which is saved for later retrieval by the
+   *                      {@link #getCause()} method). A {@code null} value
+   *                      is permitted, and indicates that the cause is
+   *                      nonexistent or unknown.
+   */
+  public BadRequestException(final String errorMessage,
+                             final Throwable cause)
+  {
+    this(errorMessage, null, cause);
+  }
+
+  /**
+   * Create a new {@code BadRequestException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    * @param scimType      The SCIM detailed error keyword.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public BadRequestException(final String errorMessage,
                              final String scimType,
-                             final Throwable cause) {
+                             final Throwable cause)
+  {
     super(400, scimType, errorMessage, cause);
   }
 
   /**
-   * Create a new <code>BadRequestException</code> from the provided
-   * information.
+   * Create a new {@code BadRequestException} from the provided information.
    *
    * @param scimError     The SCIM error response.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public BadRequestException(final ErrorResponse scimError,
-                             final Throwable cause) {
+                             final Throwable cause)
+  {
     super(scimError, cause);
   }
 
   /**
-   * Factory method to create a new <code>BadRequestException</code> with the
+   * Factory method to create a new {@code BadRequestException} with the
    * invalidFilter SCIM detailed error keyword.
    *
    * @param errorMessage  The error message for this SCIM exception.
-   * @return The new <code>BadRequestException</code>.
+   * @return The new {@code BadRequestException}.
    */
   public static BadRequestException invalidFilter(final String errorMessage)
   {
@@ -138,11 +203,11 @@ public class BadRequestException extends ScimException
   }
 
   /**
-   * Factory method to create a new <code>BadRequestException</code> with the
+   * Factory method to create a new {@code BadRequestException} with the
    * tooMany SCIM detailed error keyword.
    *
    * @param errorMessage  The error message for this SCIM exception.
-   * @return The new <code>BadRequestException</code>.
+   * @return The new {@code BadRequestException}.
    */
   public static BadRequestException tooMany(final String errorMessage)
   {
@@ -150,11 +215,11 @@ public class BadRequestException extends ScimException
   }
 
   /**
-   * Factory method to create a new <code>BadRequestException</code> with the
+   * Factory method to create a new {@code BadRequestException} with the
    * uniqueness SCIM detailed error keyword.
    *
    * @param errorMessage  The error message for this SCIM exception.
-   * @return The new <code>BadRequestException</code>.
+   * @return The new {@code BadRequestException}.
    */
   public static BadRequestException uniqueness(final String errorMessage)
   {
@@ -162,11 +227,11 @@ public class BadRequestException extends ScimException
   }
 
   /**
-   * Factory method to create a new <code>BadRequestException</code> with the
+   * Factory method to create a new {@code BadRequestException} with the
    * mutability SCIM detailed error keyword.
    *
    * @param errorMessage  The error message for this SCIM exception.
-   * @return The new <code>BadRequestException</code>.
+   * @return The new {@code BadRequestException}.
    */
   public static BadRequestException mutability(final String errorMessage)
   {
@@ -174,11 +239,11 @@ public class BadRequestException extends ScimException
   }
 
   /**
-   * Factory method to create a new <code>BadRequestException</code> with the
+   * Factory method to create a new {@code BadRequestException} with the
    * invalidSyntax SCIM detailed error keyword.
    *
    * @param errorMessage  The error message for this SCIM exception.
-   * @return The new <code>BadRequestException</code>.
+   * @return The new {@code BadRequestException}.
    */
   public static BadRequestException invalidSyntax(final String errorMessage)
   {
@@ -186,11 +251,11 @@ public class BadRequestException extends ScimException
   }
 
   /**
-   * Factory method to create a new <code>BadRequestException</code> with the
+   * Factory method to create a new {@code BadRequestException} with the
    * invalidPath SCIM detailed error keyword.
    *
    * @param errorMessage  The error message for this SCIM exception.
-   * @return The new <code>BadRequestException</code>.
+   * @return The new {@code BadRequestException}.
    */
   public static BadRequestException invalidPath(final String errorMessage)
   {
@@ -198,11 +263,11 @@ public class BadRequestException extends ScimException
   }
 
   /**
-   * Factory method to create a new <code>BadRequestException</code> with the
+   * Factory method to create a new {@code BadRequestException} with the
    * noTarget SCIM detailed error keyword.
    *
    * @param errorMessage  The error message for this SCIM exception.
-   * @return The new <code>BadRequestException</code>.
+   * @return The new {@code BadRequestException}.
    */
   public static BadRequestException noTarget(final String errorMessage)
   {
@@ -210,11 +275,11 @@ public class BadRequestException extends ScimException
   }
 
   /**
-   * Factory method to create a new <code>BadRequestException</code> with the
+   * Factory method to create a new {@code BadRequestException} with the
    * invalidValue SCIM detailed error keyword.
    *
    * @param errorMessage  The error message for this SCIM exception.
-   * @return The new <code>BadRequestException</code>.
+   * @return The new {@code BadRequestException}.
    */
   public static BadRequestException invalidValue(final String errorMessage)
   {
@@ -222,11 +287,11 @@ public class BadRequestException extends ScimException
   }
 
   /**
-   * Factory method to create a new <code>BadRequestException</code> with the
+   * Factory method to create a new {@code BadRequestException} with the
    * invalidVersion SCIM detailed error keyword.
    *
    * @param errorMessage  The error message for this SCIM exception.
-   * @return The new <code>BadRequestException</code>.
+   * @return The new {@code BadRequestException}.
    */
   public static BadRequestException invalidVersion(final String errorMessage)
   {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ForbiddenException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ForbiddenException.java
@@ -17,55 +17,76 @@
 
 package com.unboundid.scim2.common.exceptions;
 
-
+import com.unboundid.scim2.common.filters.Filter;
 import com.unboundid.scim2.common.messages.ErrorResponse;
 
 /**
- * Signals the server does not support the requested operation.
+ * This class represents a SCIM exception pertaining to the
+ * {@code HTTP 403 FORBIDDEN} error response code. This exception type should be
+ * thrown when a client attempts an operation that is not permitted or supported
+ * by the SCIM service provider.
+ * <br><br>
+ * The following is an example of a ForbiddenException presented to a SCIM
+ * client. This example error response indicates that the client tried to
+ * provide a SCIM {@link Filter} with a disallowed filter type.
+ * <pre>
+ *   {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
+ *     "status": "403",
+ *     "detail": "The provided filter type is not supported."
+ *   }
+ * </pre>
  *
- * This exception corresponds to HTTP response code 403 FORBIDDEN.
+ * The ForbiddenException in the above example can be created with the following
+ * Java code:
+ * <pre>
+ *   throw new ForbiddenException("The provided filter type is not supported.");
+ * </pre>
+ *
+ * This exception type generally does not have a {@code scimType} value.
  */
 public class ForbiddenException extends ScimException
 {
   /**
-   * Create a new <code>ForbiddenException</code> from the provided
-   * information.
+   * Create a new {@code ForbiddenException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    */
-  public ForbiddenException(final String errorMessage) {
+  public ForbiddenException(final String errorMessage)
+  {
     super(403, null, errorMessage);
   }
 
   /**
-   * Create a new <code>ForbiddenException</code> from the provided
-   * information.
+   * Create a new {@code ForbiddenException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
-   * @param scimType      The SCIM detailed error keyword.
+   * @param scimType      The SCIM detailed error keyword. This should generally
+   *                      be {@code null} for ForbiddenExceptions.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public ForbiddenException(final String errorMessage,
                             final String scimType,
-                            final Throwable cause) {
+                            final Throwable cause)
+  {
     super(403, scimType, errorMessage, cause);
   }
 
   /**
-   * Create a new <code>ForbiddenException</code> from the provided
-   * information.
+   * Create a new {@code ForbiddenException} from the provided information.
    *
    * @param scimError     The SCIM error response.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public ForbiddenException(final ErrorResponse scimError,
-                            final Throwable cause) {
+                            final Throwable cause)
+  {
     super(scimError, cause);
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ForbiddenException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ForbiddenException.java
@@ -22,9 +22,10 @@ import com.unboundid.scim2.common.messages.ErrorResponse;
 /**
  * This class represents a SCIM exception pertaining to the
  * {@code HTTP 403 FORBIDDEN} error response code. This exception type should be
- * thrown when a client attempts an operation that they are not authorized to
- * use. This error indicates that the client has insufficient access rights, or
- * that the operation is not permitted by the service provider.
+ * thrown when a client provides valid credentials, but attempts an operation
+ * that they are not authorized to use. This error indicates that the client has
+ * insufficient access rights, or that the operation is not permitted by the
+ * service provider.
  * <br><br>
  * The following is an example of a ForbiddenException presented to a SCIM
  * client.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ForbiddenException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ForbiddenException.java
@@ -17,30 +17,29 @@
 
 package com.unboundid.scim2.common.exceptions;
 
-import com.unboundid.scim2.common.filters.Filter;
 import com.unboundid.scim2.common.messages.ErrorResponse;
 
 /**
  * This class represents a SCIM exception pertaining to the
  * {@code HTTP 403 FORBIDDEN} error response code. This exception type should be
- * thrown when a client attempts an operation that is not permitted or supported
- * by the SCIM service provider.
+ * thrown when a client attempts an operation that they are not authorized to
+ * use. This error indicates that the client has insufficient access rights, or
+ * that the operation is not permitted by the service provider.
  * <br><br>
  * The following is an example of a ForbiddenException presented to a SCIM
- * client. This example error response indicates that the client tried to
- * provide a SCIM {@link Filter} with a disallowed filter type.
+ * client.
  * <pre>
  *   {
  *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
  *     "status": "403",
- *     "detail": "The provided filter type is not supported."
+ *     "detail": "You do not have access to this resource."
  *   }
  * </pre>
  *
  * The ForbiddenException in the above example can be created with the following
  * Java code:
  * <pre>
- *   throw new ForbiddenException("The provided filter type is not supported.");
+ *   throw new ForbiddenException("You do not have access to this resource.");
  * </pre>
  *
  * This exception type generally does not have a {@code scimType} value.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/MethodNotAllowedException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/MethodNotAllowedException.java
@@ -20,31 +20,60 @@ package com.unboundid.scim2.common.exceptions;
 import com.unboundid.scim2.common.messages.ErrorResponse;
 
 /**
- * Indicates that the HTTP method requested is not allowed for the
- * requested resource.
+ * This class represents a SCIM exception pertaining to the
+ * {@code HTTP 405 METHOD NOT ALLOWED} error response code. This exception type
+ * should be thrown when a client sends a request to a valid endpoint, but
+ * provides an unsupported REST method (e.g., {@code GET}, {@code POST}).
+ * <br><br>
+ * The following is an example of a MethodNotAllowedException as seen by a SCIM
+ * client.
+ * <pre>
+ *   {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
+ *     "status": "405",
+ *     "detail": "The /.search endpoint only supports POST requests."
+ *   }
+ * </pre>
  *
- * This exception corresponds to HTTP response code 405 METHOD NOT ALLOWED.
+ * The MethodNotAllowedException in the above example can be created with the
+ * following Java code:
+ * <pre>
+ *   throw new MethodNotAllowedException(
+ *           "The /.search endpoint only supports POST requests.");
+ * </pre>
+ *
+ * This exception type generally does not have a {@code scimType} value.
  */
 public class MethodNotAllowedException extends ScimException
 {
-
+  private static final int METHOD_NOT_ALLOWED_CODE = 405;
 
 
   /**
-   * Create a new <code>MethodNotAllowedException</code> from the provided
+   * Create a new {@code MethodNotAllowedException} from the provided
+   * information.
+   *
+   * @param errorMessage  The error message for this SCIM exception.
+   */
+  public MethodNotAllowedException(final String errorMessage)
+  {
+    super(METHOD_NOT_ALLOWED_CODE, errorMessage);
+  }
+
+
+  /**
+   * Create a new {@code MethodNotAllowedException} from the provided
    * information.
    *
    * @param scimError     The SCIM error response.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public MethodNotAllowedException(final ErrorResponse scimError,
-                            final Throwable cause) {
+                            final Throwable cause)
+  {
     super(scimError, cause);
   }
-
-
-
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/NotImplementedException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/NotImplementedException.java
@@ -20,52 +20,74 @@ package com.unboundid.scim2.common.exceptions;
 import com.unboundid.scim2.common.messages.ErrorResponse;
 
 /**
- * Signals the service provider does nto support the request operation;
- * for example, PATCH.
+ * This class represents a SCIM exception pertaining to the
+ * {@code HTTP 501 NOT IMPLEMENTED} error response code. This exception type
+ * should be thrown when a client attempts to perform an operation that the
+ * service provider does not support, such as attempting a PATCH operation. This
+ * exception can also be used if a client accesses an endpoint that is not
+ * supported or defined.
+ * <br><br>
+ * The following is an example of a NotImplementedException as seen by a SCIM
+ * client. This example error response indicates that the client tried to access
+ * an endpoint that was not supported.
+ * <pre>
+ *   {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
+ *     "status": "501",
+ *     "detail": "The requested endpoint is not supported."
+ *   }
+ * </pre>
  *
- * This exception corresponds to HTTP response code 501 NOT IMPLEMENTED.
+ * The NotImplementedException in the above example can be created with the
+ * following Java code:
+ * <pre>
+ *   throw new NotImplementedException("The requested endpoint is not supported.");
+ * </pre>
+ *
+ * This exception type generally does not have a {@code scimType} value.
  */
 public class NotImplementedException extends ScimException
 {
   /**
-   * Create a new <code>NotImplementedException</code> from the provided
-   * information.
+   * Create a new {@code NotImplementedException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    */
-  public NotImplementedException(final String errorMessage) {
+  public NotImplementedException(final String errorMessage)
+  {
     super(501, null, errorMessage);
   }
 
   /**
-   * Create a new <code>NotImplementedException</code> from the provided
-   * information.
+   * Create a new {@code NotImplementedException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
-   * @param scimType      The SCIM detailed error keyword.
+   * @param scimType      The SCIM detailed error keyword. This should generally
+   *                      be {@code null} for NotImplementedExceptions.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public NotImplementedException(final String errorMessage,
                                  final String scimType,
-                                 final Throwable cause) {
+                                 final Throwable cause)
+  {
     super(501, scimType, errorMessage, cause);
   }
 
   /**
-   * Create a new <code>NotImplementedException</code> from the provided
-   * information.
+   * Create a new {@code NotImplementedException} from the provided information.
    *
    * @param scimError     The SCIM error response.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public NotImplementedException(final ErrorResponse scimError,
-                                 final Throwable cause) {
+                                 final Throwable cause)
+  {
     super(scimError, cause);
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/NotModifiedException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/NotModifiedException.java
@@ -18,78 +18,96 @@
 package com.unboundid.scim2.common.exceptions;
 
 import com.unboundid.scim2.common.messages.ErrorResponse;
+import com.unboundid.scim2.common.types.ETagConfig;
 
 /**
- * Signals the Resource has not changed on the server since last retrieved
+ * This class represents a SCIM exception pertaining to the
+ * {@code HTTP 304 NOT MODIFIED} error response code. This exception class is
+ * related to the use of SCIM ETags, which are discussed in
+ * {@link ETagConfig}. Note that while this class constructs a JSON response
+ * body like other implementations of {@link ScimException}, it is expected that
+ * a SCIM service provider returns an empty JSON body when returning this error
+ * code.
+ * <br><br>
+ * If SCIM ETags are supported by a service provider, a client may request a
+ * resource only if it has been modified. To perform this, a client must issue
+ * a {@code GET} request with an {@code If-None-Match} HTTP header that includes
+ * the ETag. If the current resource's {@code meta.version} field matches the
+ * ETag provided by the client, then the service provider should return a
+ * NotModifiedException if this is not expected.
+ * <br><br>
+ * A NotModifiedException can be created with the following Java code:
+ * <pre>
+ *   throw new NotModifiedException("The resource has not been modified.");
+ * </pre>
  *
- * This exception corresponds to HTTP response code
- * 304 NOT MODIFIED.
+ * This exception type generally does not have a {@code scimType} value.
  */
 public class NotModifiedException extends ScimException
 {
   private final String version;
 
   /**
-   * Create a new <code>NotModifiedException</code> from the provided
-   * information.
+   * Create a new {@code NotModifiedException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    */
-  public NotModifiedException(final String errorMessage) {
+  public NotModifiedException(final String errorMessage)
+  {
     super(304, null, errorMessage);
     version = null;
   }
 
   /**
-   * Create a new <code>NotModifiedException</code> from the provided
-   * information.
+   * Create a new {@code NotModifiedException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public NotModifiedException(final String errorMessage,
-                              final Throwable cause) {
+                              final Throwable cause)
+  {
     super(304, null, errorMessage, cause);
     version = null;
   }
 
   /**
-   * Create a new <code>NotModifiedException</code> from the provided
-   * information.
+   * Create a new {@code NotModifiedException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    * @param scimType      The SCIM detailed error keyword.
    * @param version       The current version of the Resource.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public NotModifiedException(final String errorMessage,
                               final String scimType,
                               final String version,
-                              final Throwable cause) {
+                              final Throwable cause)
+  {
     super(304, scimType, errorMessage, cause);
     this.version = version;
   }
 
   /**
-   * Create a new <code>NotModifiedException</code> from the provided
-   * information.
+   * Create a new {@code NotModifiedException} from the provided information.
    *
    * @param scimError     The SCIM error response.
    * @param version       The current version of the Resource.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public NotModifiedException(final ErrorResponse scimError,
                               final String version,
-                              final Throwable cause) {
+                              final Throwable cause)
+  {
     super(scimError, cause);
     this.version = version;
   }
@@ -100,7 +118,8 @@ public class NotModifiedException extends ScimException
    *
    * @return The current version of the Resource.
    */
-  public String getVersion() {
+  public String getVersion()
+  {
     return version;
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/PreconditionFailedException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/PreconditionFailedException.java
@@ -18,79 +18,104 @@
 package com.unboundid.scim2.common.exceptions;
 
 import com.unboundid.scim2.common.messages.ErrorResponse;
+import com.unboundid.scim2.common.types.ETagConfig;
 
 /**
- * Signals server failed to update as Resource changed on the server since last
- * retrieved
+ * This class represents a SCIM exception pertaining to the
+ * {@code HTTP 412 PRECONDITION FAILED} error response code. This exception type
+ * should be thrown when a client tries to update a resource and provides an
+ * outdated SCIM ETag, indicating that the resource has changed since the last
+ * time they viewed it. For more information on SCIM ETags, see the class-level
+ * documentation of {@link ETagConfig}.
+ * <br><br>
+ * The following is an example of a PreconditionFailedException as seen by a
+ * SCIM client.
+ * <pre>
+ *   {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
+ *     "status": "412",
+ *     "detail": "Failed to update. The resource changed on the server."
+ *   }
+ * </pre>
  *
- * This exception corresponds to HTTP response code
- * 412 PRECONDITION FAILED.
+ * The PreconditionFailedException in the above example can be created with the
+ * following Java code:
+ * <pre>
+ *   throw new PreconditionFailedException(
+ *          "Failed to update. The resource changed on the server.");
+ * </pre>
+ *
+ * This exception type generally does not have a {@code scimType} value.
  */
 public class PreconditionFailedException extends ScimException
 {
   private final String version;
 
   /**
-   * Create a new <code>PreconditionFailedException</code> from the provided
+   * Create a new {@code PreconditionFailedException} from the provided
    * information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    */
-  public PreconditionFailedException(final String errorMessage) {
+  public PreconditionFailedException(final String errorMessage)
+  {
     super(412, null, errorMessage);
     this.version = null;
   }
 
   /**
-   * Create a new <code>PreconditionFailedException</code> from the provided
+   * Create a new {@code PreconditionFailedException} from the provided
    * information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public PreconditionFailedException(final String errorMessage,
-                                     final Throwable cause) {
+                                     final Throwable cause)
+  {
     super(412, null, errorMessage, cause);
     this.version = null;
   }
 
   /**
-   * Create a new <code>PreconditionFailedException</code> from the provided
+   * Create a new {@code PreconditionFailedException} from the provided
    * information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    * @param scimType      The SCIM detailed error keyword.
    * @param version       The current version of the Resource.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public PreconditionFailedException(final String errorMessage,
                                      final String scimType,
                                      final String version,
-                                     final Throwable cause) {
+                                     final Throwable cause)
+  {
     super(412, scimType, errorMessage, cause);
     this.version = version;
   }
 
   /**
-   * Create a new <code>PreconditionFailedException</code> from the provided
+   * Create a new {@code PreconditionFailedException} from the provided
    * information.
    *
    * @param scimError     The SCIM error response.
    * @param version       The current version of the Resource.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public PreconditionFailedException(final ErrorResponse scimError,
                                      final String version,
-                                     final Throwable cause) {
+                                     final Throwable cause)
+  {
     super(scimError, cause);
     this.version = version;
   }
@@ -100,7 +125,8 @@ public class PreconditionFailedException extends ScimException
    *
    * @return The current version of the Resource.
    */
-  public String getVersion() {
+  public String getVersion()
+  {
     return version;
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ResourceConflictException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ResourceConflictException.java
@@ -18,55 +18,125 @@
 package com.unboundid.scim2.common.exceptions;
 
 import com.unboundid.scim2.common.messages.ErrorResponse;
+import com.unboundid.scim2.common.types.ETagConfig;
 
 /**
- * Signals the specified version number does not match the resource's latest
- * version number or a Service Provider refused to create a new,
- * duplicate resource.
+ * This class represents a SCIM exception pertaining to the
+ * {@code HTTP 409 CONFLICT} error response code. This exception type should be
+ * thrown in the following scenarios:
+ * <ul>
+ *   <li> If the client provides an invalid ETag for a resource.
+ *   <li> When a client attempts to create a new duplicate resource.
+ * </ul>
+ * For an explanation on SCIM ETags, see {@link ETagConfig}. If a client
+ * provides an ETag that does not match the current ETag of the SCIM resource,
+ * then it likely indicates that the client is referencing an outdated version
+ * of the resource. In this situation, the client should fetch the latest
+ * version of the resource and attempt the operation again.
+ * <br><br>
+ * The following is an example of a ResourceConflictException as seen by a SCIM
+ * client. This example error response indicates that the client tried to create
+ * a user whose unique username is already in use by another user.
+ * <pre>
+ *   {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
+ *     "status": "409",
+ *     "scimType": "uniqueness",
+ *     "detail": "The userName is already in use."
+ *   }
+ * </pre>
  *
- * This exception corresponds to HTTP response code 409 CONFLICT.
+ * Note that a userName uniqueness violation should include a {@code scimType}
+ * value of {@code "uniqueness"}. The ResourceConflictException in the above
+ * example can be created with the following Java code:
+ * <pre>
+ *   throw ResourceConflictException.uniqueness(
+ *           "The userName is already in use.");
+ * </pre>
+ *
+ * To create a generic ResourceConflictException that does not contain
+ * {@code scimType}, the constructors on this class may be used instead:
+ * <pre>
+ *   throw new ResourceConflictException("Detailed error message.");
+ * </pre>
  */
 public class ResourceConflictException extends ScimException
 {
   /**
-   * Create a new <code>ResourceConflictException</code> from the provided
-   * information.
+   * The SCIM detailed error keyword that indicates a uniqueness conflict.
+   */
+  public static final String UNIQUENESS = "uniqueness";
+
+  /**
+   * Create a new {@code ResourceConflictException} from the provided
+   * information. This constructor sets the {@code scimType} field to
+   * {@code null}.
    *
    * @param errorMessage  The error message for this SCIM exception.
    */
-  public ResourceConflictException(final String errorMessage) {
+  public ResourceConflictException(final String errorMessage)
+  {
     super(409, null, errorMessage);
   }
 
   /**
-   * Create a new <code>ResourceConflictException</code> from the provided
+   * Create a new {@code ResourceConflictException} from the provided
+   * information. This constructor sets the {@code scimType} field to
+   * {@code "uniqueness"}.
+   *
+   * @param errorMessage  The error message for this SCIM exception.
+   * @param scimType      The SCIM detail error keyword.
+   */
+  public ResourceConflictException(final String errorMessage,
+                                   final String scimType)
+  {
+    super(409, UNIQUENESS, errorMessage);
+  }
+
+  /**
+   * Create a new {@code ResourceConflictException} from the provided
+   * information. This constructor sets the {@code scimType} field to
+   * {@code "uniqueness"}.
+   *
+   * @param errorMessage  The error message for this SCIM exception.
+   * @return  The new {@code ResourceConflictException}.
+   */
+  public static ResourceConflictException uniqueness(final String errorMessage)
+  {
+    return new ResourceConflictException(errorMessage, UNIQUENESS);
+  }
+
+  /**
+   * Create a new {@code ResourceConflictException} from the provided
    * information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    * @param scimType      The SCIM detailed error keyword.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public ResourceConflictException(final String errorMessage,
                                    final String scimType,
-                                   final Throwable cause) {
+                                   final Throwable cause)
+  {
     super(409, scimType, errorMessage, cause);
   }
 
   /**
-   * Create a new <code>ResourceConflictException</code> from the provided
+   * Create a new {@code ResourceConflictException} from the provided
    * information.
    *
    * @param scimError     The SCIM error response.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public ResourceConflictException(final ErrorResponse scimError,
-                                   final Throwable cause) {
+                                   final Throwable cause)
+  {
     super(scimError, cause);
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ResourceNotFoundException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ResourceNotFoundException.java
@@ -20,51 +20,74 @@ package com.unboundid.scim2.common.exceptions;
 import com.unboundid.scim2.common.messages.ErrorResponse;
 
 /**
- * Signals the specified resource; for example, User, does not exist.
+ * This class represents a SCIM exception pertaining to the
+ * {@code HTTP 404 NOT FOUND} error response code. This exception type should be
+ * thrown when a client attempts to access a resource or an endpoint that does
+ * not exist.
+ * <br><br>
+ * The following is an example of a ResourceNotFoundException presented to a
+ * SCIM client. This example error response indicates that the client referenced
+ * a SCIM resource that does not exist.
+ * <pre>
+ *   {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
+ *     "status": "404",
+ *     "detail": "The requested resource was not found."
+ *   }
+ * </pre>
  *
- * This exception corresponds to HTTP response code 404 NOT FOUND.
+ * The ResourceNotFoundException in the above example can be created with the
+ * following Java code:
+ * <pre>
+ *   throw new ResourceNotFoundException("The requested resource was not found.");
+ * </pre>
+ *
+ * This exception type generally does not have a {@code scimType} value.
  */
 public class ResourceNotFoundException extends ScimException
 {
   /**
-   * Create a new <code>ResourceNotFoundException</code> from the provided
+   * Create a new {@code ResourceNotFoundException} from the provided
    * information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    */
-  public ResourceNotFoundException(final String errorMessage) {
+  public ResourceNotFoundException(final String errorMessage)
+  {
     super(404, null, errorMessage);
   }
 
   /**
-   * Create a new <code>ResourceNotFoundException</code> from the provided
+   * Create a new {@code ResourceNotFoundException} from the provided
    * information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    * @param scimType      The SCIM detailed error keyword.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public ResourceNotFoundException(final String errorMessage,
                                    final String scimType,
-                                   final Throwable cause) {
+                                   final Throwable cause)
+  {
     super(404, scimType, errorMessage, cause);
   }
 
   /**
-   * Create a new <code>ResourceNotFoundException</code> from the provided
+   * Create a new {@code ResourceNotFoundException} from the provided
    * information.
    *
    * @param scimError     The SCIM error response.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public ResourceNotFoundException(final ErrorResponse scimError,
-                                   final Throwable cause) {
+                                   final Throwable cause)
+  {
     super(scimError, cause);
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ServerErrorException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ServerErrorException.java
@@ -20,51 +20,69 @@ package com.unboundid.scim2.common.exceptions;
 import com.unboundid.scim2.common.messages.ErrorResponse;
 
 /**
- * Signals an internal error from the service provider.
+ * This class represents a SCIM exception pertaining to the
+ * {@code HTTP 500 INTERNAL SERVER ERROR} error response code. This exception
+ * type should be thrown when a SCIM service provider encounters an unexpected
+ * error.
+ * <br><br>
+ * The following is an example of a ServerErrorException as seen by a SCIM client.
+ * <pre>
+ *   {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
+ *     "status": "500",
+ *     "detail": "An unexpected error occurred."
+ *   }
+ * </pre>
  *
- * This exception corresponds to HTTP response code 500 INTERNAL SERVER ERROR.
+ * The ServerErrorException in the above example can be created with the
+ * following Java code:
+ * <pre>
+ *   throw new ServerErrorException("An unexpected error occurred.");
+ * </pre>
+ *
+ * This exception type generally does not have a {@code scimType} value.
  */
 public class ServerErrorException extends ScimException
 {
   /**
-   * Create a new <code>ServerErrorException</code> from the provided
-   * information.
+   * Create a new {@code ServerErrorException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    */
-  public ServerErrorException(final String errorMessage) {
+  public ServerErrorException(final String errorMessage)
+  {
     super(500, null, errorMessage);
   }
 
   /**
-   * Create a new <code>ServerErrorException</code> from the provided
-   * information.
+   * Create a new {@code ServerErrorException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    * @param scimType      The SCIM detailed error keyword.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public ServerErrorException(final String errorMessage,
                               final String scimType,
-                              final Throwable cause) {
+                              final Throwable cause)
+  {
     super(500, scimType, errorMessage, cause);
   }
 
   /**
-   * Create a new <code>ServerErrorException</code> from the provided
-   * information.
+   * Create a new {@code ServerErrorException} from the provided information.
    *
    * @param scimError     The SCIM error response.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public ServerErrorException(final ErrorResponse scimError,
-                              final Throwable cause) {
+                              final Throwable cause)
+  {
     super(scimError, cause);
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/UnauthorizedException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/UnauthorizedException.java
@@ -22,10 +22,9 @@ import com.unboundid.scim2.common.messages.ErrorResponse;
 /**
  * This class represents a SCIM exception pertaining to the
  * {@code HTTP 401 UNAUTHORIZED} error response code. This exception type should
- * be thrown when a client attempts to access a resource or endpoint when they
- * do not have the appropriate authorization or access rights to do so. This
- * error most commonly occurs when a client does not have a valid bearer token
- * for their SCIM request.
+ * be thrown when a client provides an invalid or missing authorization header
+ * in the request. This error most commonly occurs when a client does not have a
+ * valid bearer token for their SCIM request.
  * <br><br>
  * The following is an example of an UnauthorizedException presented to a SCIM
  * client. This example error response indicates that the client request was

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/UnauthorizedException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/UnauthorizedException.java
@@ -20,51 +20,74 @@ package com.unboundid.scim2.common.exceptions;
 import com.unboundid.scim2.common.messages.ErrorResponse;
 
 /**
- * Signals an authorization failure from the service provider.
+ * This class represents a SCIM exception pertaining to the
+ * {@code HTTP 401 UNAUTHORIZED} error response code. This exception type should
+ * be thrown when a client attempts to access a resource or endpoint when they
+ * do not have the appropriate authorization or access rights to do so. This
+ * error most commonly occurs when a client does not have a valid bearer token
+ * for their SCIM request.
+ * <br><br>
+ * The following is an example of an UnauthorizedException presented to a SCIM
+ * client. This example error response indicates that the client request was
+ * denied due to insufficient access rights.
+ * <pre>
+ *   {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
+ *     "status": "401",
+ *     "detail": "The client is not authorized to perform the operation."
+ *   }
+ * </pre>
  *
- * This exception corresponds to HTTP response code 401 UNAUTHORIZED.
+ * The UnauthorizedException in the above example can be created with the
+ * following Java code:
+ * <pre>
+ *   throw new UnauthorizedException(
+ *           "The client is not authorized to perform the operation.");
+ * </pre>
+ *
+ * This exception type generally does not have a {@code scimType} value.
  */
 public class UnauthorizedException extends ScimException
 {
   /**
-   * Create a new <code>UnauthorizedException</code> from the provided
-   * information.
+   * Create a new {@code UnauthorizedException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    */
-  public UnauthorizedException(final String errorMessage) {
+  public UnauthorizedException(final String errorMessage)
+  {
     super(401, null, errorMessage);
   }
 
   /**
-   * Create a new <code>UnauthorizedException</code> from the provided
-   * information.
+   * Create a new {@code UnauthorizedException} from the provided information.
    *
    * @param errorMessage  The error message for this SCIM exception.
    * @param scimType      The SCIM detailed error keyword.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public UnauthorizedException(final String errorMessage,
                                final String scimType,
-                               final Throwable cause) {
+                               final Throwable cause)
+  {
     super(401, scimType, errorMessage, cause);
   }
 
   /**
-   * Create a new <code>UnauthorizedException</code> from the provided
-   * information.
+   * Create a new {@code UnauthorizedException} from the provided information.
    *
    * @param scimError     The SCIM error response.
    * @param cause         The cause (which is saved for later retrieval by the
-   *                      {@link #getCause()} method).  (A {@code null} value
+   *                      {@link #getCause()} method). A {@code null} value
    *                      is permitted, and indicates that the cause is
-   *                      nonexistent or unknown.)
+   *                      nonexistent or unknown.
    */
   public UnauthorizedException(final ErrorResponse scimError,
-                               final Throwable cause) {
+                               final Throwable cause)
+  {
     super(scimError, cause);
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ErrorResponse.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ErrorResponse.java
@@ -21,15 +21,48 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.unboundid.scim2.common.types.AttributeDefinition;
 import com.unboundid.scim2.common.annotations.Schema;
 import com.unboundid.scim2.common.annotations.Attribute;
 import com.unboundid.scim2.common.BaseScimResource;
+import com.unboundid.scim2.common.exceptions.BadRequestException;
+import com.unboundid.scim2.common.exceptions.ResourceConflictException;
+import com.unboundid.scim2.common.exceptions.ScimException;
+import com.unboundid.scim2.common.types.AttributeDefinition;
 import com.unboundid.scim2.common.utils.StatusDeserializer;
 import com.unboundid.scim2.common.utils.StatusSerializer;
 
 /**
- * This object is returned whenever by SCIM when an error occurs.
+ * This class represents a SCIM API error response. An error response represents
+ * a JSON body with an error message from a SCIM service provider. It has a
+ * schema URI of {@code urn:ietf:params:scim:api:messages:2.0:Error}.
+ * <br><br>
+ * An error response has the following fields:
+ * <ul>
+ *   <li> {@code schemas}: A required parameter that contains the schema of the
+ *        SCIM error response object.
+ *   <li> {@code scimType}: An optional SCIM "detail error keyword"
+ *        that succinctly describes the reason for the error (e.g.,
+ *        {@code uniqueness}, {@code tooMany}). This is typically used for
+ *        {@link BadRequestException} and {@link ResourceConflictException}
+ *        errors.
+ *   <li> {@code detail}: An optional parameter containing a descriptive message
+ *        that describes the reason for the error.
+ *   <li> {@code status}: A required parameter that contains the HTTP status code
+ *        for the error (e.g., 401, 500).
+ * </ul>
+ * <br><br>
+ * An example error response is shown below:
+ * <pre>
+ *   {
+ *      "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
+ *      "scimType": "mutability",
+ *      "detail": "The 'id' attribute is read-only and cannot be modified.",
+ *      "status": "400"
+ *   }
+ * </pre>
+ *
+ * To create a SCIM error response as an exception, use the
+ * {@link ScimException} class, which contains an ErrorResponse.
  */
 @Schema(id="urn:ietf:params:scim:api:messages:2.0:Error",
     name="Error Response", description = "SCIM 2.0 Error Response")

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -49,7 +49,48 @@ import java.util.List;
 import static com.unboundid.scim2.common.utils.StaticUtils.toList;
 
 /**
- * An individual patch operation.
+ * This class represents a SCIM 2 PATCH operation. A patch operation is a
+ * component of a {@link PatchRequest}, and it represents an individual update
+ * to a SCIM resource. A patch operation must be one of the following types:
+ * <ul>
+ *   <li> add
+ *   <li> remove
+ *   <li> replace
+ * </ul>
+ *
+ * An {@code add} operation will add new attribute data. A {@code remove}
+ * operation will delete the existing value(s) on an attribute. A
+ * {@code replace} operation will overwrite any existing values of an attribute.
+ * <br><br>
+ *
+ * To create an {@code add} operation, use methods of the following form:
+ * <pre>
+ *   PatchOperation.addIntegerValues(path, 512);
+ *   PatchOperation.addStringValues(path, "Kingdom Tears");
+ *   PatchOperation.add(path, jsonNodeValue);
+ * </pre>
+ *
+ * To create a {@code remove} operation, use the following method:
+ * <pre>
+ *   PatchOperation.remove(path);
+ * </pre>
+ *
+ * To create a {@code replace} operation, use methods of the following form:
+ * <pre>
+ *   PatchOperation.replace(path, 512);
+ *   PatchOperation.replace(path, "Kingdom Tears");
+ *   PatchOperation.replace(path, true);
+ *   PatchOperation.replace(path, jsonNodeValue);
+ * </pre>
+ *
+ * To create a patch operation in an alternative way, use the {@link #create}
+ * static method. This method is useful if the operation type is not known at
+ * compile time.
+ * <pre>
+ *   PatchOperation.create(operationType, path, jsonNodeValue);
+ * </pre>
+ *
+ * @see PatchRequest
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.PROPERTY,
@@ -1595,8 +1636,9 @@ public abstract class PatchOperation
    * Create a new patch operation based on the parameters provided.
    *
    * @param opType The operation type.
-   * @param path The path targeted by this patch operation.
-   * @param value The value(s).
+   * @param path   The path targeted by this patch operation.
+   * @param value  The value(s). This field will be ignored for {@code remove}
+   *               operations.
    *
    * @return The new patch operation.
    * @throws ScimException If the path is invalid.
@@ -1612,8 +1654,9 @@ public abstract class PatchOperation
    * Create a new patch operation based on the parameters provided.
    *
    * @param opType The operation type.
-   * @param path The path targeted by this patch operation.
-   * @param value The value(s).
+   * @param path   The path targeted by this patch operation.
+   * @param value  The value(s). This field will be ignored for {@code remove}
+   *               operations.
    *
    * @return The new patch operation.
    */

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
@@ -32,7 +32,39 @@ import java.util.List;
 import static com.unboundid.scim2.common.utils.StaticUtils.toList;
 
 /**
- * Class representing a SCIM 2 patch request.
+ * This class represents a SCIM 2 PATCH request. A patch request contains a list
+ * of {@link PatchOperation} elements, where each patch operation represents a
+ * change that should be applied to a SCIM resource. The following is an example
+ * of a patch request in JSON form:
+ * <pre>
+ * {
+ *   "schemas": [
+ *     "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+ *   ],
+ *   "Operations": [
+ *     {
+ *       "op": "replace",
+ *       "path": "active",
+ *       "value": true
+ *     }
+ *   ]
+ * }
+ * </pre>
+ *
+ * This example request contains a single operation that sets the {@code active}
+ * value to {@code true}. This request can be created with the following Java
+ * code:
+ * <pre>
+ *   PatchRequest request = new PatchRequest(
+ *       PatchOperation.replace("active", true)
+ *   );
+ * </pre>
+ *
+ * All patch requests are performed atomically. RFC 7644 Section 3.5.2 states
+ * that if any operation within the operation list fails, then the resource
+ * SHALL not be updated at all.
+ *
+ * @see PatchOperation
  */
 @Schema(id="urn:ietf:params:scim:api:messages:2.0:PatchOp",
     name="Patch Operation", description = "SCIM 2.0 Patch Operation Request")

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/ETagConfig.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/ETagConfig.java
@@ -22,8 +22,39 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.unboundid.scim2.common.annotations.Attribute;
 
 /**
- * A complex type that specifies Etag configuration options.
+ * This class represents a configuration object that helps a SCIM service
+ * provider declare support for SCIM entity tags (ETags). This class is used to
+ * help assemble this field on the {@code /ServiceProviderConfig} endpoint. For
+ * more information, see {@link ServiceProviderConfigResource}.
+ * <br><br>
+ *
+ * <h2>What is an ETag?</h2>
+ * A SCIM ETag is akin to an HTTP ETag, which is a piece of metadata that
+ * represents a specific version of a resource. ETags help HTTP clients keep
+ * track of changes to resources. For example, if a resource is created, a
+ * service provider can generate a unique ETag identifier, which represents the
+ * initial version of the SCIM resource. If the resource is ever updated with
+ * new data, a new ETag corresponding to the updated resource will be generated.
+ * These ETag values can be used to determine if the resource is updated at a
+ * later time. For example, if a client creates a resource, records the ETag,
+ * and fetches the resource again at a later time, it can conclusively determine
+ * whether the resource was updated by other clients by comparing the current
+ * ETag value with the one that was previously recorded. If the ETag remains
+ * unchanged, then the resource was not updated.
+ * <br><br>
+ * If a SCIM service provider supports ETag versioning, an ETag corresponding to
+ * a resource will be specified in the {@code meta.version} attribute.
+ * <pre>
+ *   "meta": {
+ *     "resourceType": "User",
+ *     "created": "2022-10-21T18:58:07.878Z",
+ *     "lastModified": "2023-06-06T19:17:49.884Z",
+ *     "location": "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646",
+ *     "version":"W\/\"e180ee84f0671b1\""
+ *   }
+ * </pre>
  */
+@SuppressWarnings("JavadocLinkAsPlainText")
 public class ETagConfig
 {
   @Attribute(description = "Boolean value specifying whether the " +

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ApiConstants.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/ApiConstants.java
@@ -18,7 +18,8 @@
 package com.unboundid.scim2.common.utils;
 
 /**
- * Various constants used by the SCIM API.
+ * This class contains a selection of constants used by SCIM API clients and
+ * service providers.
  */
 public class ApiConstants
 {
@@ -98,4 +99,3 @@ public class ApiConstants
    */
   public static final String QUERY_PARAMETER_PAGE_SIZE = "count";
 }
-

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/CaseIgnoreObjectNode.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/CaseIgnoreObjectNode.java
@@ -60,7 +60,6 @@ public class CaseIgnoreObjectNode extends ObjectNode
   /**
    * {@inheritDoc}
    */
-  @SuppressWarnings("unchecked")
   @Override
   public ObjectNode deepCopy()
   {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/SchemaUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/SchemaUtils.java
@@ -637,7 +637,7 @@ public class SchemaUtils
   }
 
   /**
-   * Gets the id property from schema annotation.  If the the id
+   * Gets the id property from schema annotation.  If the id
    * attribute was {@code null}, a schema id is generated.
    *
    * @param schemaAnnotation the SCIM SchemaInfo annotation.


### PR DESCRIPTION
This commit further expands on documentation, primarily in the common
package. Some Javadoc code examples highlighted the need for exception
constructors that do not take in a 'scimType' for the most general
cases. New constructors for these cases have been added and referenced
in the documentation.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-47822