### PR TITLE
Fix scim2-sdk-server tests being skipped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <guava.version>32.1.2-jre</guava.version>
     <testng.version>7.5.1</testng.version>
     <assertj.version>3.24.2</assertj.version>
+    <maven.surefire.version>3.1.2</maven.surefire.version>
   </properties>
 
   <profiles>
@@ -180,7 +181,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>${maven.surefire.version}</version>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
@@ -266,6 +267,15 @@
             </property>
           </properties>
         </configuration>
+        <dependencies>
+          <!-- Explicitly declare the TestNG dependency to resolve an issue
+               where the scim2-sdk-server tests were skipped. -->
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-testng</artifactId>
+            <version>${maven.surefire.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/scim2-sdk-server/pom.xml
+++ b/scim2-sdk-server/pom.xml
@@ -216,6 +216,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.connectors</groupId>
       <artifactId>jersey-apache-connector</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Added some test dependencies that were removed in a previous commit, as they were incorrectly determined to be unused. These changes alone were insufficient because the newest version of the Maven Surefire Plugin was not correctly invoking the TestNG framework. To work around this issue, the plugin has been explicitly configured to use TestNG.