### PR TITLE
Support ADD patch ops targeting existing values 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 Fixed an issue where `AndFilter.equals()` and `OrFilter.equals()` could incorrectly evaluate to
 true.
 
+Updated Jackson dependencies to 2.17.2.
+
 ## v3.1.0 - 2024-Jun-25
 Updated all classes within the UnboundID SCIM 2 SDK to utilize `@Nullable` and `@NotNull`
 annotations for all non-primitive input parameters, member variables, and return values. These

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,39 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## v3.1.1 - TBD
+## v3.2.0 - TBD
 Fixed an issue where `AndFilter.equals()` and `OrFilter.equals()` could incorrectly evaluate to
 true.
 
 Updated Jackson dependencies to 2.17.2.
+
+Added a property that allows ADD patch operations with value filters to target an existing value.
+For example, consider the following patch request. This request aims to add a `display` field on a
+user's work email.
+```json
+{
+  "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+  "Operations": [
+    {
+      "op": "add",
+      "path": "emails[type eq \"work\"].display",
+      "value": "apollo.j@example.com"
+    }
+  ]
+}
+```
+When the new behavior is configured, this operation will search the resource for an existing "work"
+email and add a `"display": "apollo.j@example.com"` field to that email. This behavior allows for
+better integration with SCIM provisioners that send individual requests such as
+`emails[type eq "work"].display` followed by `emails[type eq "work"].value`, which are intended to
+target the same email. To use this behavior, toggle the property by adding the following Java code
+in your application:
+```
+PatchOperation.APPEND_NEW_PATCH_VALUES_PROPERTY = false;
+```
+The default value of `APPEND_NEW_PATCH_VALUES_PROPERTY` is `true`, which will always add a new
+value (i.e., email) on the multi-valued attribute instead of updating an existing value/email.
+This matches the behavior of the SDK since the 3.0.0 release.
 
 ## v3.1.0 - 2024-Jun-25
 Updated all classes within the UnboundID SCIM 2 SDK to utilize `@Nullable` and `@NotNull`

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.unboundid.product.scim2</groupId>
   <artifactId>scim2-parent</artifactId>
-  <version>3.1.1-SNAPSHOT</version>
+  <version>3.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>UnboundID SCIM2 SDK Parent</name>
   <description>

--- a/scim2-assembly/pom.xml
+++ b/scim2-assembly/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-assembly</artifactId>
   <packaging>pom</packaging>

--- a/scim2-sdk-client/pom.xml
+++ b/scim2-sdk-client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>3.1.1-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>scim2-sdk-client</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-common/pom.xml
+++ b/scim2-sdk-common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>3.1.1-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>scim2-sdk-common</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-server/pom.xml
+++ b/scim2-sdk-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-sdk-server</artifactId>
   <packaging>jar</packaging>

--- a/scim2-ubid-extensions/pom.xml
+++ b/scim2-ubid-extensions/pom.xml
@@ -19,7 +19,7 @@
   <parent>
       <artifactId>scim2-parent</artifactId>
       <groupId>com.unboundid.product.scim2</groupId>
-      <version>3.1.1-SNAPSHOT</version>
+      <version>3.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-ubid-extensions</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
In the 3.0.0 release, we implemented support for ADD patch operations
with a value filter. The SDK would always append a new value to the
array, since it is technically an "add". However, this does not play
well with SCIM provisioners that send multiple individual updates,
since these intend to target the same value within a multi-valued
attribute, such as a user's work email. The intention is to add a new
value to the field that matches the path filter (e.g.,
"type eq \"work\"").

The new behavior is available via an opt-in setting in a static boolean
variable, PatchOperation.APPEND_NEW_PATCH_VALUES_PROPERTY. To opt into
this setting, set the value of this variable to false.

As a result of this change, the version of the SCIM SDK has been updated
to 3.2.0-SNAPSHOT.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-49194
Resolves #213