### PR TITLE
Eliminate warnings.

### DIFF
--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
@@ -50,6 +50,7 @@ public class Parser
   {
     @NotNull
     private final String string;
+
     private int pos;
     private int mark;
 
@@ -122,12 +123,23 @@ public class Parser
 
     /**
      * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException   If {@code n} is negative.
      */
     @Override
-    public long skip(final long n)
+    public long skip(final long n) throws IllegalArgumentException
     {
+      if (n < 0L)
+      {
+        throw new IllegalArgumentException(
+            "Attempted to skip a negative number of characters.");
+      }
       long chars = Math.min(string.length() - pos, n);
-      pos += chars;
+
+      // The left side of Math.min() is an integer, and 'chars' will always be
+      // non-negative, so 'chars' can always be represented as an int.
+      pos += (int) chars;
+
       return chars;
     }
 

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StaticUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StaticUtils.java
@@ -28,16 +28,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * This class provides a number of static utility functions.
  */
 public final class StaticUtils
 {
-  @NotNull
-  private static final Pattern SEPARATOR = Pattern.compile("\\s*,\\s*");
-
   /**
    * Prevent this class from being instantiated.
    */
@@ -240,7 +236,13 @@ public final class StaticUtils
   @NotNull
   public static String[] splitCommaSeparatedString(@NotNull final String str)
   {
-    return SEPARATOR.split(str.trim());
+    String[] separatedArray = str.split(",");
+    for (int i = 0; i < separatedArray.length; i++)
+    {
+      separatedArray[i] = separatedArray[i].trim();
+    }
+
+    return separatedArray;
   }
 
 

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/StaticUtilsTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/StaticUtilsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2024 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+
 package com.unboundid.scim2.common;
 
 import org.testng.annotations.Test;
@@ -8,6 +25,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class StaticUtilsTest
 {
+  /**
+   * Unit test for the {@code splitCommaSeparatedString()} method.
+   */
   @Test
   public void testSplitCommaSeparatedString()
   {

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/StaticUtilsTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/StaticUtilsTest.java
@@ -31,7 +31,7 @@ public class StaticUtilsTest
   @Test
   public void testSplitCommaSeparatedString()
   {
-    // Ensure that the @NotNull parameter is not permitted.
+    // Ensure the validity of the @NotNull parameter.
     assertThatThrownBy(() -> splitCommaSeparatedString(null))
         .isInstanceOf(NullPointerException.class);
 

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/StaticUtilsTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/StaticUtilsTest.java
@@ -1,0 +1,69 @@
+package com.unboundid.scim2.common;
+
+import org.testng.annotations.Test;
+
+import static com.unboundid.scim2.common.utils.StaticUtils.splitCommaSeparatedString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class StaticUtilsTest
+{
+  @Test
+  public void testSplitCommaSeparatedString()
+  {
+    // Ensure that the @NotNull parameter is not permitted.
+    assertThatThrownBy(() -> splitCommaSeparatedString(null))
+        .isInstanceOf(NullPointerException.class);
+
+    assertThat(splitCommaSeparatedString("value"))
+        .containsExactly("value");
+
+    assertThat(splitCommaSeparatedString(" value"))
+        .containsExactly("value");
+
+    assertThat(splitCommaSeparatedString("value "))
+        .containsExactly("value");
+
+    assertThat(splitCommaSeparatedString(" value "))
+        .containsExactly("value");
+
+    assertThat(splitCommaSeparatedString("  value  "))
+        .containsExactly("value");
+
+    assertThat(splitCommaSeparatedString("\tvalue\t"))
+        .containsExactly("value");
+
+    assertThat(splitCommaSeparatedString("value1,value2"))
+        .containsExactly("value1", "value2");
+
+    assertThat(splitCommaSeparatedString(" value1,value2"))
+        .containsExactly("value1", "value2");
+
+    assertThat(splitCommaSeparatedString("value1 ,value2"))
+        .containsExactly("value1", "value2");
+
+    assertThat(splitCommaSeparatedString("value1, value2"))
+        .containsExactly("value1", "value2");
+
+    assertThat(splitCommaSeparatedString("value1,value2 "))
+        .containsExactly("value1", "value2");
+
+    assertThat(splitCommaSeparatedString(" value1 , value2 "))
+        .containsExactly("value1", "value2");
+
+    assertThat(splitCommaSeparatedString("value1 , value2 , value3"))
+        .containsExactly("value1", "value2", "value3");
+
+    assertThat(splitCommaSeparatedString("   value1 , value2 , value3  "))
+        .containsExactly("value1", "value2", "value3");
+
+    assertThat(splitCommaSeparatedString(","))
+        .isEmpty();
+
+    assertThat(splitCommaSeparatedString(",,"))
+        .isEmpty();
+
+    assertThat(splitCommaSeparatedString("   value1 ,    , value3  "))
+        .containsExactly("value1", "", "value3");
+  }
+}


### PR DESCRIPTION
Updated some SDK code to avoid warning messages from code scanning tools. This includes a change to the StringReader#skip method, which now explicitly checks for negative values.

JiraIssue: DS-48860