### PR TITLE
Support replace ops with an empty array value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## v3.0.1 - TBD
-Placeholder for the next release.
+Resolved an issue with replace operations that set the `value` field to an empty array. When these
+operations are applied, the SCIM SDK now clears all matching values of the targeted multi-valued
+attribute. If the `path` of the replace operation does not have a filter, then the multi-valued
+attribute will be deleted from the resource.
 
 ## v3.0.0 - 2023-Oct-03
 Removed support for Java 8. The UnboundID SCIM 2 SDK now requires Java 11 or a later release.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -594,8 +594,8 @@ public abstract class PatchOperation
     @Override
     public void apply(final ObjectNode node) throws ScimException
     {
-      JsonUtils.replaceValue(getPath() == null ? Path.root() :
-          getPath(), node, value);
+      Path path = (getPath() == null) ? Path.root() : getPath();
+      JsonUtils.replaceValue(path, node, value);
       addMissingSchemaUrns(node);
     }
 


### PR DESCRIPTION
This commit resolves an issue with replace operations that contained an empty array as the value. If a filter is not included in the path, the SDK now treats this as a request to delete all values of the targeted multi-valued attribute. If a filter is included, then all attribute values that match the filter will be removed.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-48754
Resolves #209 
