### PR TITLE
Apply whitespace formatting changes.

### DIFF
--- a/config/scim2-parent-checkstyle.xml
+++ b/config/scim2-parent-checkstyle.xml
@@ -181,6 +181,14 @@
     </module>
 
 
+    <!-- Ensure that there are spaces after fields such as 'if'. -->
+    <module name="WhitespaceAfter">
+      <property name="tokens"
+                value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE"/>
+    </module>
+
+
     <!-- Ensure that all long constants are followed by a capital L. -->
     <module name="UpperEll" />
 

--- a/config/scim2-parent-unit-checkstyle.xml
+++ b/config/scim2-parent-unit-checkstyle.xml
@@ -164,6 +164,14 @@
     </module>
 
 
+    <!-- Ensure that there are spaces after fields such as 'if'. -->
+    <module name="WhitespaceAfter">
+      <property name="tokens"
+                value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE"/>
+    </module>
+
+
     <!-- Ensure that all long constants are followed by a capital L. -->
     <module name="UpperEll" />
   </module>

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimService.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/ScimService.java
@@ -97,7 +97,7 @@ public class ScimService implements ScimInterface
   public ServiceProviderConfigResource getServiceProviderConfig()
       throws ScimException
   {
-    if(serviceProviderConfig == null)
+    if (serviceProviderConfig == null)
     {
       serviceProviderConfig = retrieve(
           baseTarget.path(SERVICE_PROVIDER_CONFIG_ENDPOINT).getUri(),
@@ -428,7 +428,7 @@ public class ScimService implements ScimInterface
   {
     ModifyRequestBuilder.Typed requestBuilder = new ModifyRequestBuilder.Typed(
         baseTarget.path(endpoint).path(id));
-    for(PatchOperation op : patchRequest.getOperations())
+    for (PatchOperation op : patchRequest.getOperations())
     {
       requestBuilder.addOperation(op);
     }
@@ -489,7 +489,7 @@ public class ScimService implements ScimInterface
         new ModifyRequestBuilder.Generic<T>(resolveWebTarget(
             checkAndGetLocation(resource)), resource);
 
-    for(PatchOperation op : patchRequest.getOperations())
+    for (PatchOperation op : patchRequest.getOperations())
     {
       requestBuilder.addOperation(op);
     }
@@ -577,7 +577,7 @@ public class ScimService implements ScimInterface
   private WebTarget resolveWebTarget(@NotNull final URI url)
   {
     URI relativePath;
-    if(url.isAbsolute())
+    if (url.isAbsolute())
     {
       relativePath = baseTarget.getUri().relativize(url);
       if (relativePath.equals(url))
@@ -609,7 +609,7 @@ public class ScimService implements ScimInterface
       throws IllegalArgumentException
   {
     Meta meta = resource.getMeta();
-    if(meta == null || meta.getLocation() == null)
+    if (meta == null || meta.getLocation() == null)
     {
       throw new IllegalArgumentException(
           "Resource URI must be specified by meta.location");

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/CreateRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/CreateRequestBuilder.java
@@ -78,7 +78,7 @@ public final class CreateRequestBuilder<T extends ScimResource>
         Entity.entity(resource, getContentType()));
     try
     {
-      if(response.getStatusInfo().getFamily() ==
+      if (response.getStatusInfo().getFamily() ==
           Response.Status.Family.SUCCESSFUL)
       {
         return response.readEntity(cls);

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/DeleteRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/DeleteRequestBuilder.java
@@ -67,7 +67,7 @@ public class DeleteRequestBuilder extends RequestBuilder<DeleteRequestBuilder>
   Invocation.Builder buildRequest()
   {
     Invocation.Builder request = super.buildRequest();
-    if(version != null)
+    if (version != null)
     {
       request.header(HttpHeaders.IF_MATCH, version);
     }
@@ -85,7 +85,7 @@ public class DeleteRequestBuilder extends RequestBuilder<DeleteRequestBuilder>
     Response response = buildRequest().delete();
     try
     {
-      if(response.getStatusInfo().getFamily() !=
+      if (response.getStatusInfo().getFamily() !=
           Response.Status.Family.SUCCESSFUL)
       {
         throw toScimException(response);

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ListResponseBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ListResponseBuilder.java
@@ -99,7 +99,7 @@ public class ListResponseBuilder<T>
   @NotNull
   public ListResponse<T> build()
   {
-    final Map<String,Object> properties = new LinkedHashMap<String,Object>();
+    final Map<String, Object> properties = new LinkedHashMap<String, Object>();
     properties.put("totalResults", totalResults == null ?
       resources.size() : totalResults);
     properties.put("resources", resources);

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ModifyRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ModifyRequestBuilder.java
@@ -75,7 +75,7 @@ public abstract class ModifyRequestBuilder<T extends ModifyRequestBuilder<T>>
   Invocation.Builder buildRequest()
   {
     Invocation.Builder request = super.buildRequest();
-    if(version != null)
+    if (version != null)
     {
       request.header(HttpHeaders.IF_MATCH, version);
     }
@@ -213,7 +213,7 @@ public abstract class ModifyRequestBuilder<T extends ModifyRequestBuilder<T>>
           Entity.entity(patchRequest, getContentType()));
       try
       {
-        if(response.getStatusInfo().getFamily() ==
+        if (response.getStatusInfo().getFamily() ==
             Response.Status.Family.SUCCESSFUL)
         {
           return response.readEntity(cls);

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ReplaceRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ReplaceRequestBuilder.java
@@ -75,7 +75,7 @@ public final class ReplaceRequestBuilder<T extends ScimResource>
   Invocation.Builder buildRequest()
   {
     Invocation.Builder request = super.buildRequest();
-    if(version != null)
+    if (version != null)
     {
       request.header(HttpHeaders.IF_MATCH, version);
     }
@@ -111,7 +111,7 @@ public final class ReplaceRequestBuilder<T extends ScimResource>
         Entity.entity(resource, getContentType()));
     try
     {
-      if(response.getStatusInfo().getFamily() ==
+      if (response.getStatusInfo().getFamily() ==
           Response.Status.Family.SUCCESSFUL)
       {
         return response.readEntity(cls);

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RequestBuilder.java
@@ -125,13 +125,13 @@ public class RequestBuilder<T extends RequestBuilder>
   public T accept(@NotNull final String... acceptStrings)
   {
     this.accept.clear();
-    if((acceptStrings == null) || (acceptStrings.length == 0))
+    if ((acceptStrings == null) || (acceptStrings.length == 0))
     {
       throw new IllegalArgumentException(
           "Accepted media types must not be null or empty");
     }
 
-    for(String acceptString : acceptStrings)
+    for (String acceptString : acceptStrings)
     {
       accept.add(acceptString);
     }
@@ -167,7 +167,7 @@ public class RequestBuilder<T extends RequestBuilder>
   static String getResourceVersion(@NotNull final ScimResource resource)
       throws IllegalArgumentException
   {
-    if(resource == null || resource.getMeta() == null ||
+    if (resource == null || resource.getMeta() == null ||
         resource.getMeta().getVersion() == null)
     {
       throw new IllegalArgumentException(
@@ -197,7 +197,7 @@ public class RequestBuilder<T extends RequestBuilder>
 
       return exception;
     }
-    catch(ProcessingException ex)
+    catch (ProcessingException ex)
     {
       // The exception message likely contains unwanted details about why the
       // server failed to process the response, instead of the actual SCIM
@@ -229,7 +229,7 @@ public class RequestBuilder<T extends RequestBuilder>
   @NotNull
   WebTarget buildTarget()
   {
-    for(Map.Entry<String, List<Object>> queryParam : queryParams.entrySet())
+    for (Map.Entry<String, List<Object>> queryParam : queryParams.entrySet())
     {
       target = target.queryParam(queryParam.getKey(),
                                  queryParam.getValue().toArray());
@@ -268,7 +268,7 @@ public class RequestBuilder<T extends RequestBuilder>
   {
     Invocation.Builder builder =
         buildTarget().request(accept.toArray(new String[accept.size()]));
-    for(Map.Entry<String, List<Object>> header : headers.entrySet())
+    for (Map.Entry<String, List<Object>> header : headers.entrySet())
     {
       builder = builder.header(header.getKey(),
                                StaticUtils.listToString(header.getValue(),

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ResourceReturningRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ResourceReturningRequestBuilder.java
@@ -60,9 +60,9 @@ public abstract class ResourceReturningRequestBuilder
   @NotNull
   WebTarget buildTarget()
   {
-    if(attributes != null && attributes.size() > 0)
+    if (attributes != null && attributes.size() > 0)
     {
-      if(!excluded)
+      if (!excluded)
       {
         return super.buildTarget().queryParam(
             ApiConstants.QUERY_PARAMETER_ATTRIBUTES,

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RetrieveRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RetrieveRequestBuilder.java
@@ -59,7 +59,7 @@ public abstract class RetrieveRequestBuilder
   Invocation.Builder buildRequest()
   {
     Invocation.Builder request = super.buildRequest();
-    if(version != null)
+    if (version != null)
     {
       request.header(HttpHeaders.IF_NONE_MATCH, version);
     }
@@ -133,7 +133,7 @@ public abstract class RetrieveRequestBuilder
       Response response = buildRequest().get();
       try
       {
-        if(response.getStatusInfo().getFamily() ==
+        if (response.getStatusInfo().getFamily() ==
             Response.Status.Family.SUCCESSFUL)
         {
           return response.readEntity(cls);
@@ -197,7 +197,7 @@ public abstract class RetrieveRequestBuilder
       Response response = buildRequest().get();
       try
       {
-        if(response.getStatusInfo().getFamily() ==
+        if (response.getStatusInfo().getFamily() ==
             Response.Status.Family.SUCCESSFUL)
         {
           return response.readEntity(cls);

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/SearchRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/SearchRequestBuilder.java
@@ -138,17 +138,17 @@ public final class SearchRequestBuilder
   WebTarget buildTarget()
   {
     WebTarget target = super.buildTarget();
-    if(filter != null)
+    if (filter != null)
     {
       target = target.queryParam(QUERY_PARAMETER_FILTER, filter);
     }
-    if(sortBy != null && sortOrder != null)
+    if (sortBy != null && sortOrder != null)
     {
       target = target.queryParam(QUERY_PARAMETER_SORT_BY, sortBy);
       target = target.queryParam(QUERY_PARAMETER_SORT_ORDER,
           sortOrder.getName());
     }
-    if(startIndex != null && count != null)
+    if (startIndex != null && count != null)
     {
       target = target.queryParam(QUERY_PARAMETER_PAGE_START_INDEX, startIndex);
       target = target.queryParam(QUERY_PARAMETER_PAGE_SIZE, count);
@@ -241,13 +241,13 @@ public final class SearchRequestBuilder
       throws ScimException
   {
     Response response;
-    if(post)
+    if (post)
     {
       Set<String> attributeSet = null;
       Set<String> excludedAttributeSet = null;
-      if(attributes != null && attributes.size() > 0)
+      if (attributes != null && attributes.size() > 0)
       {
-        if(!excluded)
+        if (!excluded)
         {
           attributeSet = attributes;
         }
@@ -331,7 +331,7 @@ public final class SearchRequestBuilder
           }
           finally
           {
-            if(inputStream != null)
+            if (inputStream != null)
             {
               inputStream.close();
             }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
@@ -216,7 +216,7 @@ public abstract class BaseScimResource
                         @NotNull final JsonNode value)
       throws ScimException
   {
-    if(SchemaUtils.isUrn(key) && value.isObject())
+    if (SchemaUtils.isUrn(key) && value.isObject())
     {
       extensionObjectNode.set(key, value);
     }
@@ -224,7 +224,7 @@ public abstract class BaseScimResource
     {
       String message = "Core attribute " + key +  " is undefined";
       Schema schemaAnnotation = this.getClass().getAnnotation(Schema.class);
-      if(schemaAnnotation != null)
+      if (schemaAnnotation != null)
       {
         message += " for schema " + schemaAnnotation.id();
       }
@@ -245,7 +245,7 @@ public abstract class BaseScimResource
     HashMap<String, Object> map =
         new HashMap<String, Object>(extensionObjectNode.size());
     Iterator<Map.Entry<String, JsonNode>> i = extensionObjectNode.fields();
-    while(i.hasNext())
+    while (i.hasNext())
     {
       Map.Entry<String, JsonNode> field = i.next();
       map.put(field.getKey(), field.getValue());
@@ -262,7 +262,7 @@ public abstract class BaseScimResource
   private void addMyUrn()
   {
     String mySchema = SchemaUtils.getSchemaUrn(this.getClass());
-    if((mySchema != null) && (!mySchema.isEmpty()))
+    if ((mySchema != null) && (!mySchema.isEmpty()))
     {
       getSchemaUrns().add(mySchema);
     }
@@ -371,7 +371,7 @@ public abstract class BaseScimResource
     {
       JsonNode extensionNode =
           extensionObjectNode.path(getSchemaUrnOrThrowException(clazz));
-      if(extensionNode.isMissingNode())
+      if (extensionNode.isMissingNode())
       {
         return null;
       }
@@ -380,7 +380,7 @@ public abstract class BaseScimResource
         return JsonUtils.nodeToValue(extensionNode, clazz);
       }
     }
-    catch(JsonProcessingException ex)
+    catch (JsonProcessingException ex)
     {
       throw new RuntimeException(ex);
     }
@@ -416,7 +416,7 @@ public abstract class BaseScimResource
   public <T> boolean removeExtension(@NotNull final Class<T> clazz)
   {
     String schemaUrn = getSchemaUrnOrThrowException(clazz);
-    if(extensionObjectNode.remove(schemaUrn) == null)
+    if (extensionObjectNode.remove(schemaUrn) == null)
     {
       return false;
     }
@@ -431,7 +431,7 @@ public abstract class BaseScimResource
   private <T> String getSchemaUrnOrThrowException(@NotNull final Class<T> clazz)
   {
     String schemaUrn = SchemaUtils.getSchemaUrn(clazz);
-    if(schemaUrn == null)
+    if (schemaUrn == null)
     {
       throw new IllegalArgumentException(
           "Unable to determine the extension class schema.");

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
@@ -123,7 +123,7 @@ public final class GenericScimResource implements ScimResource
     try
     {
       List<JsonNode> values = JsonUtils.findMatchingPaths(META, objectNode);
-      if(values.isEmpty())
+      if (values.isEmpty())
       {
         return null;
       }
@@ -163,7 +163,7 @@ public final class GenericScimResource implements ScimResource
     try
     {
       JsonNode value = JsonUtils.getValue(ID, objectNode);
-      if(value.isNull())
+      if (value.isNull())
       {
         return null;
       }
@@ -202,7 +202,7 @@ public final class GenericScimResource implements ScimResource
     try
     {
       JsonNode value = JsonUtils.getValue(SCHEMAS, objectNode);
-      if(value.isNull() || !value.isArray())
+      if (value.isNull() || !value.isArray())
       {
         return Collections.emptyList();
       }
@@ -251,7 +251,7 @@ public final class GenericScimResource implements ScimResource
     try
     {
       JsonNode value = JsonUtils.getValue(EXTERNAL_ID, objectNode);
-      if(value.isNull())
+      if (value.isNull())
       {
         return null;
       }
@@ -725,7 +725,7 @@ public final class GenericScimResource implements ScimResource
       throws ScimException
   {
     ArrayNode valuesArrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(String value : values)
+    for (String value : values)
     {
       valuesArrayNode.add(value);
     }
@@ -1226,7 +1226,7 @@ public final class GenericScimResource implements ScimResource
       throws ScimException
   {
     ArrayNode valuesArrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(Double value : values)
+    for (Double value : values)
     {
       valuesArrayNode.add(value);
     }
@@ -1578,7 +1578,7 @@ public final class GenericScimResource implements ScimResource
           throws ScimException
   {
     ArrayNode valuesArrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(Integer value : values)
+    for (Integer value : values)
     {
       valuesArrayNode.add(value);
     }
@@ -1928,7 +1928,7 @@ public final class GenericScimResource implements ScimResource
       throws ScimException
   {
     ArrayNode valuesArrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(Long value : values)
+    for (Long value : values)
     {
       valuesArrayNode.add(value);
     }
@@ -2370,7 +2370,7 @@ public final class GenericScimResource implements ScimResource
       throws ScimException
   {
     JsonNode jsonNode = getValue(path);
-    if(jsonNode.isNull())
+    if (jsonNode.isNull())
     {
       return null;
     }
@@ -2482,11 +2482,11 @@ public final class GenericScimResource implements ScimResource
     {
       return JsonUtils.getObjectReader().forType(Date.class).readValue(node);
     }
-    catch(JsonProcessingException ex)
+    catch (JsonProcessingException ex)
     {
       throw new ServerErrorException(ex.getMessage());
     }
-    catch(IOException ex)
+    catch (IOException ex)
     {
       throw new ServerErrorException(ex.getMessage());
     }
@@ -2766,7 +2766,7 @@ public final class GenericScimResource implements ScimResource
       throws ScimException
   {
     JsonNode jsonNode = getValue(path);
-    if(jsonNode.isNull())
+    if (jsonNode.isNull())
     {
       return null;
     }
@@ -2855,7 +2855,7 @@ public final class GenericScimResource implements ScimResource
       try
       {
         byte[] value = iterator.next().binaryValue();
-        if(value == null)
+        if (value == null)
         {
           // this is not a binary or text node.
           throw new ServerErrorException("Value at path " + path +
@@ -3058,7 +3058,7 @@ public final class GenericScimResource implements ScimResource
       throws ScimException
   {
     ArrayNode valuesArrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(URI value : values)
+    for (URI value : values)
     {
       valuesArrayNode.add(value.toString());
     }
@@ -3154,7 +3154,7 @@ public final class GenericScimResource implements ScimResource
       JsonNode jsonNode = getValue(path);
       return jsonNode.isNull() ? null : new URI(jsonNode.textValue());
     }
-    catch(URISyntaxException ex)
+    catch (URISyntaxException ex)
     {
       throw new ServerErrorException(ex.getMessage());
     }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
@@ -167,7 +167,7 @@ public final class Path implements Iterable<Path.Element>
     public void toString(@NotNull final StringBuilder builder)
     {
       builder.append(attribute);
-      if(valueFilter != null)
+      if (valueFilter != null)
       {
         builder.append("[");
         builder.append(valueFilter);
@@ -367,7 +367,7 @@ public final class Path implements Iterable<Path.Element>
   public Path withoutFilters()
   {
     ArrayList<Element> newElements = new ArrayList<Element>(elements.size());
-    for(Element element : elements)
+    for (Element element : elements)
     {
       newElements.add(new Element(element.getAttribute(), null));
     }
@@ -414,7 +414,7 @@ public final class Path implements Iterable<Path.Element>
   @NotNull
   public static Path root(@Nullable final String schemaUrn)
   {
-    if(schemaUrn != null && !SchemaUtils.isUrn(schemaUrn))
+    if (schemaUrn != null && !SchemaUtils.isUrn(schemaUrn))
     {
       throw new IllegalArgumentException(
           String.format("Invalid extension schema URN: %s",
@@ -521,16 +521,16 @@ public final class Path implements Iterable<Path.Element>
    */
   public void toString(@NotNull final StringBuilder builder)
   {
-    if(schemaUrn != null)
+    if (schemaUrn != null)
     {
       builder.append(schemaUrn);
       builder.append(":");
     }
     Iterator<Element> i = elements.iterator();
-    while(i.hasNext())
+    while (i.hasNext())
     {
       i.next().toString(builder);
-      if(i.hasNext())
+      if (i.hasNext())
       {
         builder.append(".");
       }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ListResponse.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ListResponse.java
@@ -81,23 +81,23 @@ public final class ListResponse<T> extends BaseScimResource
    */
   @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
   @SuppressWarnings("unchecked")
-  public ListResponse(@NotNull final Map<String,Object> props)
+  public ListResponse(@NotNull final Map<String, Object> props)
   {
-    final Map<String,Object> properties =
+    final Map<String, Object> properties =
       new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
     properties.putAll(props);
 
     checkRequiredProperties(properties, "totalResults", "resources");
 
-    this.totalResults = (Integer)properties.get("totalResults");
-    this.resources =  (List<T>)properties.get("resources");
+    this.totalResults = (Integer) properties.get("totalResults");
+    this.resources = (List<T>) properties.get("resources");
     this.startIndex = properties.containsKey("startIndex") ?
-      (Integer)properties.get("startIndex") : null;
-    this.itemsPerPage =  properties.containsKey("itemsPerPage") ?
-      (Integer)properties.get("itemsPerPage") : null;
+      (Integer) properties.get("startIndex") : null;
+    this.itemsPerPage = properties.containsKey("itemsPerPage") ?
+      (Integer) properties.get("itemsPerPage") : null;
     if (properties.containsKey("schemas"))
     {
-      this.setSchemaUrns((Collection<String>)properties.get("schemas"));
+      this.setSchemaUrns((Collection<String>) properties.get("schemas"));
     }
   }
 
@@ -272,7 +272,7 @@ public final class ListResponse<T> extends BaseScimResource
   }
 
   private void checkRequiredProperties(
-      @NotNull final Map<String,Object> properties,
+      @NotNull final Map<String, Object> properties,
       @NotNull final String... requiredProperties)
   {
     for (final String property : requiredProperties)

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -182,7 +182,7 @@ public abstract class PatchOperation
     public <T> T getValue(@NotNull final Class<T> cls)
         throws JsonProcessingException, ScimException, IllegalArgumentException
     {
-      if(value.isArray())
+      if (value.isArray())
       {
         throw new IllegalArgumentException("Patch operation contains " +
             "multiple values");
@@ -200,7 +200,7 @@ public abstract class PatchOperation
         throws JsonProcessingException, ScimException
     {
       ArrayList<T> objects = new ArrayList<T>(value.size());
-      for(JsonNode node : value)
+      for (JsonNode node : value)
       {
         objects.add(JsonUtils.getObjectReader().treeToValue(node, cls));
       }
@@ -566,7 +566,7 @@ public abstract class PatchOperation
             throws ScimException
     {
       super(path);
-      if(path == null)
+      if (path == null)
       {
         throw BadRequestException.noTarget(
             "path field must not be null for remove operations");
@@ -688,7 +688,7 @@ public abstract class PatchOperation
     public <T> T getValue(@NotNull final Class<T> cls)
         throws JsonProcessingException, ScimException, IllegalArgumentException
     {
-      if(value.isArray())
+      if (value.isArray())
       {
         throw new IllegalArgumentException("Patch operation contains " +
             "multiple values");
@@ -705,7 +705,7 @@ public abstract class PatchOperation
         throws JsonProcessingException, ScimException
     {
       ArrayList<T> objects = new ArrayList<T>(value.size());
-      for(JsonNode node : value)
+      for (JsonNode node : value)
       {
         objects.add(JsonUtils.getObjectReader().treeToValue(node, cls));
       }
@@ -781,15 +781,15 @@ public abstract class PatchOperation
    */
   PatchOperation(@Nullable final Path path) throws ScimException
   {
-    if(path != null)
+    if (path != null)
     {
-      if(path.size() > 2)
+      if (path.size() > 2)
       {
         throw BadRequestException.invalidPath(
             "Path cannot target sub-attributes more than one level deep");
       }
 
-      if(path.size() == 2)
+      if (path.size() == 2)
       {
         Filter valueFilter = path.getElement(1).getValueFilter();
         // Allow use of the special case "value" path to reference the value itself.
@@ -921,7 +921,7 @@ public abstract class PatchOperation
     // schemas attribute.
     JsonNode schemasNode =
         node.path(SchemaUtils.SCHEMAS_ATTRIBUTE_DEFINITION.getName());
-    if(schemasNode.isArray())
+    if (schemasNode.isArray())
     {
       ArrayNode schemas = (ArrayNode) schemasNode;
       if (getPath() == null)
@@ -936,7 +936,7 @@ public abstract class PatchOperation
           }
         }
       }
-      else if(getPath().getSchemaUrn() != null)
+      else if (getPath().getSchemaUrn() != null)
       {
         addSchemaUrnIfMissing(schemas, getPath().getSchemaUrn());
       }
@@ -946,9 +946,9 @@ public abstract class PatchOperation
   private void addSchemaUrnIfMissing(@NotNull final ArrayNode schemas,
                                      @NotNull final String schemaUrn)
   {
-    for(JsonNode node : schemas)
+    for (JsonNode node : schemas)
     {
-      if(node.isTextual() && node.textValue().equalsIgnoreCase(schemaUrn))
+      if (node.isTextual() && node.textValue().equalsIgnoreCase(schemaUrn))
       {
         return;
       }
@@ -1065,7 +1065,7 @@ public abstract class PatchOperation
       @NotNull final List<String> values)
   {
     ArrayNode arrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(String value : values)
+    for (String value : values)
     {
       arrayNode.add(value);
     }
@@ -1220,7 +1220,7 @@ public abstract class PatchOperation
       @NotNull final List<Double> values)
   {
     ArrayNode arrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(Double value : values)
+    for (Double value : values)
     {
       arrayNode.add(value);
     }
@@ -1337,7 +1337,7 @@ public abstract class PatchOperation
       @NotNull final List<Integer> values)
   {
     ArrayNode arrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(Integer value : values)
+    for (Integer value : values)
     {
       arrayNode.add(value);
     }
@@ -1452,7 +1452,7 @@ public abstract class PatchOperation
                                              @NotNull final List<Long> values)
   {
     ArrayNode arrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(Long value : values)
+    for (Long value : values)
     {
       arrayNode.add(value);
     }
@@ -1569,7 +1569,7 @@ public abstract class PatchOperation
       throws ScimException
   {
     ArrayNode arrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(Date value : values)
+    for (Date value : values)
     {
       arrayNode.add(GenericScimResource.getDateJsonNode(value).textValue());
     }
@@ -1696,7 +1696,7 @@ public abstract class PatchOperation
       @NotNull final List<byte[]> values)
   {
     ArrayNode arrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(byte[] value : values)
+    for (byte[] value : values)
     {
       arrayNode.add(Base64Variants.getDefaultVariant().encode(value));
     }
@@ -1814,7 +1814,7 @@ public abstract class PatchOperation
                                             @NotNull final List<URI> values)
   {
     ArrayNode arrayNode = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(URI value : values)
+    for (URI value : values)
     {
       arrayNode.add(value.toString());
     }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
@@ -137,7 +137,7 @@ public final class PatchRequest
   public void apply(@NotNull final GenericScimResource object)
       throws ScimException
   {
-    for(PatchOperation operation : this)
+    for (PatchOperation operation : this)
     {
       operation.apply(object.getObjectNode());
     }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/SortOrder.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/SortOrder.java
@@ -80,9 +80,9 @@ public enum SortOrder
   public static SortOrder fromName(@NotNull final String name)
       throws BadRequestException
   {
-    for(SortOrder sortOrder : SortOrder.values())
+    for (SortOrder sortOrder : SortOrder.values())
     {
-      if(sortOrder.getName().equals(name))
+      if (sortOrder.getName().equals(name))
       {
         return sortOrder;
       }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/AttributeDefinition.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/AttributeDefinition.java
@@ -120,9 +120,9 @@ public class AttributeDefinition
     @JsonCreator
     public static Type fromName(@Nullable final String name)
     {
-      for(Type type : Type.values())
+      for (Type type : Type.values())
       {
-        if(type.getName().equalsIgnoreCase(name))
+        if (type.getName().equalsIgnoreCase(name))
         {
           return type;
         }
@@ -200,9 +200,9 @@ public class AttributeDefinition
     public static Mutability fromName(@Nullable final String name)
         throws BadRequestException
     {
-      for(Mutability mutability : Mutability.values())
+      for (Mutability mutability : Mutability.values())
       {
-        if(mutability.getName().equalsIgnoreCase(name))
+        if (mutability.getName().equalsIgnoreCase(name))
         {
           return mutability;
         }
@@ -281,9 +281,9 @@ public class AttributeDefinition
     public static Returned fromName(@Nullable final String name)
         throws BadRequestException
     {
-      for(Returned returned : Returned.values())
+      for (Returned returned : Returned.values())
       {
-        if(returned.getName().equalsIgnoreCase(name))
+        if (returned.getName().equalsIgnoreCase(name))
         {
           return returned;
         }
@@ -351,9 +351,9 @@ public class AttributeDefinition
     public static Uniqueness fromName(@Nullable final String name)
         throws BadRequestException
     {
-      for(Uniqueness uniqueness : Uniqueness.values())
+      for (Uniqueness uniqueness : Uniqueness.values())
       {
-        if(uniqueness.getName().equalsIgnoreCase(name))
+        if (uniqueness.getName().equalsIgnoreCase(name))
         {
           return uniqueness;
         }
@@ -618,7 +618,7 @@ public class AttributeDefinition
     public Builder addSubAttributes(
         @Nullable final AttributeDefinition... subAttributes)
     {
-      if(subAttributes != null && subAttributes.length > 0)
+      if (subAttributes != null && subAttributes.length > 0)
       {
         if (this.subAttributes == null)
         {
@@ -678,7 +678,7 @@ public class AttributeDefinition
     @NotNull
     public Builder addCanonicalValues(@Nullable final String... canonicalValues)
     {
-      if(canonicalValues != null && canonicalValues.length > 0)
+      if (canonicalValues != null && canonicalValues.length > 0)
       {
         if (this.canonicalValues == null)
         {
@@ -753,7 +753,7 @@ public class AttributeDefinition
     @NotNull
     public Builder addReferenceTypes(@Nullable final String... referenceTypes)
     {
-      if(referenceTypes != null && referenceTypes.length > 0)
+      if (referenceTypes != null && referenceTypes.length > 0)
       {
         if (this.referenceTypes == null)
         {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/JsonReference.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/JsonReference.java
@@ -74,7 +74,7 @@ public class JsonReference<T>
   @Nullable
   public T getObjIfSet()
   {
-    if(set)
+    if (set)
     {
       return obj;
     }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/FilterEvaluator.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/FilterEvaluator.java
@@ -359,7 +359,7 @@ public class FilterEvaluator implements FilterVisitor<Boolean, JsonNode>
       if (node.isArray())
       {
         // filter each element of the array individually
-        for(JsonNode value : node)
+        for (JsonNode value : node)
         {
           if (filter.getValueFilter().visit(this, value))
           {
@@ -402,21 +402,21 @@ public class FilterEvaluator implements FilterVisitor<Boolean, JsonNode>
                                                @NotNull final JsonNode jsonNode)
       throws ScimException
   {
-    if(jsonNode.isArray())
+    if (jsonNode.isArray())
     {
       return jsonNode;
     }
-    if(jsonNode.isObject())
+    if (jsonNode.isObject())
     {
       List<JsonNode> nodes =
           JsonUtils.findMatchingPaths(path, (ObjectNode) jsonNode);
       ArrayList<JsonNode> flattenedNodes =
           new ArrayList<JsonNode>(nodes.size());
-      for(JsonNode node : nodes)
+      for (JsonNode node : nodes)
       {
         if (node.isArray())
         {
-          for(JsonNode child : node)
+          for (JsonNode child : node)
           {
             flattenedNodes.add(child);
           }
@@ -428,7 +428,7 @@ public class FilterEvaluator implements FilterVisitor<Boolean, JsonNode>
       }
       return flattenedNodes;
     }
-    if(jsonNode.isValueNode() && path.equals(VALUE_PATH))
+    if (jsonNode.isValueNode() && path.equals(VALUE_PATH))
     {
       // Special case for the "value" path to reference the value itself.
       // Used for referencing the value nodes of an array when the filter is
@@ -504,34 +504,34 @@ public class FilterEvaluator implements FilterVisitor<Boolean, JsonNode>
             getAttributeDefinition(filter.getAttributePath());
         String nodeValue = node.textValue();
         String comparisonValue = filter.getComparisonValue().textValue();
-        if(attributeDefinition == null || !attributeDefinition.isCaseExact())
+        if (attributeDefinition == null || !attributeDefinition.isCaseExact())
         {
           nodeValue = StaticUtils.toLowerCase(nodeValue);
           comparisonValue = StaticUtils.toLowerCase(comparisonValue);
         }
-        switch(filter.getFilterType())
+        switch (filter.getFilterType())
         {
           case CONTAINS:
-            if(nodeValue.contains(comparisonValue))
+            if (nodeValue.contains(comparisonValue))
             {
               return true;
             }
             break;
           case STARTS_WITH:
-            if(nodeValue.startsWith(comparisonValue))
+            if (nodeValue.startsWith(comparisonValue))
             {
               return true;
             }
             break;
           case ENDS_WITH:
-            if(nodeValue.endsWith(comparisonValue))
+            if (nodeValue.endsWith(comparisonValue))
             {
               return true;
             }
             break;
         }
       }
-      else if(node.equals(filter.getComparisonValue()))
+      else if (node.equals(filter.getComparisonValue()))
       {
         return true;
       }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonDiff.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonDiff.java
@@ -64,11 +64,11 @@ public class JsonDiff
     ObjectNode targetToAdd = target.deepCopy();
     ObjectNode targetToReplace = target.deepCopy();
     diff(Path.root(), source, targetToAdd, targetToReplace, ops, removeMissing);
-    if(targetToReplace.size() > 0)
+    if (targetToReplace.size() > 0)
     {
       ops.add(PatchOperation.replace(targetToReplace));
     }
-    if(targetToAdd.size() > 0)
+    if (targetToAdd.size() > 0)
     {
       ops.add(PatchOperation.add(targetToAdd));
     }
@@ -105,7 +105,7 @@ public class JsonDiff
           operations, removeMissing, si.next());
     }
 
-    if(targetToAdd != targetToReplace)
+    if (targetToAdd != targetToReplace)
     {
       // Now iterate through the fields in targetToAdd and remove any that
       // are not in the source. These new fields should only be in
@@ -144,7 +144,7 @@ public class JsonDiff
 
     if (targetValueToAdd == null)
     {
-      if(removeMissing)
+      if (removeMissing)
       {
         operations.add(PatchOperation.remove(path));
       }
@@ -242,7 +242,7 @@ public class JsonDiff
   {
     if (targetValueToAdd.size() == 0)
     {
-      if((sourceNode != null) &&
+      if ((sourceNode != null) &&
           (sourceNode.isArray()) &&
           (sourceNode.size() == 0))
       {
@@ -380,7 +380,7 @@ public class JsonDiff
   private JsonNode removeMatchingValue(@NotNull final JsonNode sourceValue,
                                        @NotNull final ArrayNode targetValues)
   {
-    if(sourceValue.isObject())
+    if (sourceValue.isObject())
     {
       // Find a target value that has the most fields in common with the source
       // and have identical values. Common fields that are also one of the
@@ -388,29 +388,29 @@ public class JsonDiff
       // a higher weight when determining the best matching value.
       TreeMap<Integer, Integer> matchScoreToIndex =
           new TreeMap<Integer, Integer>();
-      for(int i = 0; i < targetValues.size(); i++)
+      for (int i = 0; i < targetValues.size(); i++)
       {
         JsonNode targetValue = targetValues.get(i);
-        if(targetValue.isObject())
+        if (targetValue.isObject())
         {
           int matchScore = 0;
           Iterator<String> si = sourceValue.fieldNames();
-          while(si.hasNext())
+          while (si.hasNext())
           {
             String field = si.next();
-            if(sourceValue.get(field).equals(targetValue.path(field)))
+            if (sourceValue.get(field).equals(targetValue.path(field)))
             {
-              if(field.equals("value") || field.equals("$ref"))
+              if (field.equals("value") || field.equals("$ref"))
               {
                 // These fields have the highest chance of having unique values.
                 matchScore += 3;
               }
-              else if(field.equals("type") || field.equals("display"))
+              else if (field.equals("type") || field.equals("display"))
               {
                 // These fields should mostly be unique.
                 matchScore += 2;
               }
-              else if(field.equals("primary"))
+              else if (field.equals("primary"))
               {
                 // This field will definitely not be unique.
                 matchScore += 0;
@@ -424,13 +424,13 @@ public class JsonDiff
           }
           // Only consider the match if there is not already match with the same
           // score. This will prefer matches at the same index in the array.
-          if(matchScore > 0 && !matchScoreToIndex.containsKey(matchScore))
+          if (matchScore > 0 && !matchScoreToIndex.containsKey(matchScore))
           {
             matchScoreToIndex.put(matchScore, i);
           }
         }
       }
-      if(!matchScoreToIndex.isEmpty())
+      if (!matchScoreToIndex.isEmpty())
       {
         return targetValues.remove(matchScoreToIndex.lastEntry().getValue());
       }
@@ -438,7 +438,7 @@ public class JsonDiff
     else
     {
       // Find an exact match
-      for(int i = 0; i < targetValues.size(); i++)
+      for (int i = 0; i < targetValues.size(); i++)
       {
         if (JsonUtils.compareTo(sourceValue, targetValues.get(i), null) == 0)
         {
@@ -513,11 +513,11 @@ public class JsonDiff
     while (si.hasNext())
     {
       JsonNode field = si.next();
-      if(field.isNull() || field.isArray() && field.size() == 0)
+      if (field.isNull() || field.isArray() && field.size() == 0)
       {
         si.remove();
       }
-      else if(field.isContainerNode())
+      else if (field.isContainerNode())
       {
         removeNullAndEmptyValues(field);
       }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonRefBeanSerializer.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonRefBeanSerializer.java
@@ -53,20 +53,20 @@ public class JsonRefBeanSerializer extends JsonSerializer<Object>
       gen.writeStartObject();
       Collection<PropertyDescriptor> propertyDescriptors =
           SchemaUtils.getPropertyDescriptors(clazz);
-      for(PropertyDescriptor propertyDescriptor : propertyDescriptors)
+      for (PropertyDescriptor propertyDescriptor : propertyDescriptors)
       {
         Field field = SchemaUtils.findField(
             clazz, propertyDescriptor.getName());
-        if(field == null)
+        if (field == null)
         {
           continue;
         }
         field.setAccessible(true);
         Object obj = field.get(value);
-        if(obj instanceof JsonReference)
+        if (obj instanceof JsonReference)
         {
-          JsonReference<?> reference = (JsonReference<?>)obj;
-          if(reference.isSet())
+          JsonReference<?> reference = (JsonReference<?>) obj;
+          if (reference.isSet())
           {
             gen.writeFieldName(field.getName());
             serializers.defaultSerializeValue(reference.getObj(), gen);

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
@@ -104,13 +104,13 @@ public class JsonUtils
     {
       ArrayNode matchingArray = getJsonNodeFactory().arrayNode();
       Iterator<JsonNode> i = array.elements();
-      while(i.hasNext())
+      while (i.hasNext())
       {
         JsonNode node = i.next();
-        if(FilterEvaluator.evaluate(valueFilter, node))
+        if (FilterEvaluator.evaluate(valueFilter, node))
         {
           matchingArray.add(node);
-          if(removeMatching)
+          if (removeMatching)
           {
             i.remove();
           }
@@ -149,7 +149,7 @@ public class JsonUtils
         throws ScimException
     {
       JsonNode node = parent.path(field);
-      if(node.isArray() && valueFilter != null)
+      if (node.isArray() && valueFilter != null)
       {
         return filterArray((ArrayNode) node, valueFilter, false);
       }
@@ -165,11 +165,11 @@ public class JsonUtils
         throws ScimException
     {
       JsonNode node = parent.path(field);
-      if(node.isArray())
+      if (node.isArray())
       {
         ArrayNode arrayNode = (ArrayNode) node;
 
-        if(valueFilter != null)
+        if (valueFilter != null)
         {
           arrayNode = filterArray((ArrayNode) node, valueFilter,
               removeValues);
@@ -179,17 +179,17 @@ public class JsonUtils
           values.add(arrayNode);
         }
 
-        if(removeValues && (valueFilter == null || node.size() == 0))
+        if (removeValues && (valueFilter == null || node.size() == 0))
         {
           // There are no more values left after removing the matching values.
           // Just remove the field.
           parent.remove(field);
         }
       }
-      else if(node.isObject() || node.isValueNode())
+      else if (node.isObject() || node.isValueNode())
       {
         values.add(node);
-        if(removeValues)
+        if (removeValues)
         {
           parent.remove(field);
         }
@@ -235,27 +235,27 @@ public class JsonUtils
         throws ScimException
     {
       JsonNode node = parent.path(field);
-      if(node.isValueNode() || ((node.isMissingNode() || node.isNull()) &&
+      if (node.isValueNode() || ((node.isMissingNode() || node.isNull()) &&
           valueFilter != null))
       {
         throw BadRequestException.noTarget("Attribute " +
             field + " does not have a multi-valued or " +
             "complex value");
       }
-      if(node.isMissingNode() || node.isNull())
+      if (node.isMissingNode() || node.isNull())
       {
         // Create the missing node as an JSON object node.
         ObjectNode newObjectNode = getJsonNodeFactory().objectNode();
         parent.set(field, newObjectNode);
         return newObjectNode;
       }
-      else if(node.isArray())
+      else if (node.isArray())
       {
         ArrayNode arrayNode = (ArrayNode) node;
-        if(valueFilter != null)
+        if (valueFilter != null)
         {
           arrayNode = filterArray(arrayNode, valueFilter, false);
-          if(arrayNode.size() == 0)
+          if (arrayNode.size() == 0)
           {
             throw BadRequestException.noTarget("Attribute " +
                 field + " does not have a value matching the " +
@@ -428,9 +428,9 @@ public class JsonUtils
 
       // When key is null, the node to update is the parent itself.
       JsonNode node = key == null ? parent : parent.path(key);
-      if(node.isObject())
+      if (node.isObject())
       {
-        if(value.isObject())
+        if (value.isObject())
         {
           // Go through the fields of both objects and merge them.
           ObjectNode targetObject = (ObjectNode) node;
@@ -448,25 +448,25 @@ public class JsonUtils
           parent.set(key, value);
         }
       }
-      else if(node.isArray())
+      else if (node.isArray())
       {
-        if(value.isArray() && appendValues)
+        if (value.isArray() && appendValues)
         {
           // Append the new values to the existing ones.
           ArrayNode targetArray = (ArrayNode) node;
           ArrayNode valueArray = (ArrayNode) value;
-          for(JsonNode valueNode : valueArray)
+          for (JsonNode valueNode : valueArray)
           {
             boolean valueFound = false;
-            for(JsonNode targetNode : targetArray)
+            for (JsonNode targetNode : targetArray)
             {
-              if(valueNode.equals(targetNode))
+              if (valueNode.equals(targetNode))
               {
                 valueFound = true;
                 break;
               }
             }
-            if(!valueFound)
+            if (!valueFound)
             {
               targetArray.add(valueNode);
             }
@@ -498,7 +498,7 @@ public class JsonUtils
         throws ScimException
     {
       JsonNode node = parent.path(field);
-      if(node.isArray() && valueFilter != null)
+      if (node.isArray() && valueFilter != null)
       {
         return filterArray((ArrayNode) node, valueFilter, false);
       }
@@ -512,18 +512,18 @@ public class JsonUtils
         throws ScimException
     {
       JsonNode node = parent.path(field);
-      if(node.isArray() && valueFilter != null)
+      if (node.isArray() && valueFilter != null)
       {
         node = filterArray((ArrayNode) node, valueFilter, false);
       }
 
-      if(node.isArray())
+      if (node.isArray())
       {
-        if(node.size() > 0)
+        if (node.size() > 0)
         {
           setPathPresent(true);
         }
-      } else if(! node.isMissingNode())
+      } else if (! node.isMissingNode())
       {
         setPathPresent(true);
       }
@@ -583,7 +583,7 @@ public class JsonUtils
   {
     GatheringNodeVisitor visitor = new GatheringNodeVisitor(false);
     traverseValues(visitor, node, path);
-    if(visitor.values.isEmpty())
+    if (visitor.values.isEmpty())
     {
       return NullNode.getInstance();
     }
@@ -862,7 +862,7 @@ public class JsonUtils
       }
       else
       {
-        if(attributeDefinition != null &&
+        if (attributeDefinition != null &&
             attributeDefinition.getType() == AttributeDefinition.Type.STRING &&
             attributeDefinition.isCaseExact())
         {
@@ -880,7 +880,7 @@ public class JsonUtils
         return n1.decimalValue().compareTo(n2.decimalValue());
       }
 
-      if(n1.isFloatingPointNumber() || n2.isFloatingPointNumber())
+      if (n1.isFloatingPointNumber() || n2.isFloatingPointNumber())
       {
         return Double.compare(n1.doubleValue(), n2.doubleValue());
       }
@@ -978,9 +978,9 @@ public class JsonUtils
     String field = null;
     Filter valueFilter = null;
     int pathDepth = path.size();
-    if(path.getSchemaUrn() != null)
+    if (path.getSchemaUrn() != null)
     {
-      if(index > 0)
+      if (index > 0)
       {
         Path.Element element = path.getElement(index - 1);
         field = element.getAttribute();
@@ -992,29 +992,29 @@ public class JsonUtils
       }
       pathDepth += 1;
     }
-    else if(path.size() > 0)
+    else if (path.size() > 0)
     {
       Path.Element element = path.getElement(index);
       field = element.getAttribute();
       valueFilter = element.getValueFilter();
     }
 
-    if(index < pathDepth - 1)
+    if (index < pathDepth - 1)
     {
       JsonNode child = nodeVisitor.visitInnerNode(node, field, valueFilter);
-      if(child.isArray())
+      if (child.isArray())
       {
-        for(JsonNode value : child)
+        for (JsonNode value : child)
         {
-          if(value.isObject())
+          if (value.isObject())
           {
-            traverseValues(nodeVisitor, (ObjectNode)value, index + 1, path);
+            traverseValues(nodeVisitor, (ObjectNode) value, index + 1, path);
           }
         }
       }
-      else if(child.isObject())
+      else if (child.isObject())
       {
-        traverseValues(nodeVisitor, (ObjectNode)child, index + 1, path);
+        traverseValues(nodeVisitor, (ObjectNode) child, index + 1, path);
       }
     }
     else
@@ -1140,7 +1140,7 @@ public class JsonUtils
   public static Date nodeToDateValue(@NotNull final JsonNode node)
       throws IllegalArgumentException
   {
-    if(!node.isTextual())
+    if (!node.isTextual())
     {
       throw new IllegalArgumentException(
           "non-textual node cannot be parsed as DateTime type");

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
@@ -70,7 +70,7 @@ public class Parser
     @Override
     public int read()
     {
-      if(pos >= string.length())
+      if (pos >= string.length())
       {
         return -1;
       }
@@ -149,7 +149,7 @@ public class Parser
     @Override
     public int read(@NotNull final char[] cbuf, final int off, final int len)
     {
-      if(pos  >= string.length())
+      if (pos  >= string.length())
       {
         return -1;
       }
@@ -239,20 +239,20 @@ public class Parser
   public static Path parsePath(@Nullable final String pathString)
       throws BadRequestException
   {
-    if(pathString == null)
+    if (pathString == null)
     {
       return Path.root();
     }
 
     final String trimmedPathString = pathString.trim();
-    if(trimmedPathString.isEmpty())
+    if (trimmedPathString.isEmpty())
     {
       return Path.root();
     }
 
     Path path = Path.root();
     StringReader reader = new StringReader(trimmedPathString);
-    if(SchemaUtils.isUrn(trimmedPathString))
+    if (SchemaUtils.isUrn(trimmedPathString))
     {
       // The attribute name is prefixed with the schema URN.
 
@@ -261,7 +261,7 @@ public class Parser
       // potential value filter.
       int j = trimmedPathString.indexOf('[');
       int i;
-      if(j >= 0)
+      if (j >= 0)
       {
         i = trimmedPathString.substring(0, j).lastIndexOf(':');
       }
@@ -276,11 +276,11 @@ public class Parser
       {
         path = Path.root(schemaUrn);
       }
-      catch(IllegalArgumentException e)
+      catch (IllegalArgumentException e)
       {
         throw BadRequestException.invalidPath(e.getMessage());
       }
-      if(attributeName.isEmpty())
+      if (attributeName.isEmpty())
       {
         // The trailing colon signifies that this is an extension root.
         return path;
@@ -296,7 +296,7 @@ public class Parser
       {
         // the only time this is allowed to occur is if the previous attribute
         // had a value filter, in which case, consume the token and move on.
-        if(path.isRoot() ||
+        if (path.isRoot() ||
             path.getElement(path.size()-1).getValueFilter() == null)
         {
           final String msg = String.format(
@@ -320,14 +320,14 @@ public class Parser
 
           path = path.attribute(attributeName, valueFilter);
         }
-        catch(BadRequestException be)
+        catch (BadRequestException be)
         {
           Debug.debugException(be);
           final String msg = String.format(
               "Invalid value filter: %s", be.getMessage());
           throw BadRequestException.invalidPath(msg);
         }
-        catch(Exception e)
+        catch (Exception e)
         {
           Debug.debugException(e);
           final String msg = String.format(
@@ -368,11 +368,11 @@ public class Parser
     int c = reader.read();
 
     StringBuilder b = new StringBuilder();
-    while(c > 0)
+    while (c > 0)
     {
       if (c == '.')
       {
-        if(reader.pos >= reader.string.length())
+        if (reader.pos >= reader.string.length())
         {
           // There is nothing after the period.
           throw BadRequestException.invalidPath(
@@ -384,7 +384,7 @@ public class Parser
       if (c == '[')
       {
         // Terminating opening brace. Consume it and return token.
-        b.append((char)c);
+        b.append((char) c);
         return b.toString();
       }
       if (c == '-' || c == '_' || c == '$' || Character.isLetterOrDigit(c)
@@ -396,13 +396,13 @@ public class Parser
       {
         final String msg = String.format(
             "Unexpected character '%s' at position %d for token starting at %d",
-            (char)c, reader.pos - 1, reader.mark);
+            (char) c, reader.pos - 1, reader.mark);
         throw BadRequestException.invalidPath(msg);
       }
       c = reader.read();
     }
 
-    if(b.length() > 0)
+    if (b.length() > 0)
     {
       return b.toString();
     }
@@ -453,10 +453,10 @@ public class Parser
       reader.mark(0);
       c = reader.read();
     }
-    while(c == ' ');
+    while (c == ' ');
 
     StringBuilder b = new StringBuilder();
-    while(c > 0)
+    while (c > 0)
     {
       if (c == ' ')
       {
@@ -465,33 +465,33 @@ public class Parser
       }
       if (c == '(' || c == ')')
       {
-        if(b.length() > 0)
+        if (b.length() > 0)
         {
           // Do not consume the parenthesis.
           reader.unread();
         }
         else
         {
-          b.append((char)c);
+          b.append((char) c);
         }
         return b.toString();
       }
       if (!isValueFilter && c == '[')
       {
         // Terminating opening brace. Consume it and return token.
-        b.append((char)c);
+        b.append((char) c);
         return b.toString();
       }
       if (isValueFilter && c == ']')
       {
-        if(b.length() > 0)
+        if (b.length() > 0)
         {
           // Do not consume the closing brace.
           reader.unread();
         }
         else
         {
-          b.append((char)c);
+          b.append((char) c);
         }
         return b.toString();
       }
@@ -499,19 +499,19 @@ public class Parser
           || Character.isLetterOrDigit(c)
           || options.isExtendedAttributeNameCharacter((char) c))
       {
-        b.append((char)c);
+        b.append((char) c);
       }
       else
       {
         final String msg = String.format(
             "Unexpected character '%s' at position %d for token starting at %d",
-            (char)c, reader.pos - 1, reader.mark);
+            (char) c, reader.pos - 1, reader.mark);
         throw BadRequestException.invalidFilter(msg);
       }
       c = reader.read();
     }
 
-    if(b.length() > 0)
+    if (b.length() > 0)
     {
       return b.toString();
     }
@@ -537,23 +537,23 @@ public class Parser
     String token;
     String previousToken = null;
 
-    while((token = readFilterToken(reader, isValueFilter)) != null)
+    while ((token = readFilterToken(reader, isValueFilter)) != null)
     {
-      if(token.equals("(") && expectsNewFilter(previousToken))
+      if (token.equals("(") && expectsNewFilter(previousToken))
       {
         precedenceStack.push(token);
       }
-      else if(token.equalsIgnoreCase(FilterType.NOT.getStringValue()) &&
+      else if (token.equalsIgnoreCase(FilterType.NOT.getStringValue()) &&
           expectsNewFilter(previousToken))
       {
         // "not" should be followed by an (
         String nextToken = readFilterToken(reader, isValueFilter);
-        if(nextToken == null)
+        if (nextToken == null)
         {
           throw BadRequestException.invalidFilter(
               "Unexpected end of filter string");
         }
-        if(!nextToken.equals("("))
+        if (!nextToken.equals("("))
         {
           final String msg = String.format(
               "Expected '(' at position %d", reader.mark);
@@ -561,10 +561,10 @@ public class Parser
         }
         precedenceStack.push(token);
       }
-      else if(token.equals(")") && !expectsNewFilter(previousToken))
+      else if (token.equals(")") && !expectsNewFilter(previousToken))
       {
         String operator = closeGrouping(precedenceStack, outputStack, false);
-        if(operator == null)
+        if (operator == null)
         {
           final String msg =
               String.format("No opening parenthesis matching closing " +
@@ -577,13 +577,13 @@ public class Parser
           outputStack.push(Filter.not(outputStack.pop()));
         }
       }
-      else if(token.equalsIgnoreCase(FilterType.AND.getStringValue()) &&
+      else if (token.equalsIgnoreCase(FilterType.AND.getStringValue()) &&
           !expectsNewFilter(previousToken))
       {
         // and has higher precedence than or.
         precedenceStack.push(token);
       }
-      else if(token.equalsIgnoreCase(FilterType.OR.getStringValue()) &&
+      else if (token.equalsIgnoreCase(FilterType.OR.getStringValue()) &&
           !expectsNewFilter(previousToken))
       {
         // pop all the pending ands first before pushing or.
@@ -600,7 +600,7 @@ public class Parser
           {
             break;
           }
-          if(!andComponents.isEmpty())
+          if (!andComponents.isEmpty())
           {
             andComponents.addFirst(outputStack.pop());
             outputStack.push(Filter.and(andComponents));
@@ -609,7 +609,7 @@ public class Parser
 
         precedenceStack.push(token);
       }
-      else if(token.endsWith("[") && expectsNewFilter(previousToken))
+      else if (token.endsWith("[") && expectsNewFilter(previousToken))
       {
         // This is a complex value filter.
         final Path filterAttribute;
@@ -627,7 +627,7 @@ public class Parser
           throw BadRequestException.invalidFilter(msg);
         }
 
-        if(filterAttribute.isRoot())
+        if (filterAttribute.isRoot())
         {
           final String msg = String.format(
               "Attribute path expected at position %d", reader.mark);
@@ -637,12 +637,12 @@ public class Parser
         outputStack.push(Filter.hasComplexValue(
             filterAttribute, readFilter(reader, true)));
       }
-      else if(isValueFilter && token.equals("]") &&
+      else if (isValueFilter && token.equals("]") &&
           !expectsNewFilter(previousToken))
       {
         break;
       }
-      else if(expectsNewFilter(previousToken))
+      else if (expectsNewFilter(previousToken))
       {
         // This must be an attribute path followed by operator and maybe value.
         final Path filterAttribute;
@@ -659,7 +659,7 @@ public class Parser
           throw BadRequestException.invalidFilter(msg);
         }
 
-        if(filterAttribute.isRoot())
+        if (filterAttribute.isRoot())
         {
           final String msg = String.format(
               "Attribute path expected at position %d", reader.mark);
@@ -668,7 +668,7 @@ public class Parser
 
         String op = readFilterToken(reader, isValueFilter);
 
-        if(op == null)
+        if (op == null)
         {
           throw BadRequestException.invalidFilter(
               "Unexpected end of filter string");
@@ -704,7 +704,7 @@ public class Parser
               valueNode = parser.readValueAsTree();
 
               // This is actually a JSON null. Use NullNode.
-              if(valueNode == null)
+              if (valueNode == null)
               {
                 valueNode = JsonUtils.getJsonNodeFactory().nullNode();
               }
@@ -784,7 +784,7 @@ public class Parser
 
     closeGrouping(precedenceStack, outputStack, true);
 
-    if(outputStack.isEmpty())
+    if (outputStack.isEmpty())
     {
       throw BadRequestException.invalidFilter(
           "Unexpected end of filter string");
@@ -816,29 +816,29 @@ public class Parser
     while (!operators.isEmpty())
     {
       operator = operators.pop();
-      if(operator.equals("(") ||
+      if (operator.equals("(") ||
           operator.equalsIgnoreCase(FilterType.NOT.getStringValue()))
       {
-        if(isAtTheEnd)
+        if (isAtTheEnd)
         {
           throw BadRequestException.invalidFilter(
               "Unexpected end of filter string");
         }
         break;
       }
-      if(repeatingOperator == null)
+      if (repeatingOperator == null)
       {
         repeatingOperator = operator;
       }
-      if(!operator.equals(repeatingOperator))
+      if (!operator.equals(repeatingOperator))
       {
-        if(output.isEmpty())
+        if (output.isEmpty())
         {
           throw BadRequestException.invalidFilter(
               "Unexpected end of filter string");
         }
         components.addFirst(output.pop());
-        if(repeatingOperator.equalsIgnoreCase(FilterType.AND.getStringValue()))
+        if (repeatingOperator.equalsIgnoreCase(FilterType.AND.getStringValue()))
         {
           output.push(Filter.and(components));
         }
@@ -849,7 +849,7 @@ public class Parser
         components.clear();
         repeatingOperator = operator;
       }
-      if(output.isEmpty())
+      if (output.isEmpty())
       {
         throw BadRequestException.invalidFilter(
             "Unexpected end of filter string");
@@ -857,15 +857,15 @@ public class Parser
       components.addFirst(output.pop());
     }
 
-    if(repeatingOperator != null && !components.isEmpty())
+    if (repeatingOperator != null && !components.isEmpty())
     {
-      if(output.isEmpty())
+      if (output.isEmpty())
       {
         throw BadRequestException.invalidFilter(
             "Unexpected end of filter string");
       }
       components.addFirst(output.pop());
-      if(repeatingOperator.equalsIgnoreCase(FilterType.AND.getStringValue()))
+      if (repeatingOperator.equalsIgnoreCase(FilterType.AND.getStringValue()))
       {
         output.push(Filter.and(components));
       }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/SchemaUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/SchemaUtils.java
@@ -183,7 +183,7 @@ public class SchemaUtils
           throws IntrospectionException
   {
     String className = cls.getCanonicalName();
-    if(!cls.isAssignableFrom(AttributeDefinition.class) &&
+    if (!cls.isAssignableFrom(AttributeDefinition.class) &&
         classesProcessed.contains(className))
     {
       throw new RuntimeException("Cycles detected in Schema");
@@ -194,9 +194,9 @@ public class SchemaUtils
     Collection<AttributeDefinition> attributes =
         new ArrayList<AttributeDefinition>();
 
-    for(PropertyDescriptor propertyDescriptor : propertyDescriptors)
+    for (PropertyDescriptor propertyDescriptor : propertyDescriptors)
     {
-      if(propertyDescriptor.getName().equals("subAttributes") &&
+      if (propertyDescriptor.getName().equals("subAttributes") &&
           cls.isAssignableFrom(AttributeDefinition.class) &&
           classesProcessed.contains(className))
       {
@@ -209,23 +209,23 @@ public class SchemaUtils
 
       Field field = findField(cls, propertyDescriptor.getName());
 
-      if(field == null)
+      if (field == null)
       {
         continue;
       }
       Attribute schemaProperty = null;
       JsonProperty jsonProperty = null;
-      if(field.isAnnotationPresent(Attribute.class))
+      if (field.isAnnotationPresent(Attribute.class))
       {
         schemaProperty = field.getAnnotation(Attribute.class);
       }
-      if(field.isAnnotationPresent(JsonProperty.class))
+      if (field.isAnnotationPresent(JsonProperty.class))
       {
         jsonProperty = field.getAnnotation(JsonProperty.class);
       }
 
       // Only generate schema for annotated fields.
-      if(schemaProperty == null)
+      if (schemaProperty == null)
       {
         continue;
       }
@@ -245,7 +245,7 @@ public class SchemaUtils
 
       // if this is a multivalued attribute the real sub attribute class is the
       // the one specified in the annotation, not the list, set, array, etc.
-      if((schemaProperty.multiValueClass() != NullType.class))
+      if ((schemaProperty.multiValueClass() != NullType.class))
       {
         propertyCls = schemaProperty.multiValueClass();
       }
@@ -253,7 +253,7 @@ public class SchemaUtils
       AttributeDefinition.Type type = getAttributeType(propertyCls);
       attributeBuilder.setType(type);
 
-      if(type == AttributeDefinition.Type.COMPLEX)
+      if (type == AttributeDefinition.Type.COMPLEX)
       {
         // Add this class to the list to allow cycle detection
         classesProcessed.push(cls.getCanonicalName());
@@ -286,7 +286,7 @@ public class SchemaUtils
       @NotNull final PropertyDescriptor propertyDescriptor,
       @Nullable final JsonProperty jsonProperty)
   {
-    if(jsonProperty != null &&
+    if (jsonProperty != null &&
         !jsonProperty.value().equals(JsonProperty.USE_DEFAULT_NAME))
     {
       attributeBuilder.setName(jsonProperty.value());
@@ -323,7 +323,7 @@ public class SchemaUtils
 
     // if the multiValuedClass attribute is present in the annotation,
     // make sure this is a collection or array.
-    if(multiValued && !collectionOrArray)
+    if (multiValued && !collectionOrArray)
     {
       throw new RuntimeException("Property named " +
           propertyDescriptor.getName() +
@@ -331,7 +331,7 @@ public class SchemaUtils
           "but is not a Collection or an array");
     }
 
-    if(!multiValued && collectionOrArray)
+    if (!multiValued && collectionOrArray)
     {
       throw new RuntimeException("Property named " +
           propertyDescriptor.getName() +
@@ -358,7 +358,7 @@ public class SchemaUtils
       @NotNull final AttributeDefinition.Builder attributeBuilder,
       @Nullable final Attribute schemaProperty)
   {
-    if(schemaProperty != null)
+    if (schemaProperty != null)
     {
       attributeBuilder.setDescription(schemaProperty.description());
     }
@@ -380,7 +380,7 @@ public class SchemaUtils
       @NotNull final AttributeDefinition.Builder attributeBuilder,
       @Nullable final Attribute schemaProperty)
   {
-    if(schemaProperty != null)
+    if (schemaProperty != null)
     {
       attributeBuilder.setCaseExact(schemaProperty.isCaseExact());
     }
@@ -402,7 +402,7 @@ public class SchemaUtils
       @NotNull final AttributeDefinition.Builder attributeBuilder,
       @Nullable final Attribute schemaProperty)
   {
-    if(schemaProperty != null)
+    if (schemaProperty != null)
     {
       attributeBuilder.setRequired(schemaProperty.isRequired());
     }
@@ -424,7 +424,7 @@ public class SchemaUtils
       @NotNull final AttributeDefinition.Builder attributeBuilder,
       @Nullable final Attribute schemaProperty)
   {
-    if(schemaProperty != null)
+    if (schemaProperty != null)
     {
       attributeBuilder.addCanonicalValues(schemaProperty.canonicalValues());
     }
@@ -446,7 +446,7 @@ public class SchemaUtils
       @NotNull final AttributeDefinition.Builder attributeBuilder,
       @Nullable final Attribute schemaProperty)
   {
-    if(schemaProperty != null)
+    if (schemaProperty != null)
     {
       attributeBuilder.setReturned(schemaProperty.returned());
     }
@@ -468,7 +468,7 @@ public class SchemaUtils
       @NotNull final AttributeDefinition.Builder attributeBuilder,
       @Nullable final Attribute schemaProperty)
   {
-    if(schemaProperty != null)
+    if (schemaProperty != null)
     {
       attributeBuilder.setUniqueness(schemaProperty.uniqueness());
     }
@@ -490,7 +490,7 @@ public class SchemaUtils
       @NotNull final AttributeDefinition.Builder attributeBuilder,
       @Nullable final Attribute schemaProperty)
   {
-    if(schemaProperty != null)
+    if (schemaProperty != null)
     {
       attributeBuilder.addReferenceTypes(schemaProperty.referenceTypes());
     }
@@ -513,7 +513,7 @@ public class SchemaUtils
       @NotNull final AttributeDefinition.Builder attributeBuilder,
       @Nullable final Attribute schemaProperty)
   {
-    if(schemaProperty != null)
+    if (schemaProperty != null)
     {
       attributeBuilder.setMutability(schemaProperty.mutability());
     }
@@ -537,7 +537,7 @@ public class SchemaUtils
   private static AttributeDefinition.Type getAttributeType(
       @NotNull final Class<?> cls)
   {
-    if((cls == Integer.class) ||
+    if ((cls == Integer.class) ||
         (cls == int.class))
     {
       return AttributeDefinition.Type.INTEGER;
@@ -559,15 +559,15 @@ public class SchemaUtils
     {
       return AttributeDefinition.Type.STRING;
     }
-    else if((cls == URI.class) || (cls == URL.class))
+    else if ((cls == URI.class) || (cls == URL.class))
     {
       return AttributeDefinition.Type.REFERENCE;
     }
-    else if((cls == Date.class) || (cls == Calendar.class))
+    else if ((cls == Date.class) || (cls == Calendar.class))
     {
       return AttributeDefinition.Type.DATETIME;
     }
-    else if((cls == byte[].class))
+    else if ((cls == byte[].class))
     {
       return AttributeDefinition.Type.BINARY;
     }
@@ -593,7 +593,7 @@ public class SchemaUtils
     Schema schemaAnnotation = cls.getAnnotation(Schema.class);
 
     // Only generate schema for annotated classes.
-    if(schemaAnnotation == null)
+    if (schemaAnnotation == null)
     {
       return null;
     }
@@ -617,12 +617,12 @@ public class SchemaUtils
                                 @NotNull final String fieldName)
   {
     Class<?> currentClass = cls;
-    while(currentClass != null)
+    while (currentClass != null)
     {
       Field [] fields = currentClass.getDeclaredFields();
-      for(Field field : fields)
+      for (Field field : fields)
       {
-        if(field.getName().equals(fieldName))
+        if (field.getName().equals(fieldName))
         {
           return field;
         }
@@ -644,7 +644,6 @@ public class SchemaUtils
   {
     return (cls.isArray() && byte[].class != cls) ||
         Collection.class.isAssignableFrom(cls);
-
   }
 
   /**
@@ -672,7 +671,7 @@ public class SchemaUtils
   private static String getSchemaIdFromAnnotation(
       @Nullable final Schema schemaAnnotation)
   {
-    if(schemaAnnotation != null)
+    if (schemaAnnotation != null)
     {
       return schemaAnnotation.id();
     }
@@ -690,7 +689,7 @@ public class SchemaUtils
   @Nullable
   public static String getNameFromSchemaAnnotation(@NotNull final Class<?> cls)
   {
-    Schema schema = (Schema)cls.getAnnotation(Schema.class);
+    Schema schema = (Schema) cls.getAnnotation(Schema.class);
     return SchemaUtils.getNameFromSchemaAnnotation(schema);
   }
 
@@ -704,7 +703,7 @@ public class SchemaUtils
   private static String getNameFromSchemaAnnotation(
       @Nullable final Schema schemaAnnotation)
   {
-    if(schemaAnnotation != null)
+    if (schemaAnnotation != null)
     {
       return schemaAnnotation.name();
     }
@@ -766,7 +765,7 @@ public class SchemaUtils
   @NotNull
   public static String forceToBeUrn(@NotNull final String string)
   {
-    if(isUrn(string))
+    if (isUrn(string))
     {
       return string;
     }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/DiffTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/DiffTestCase.java
@@ -82,11 +82,11 @@ public class DiffTestCase
         Path.root().attribute("title"))));
     ObjectNode replaceValue = JsonUtils.getJsonNodeFactory().objectNode();
     replaceValue.put("userType", "manager");
-    replaceValue.put("nickName","bjj3");
+    replaceValue.put("nickName", "bjj3");
     assertTrue(d.contains(PatchOperation.replace(replaceValue)));
 
     List<PatchOperation> d2 = JsonUtils.diff(source, target, true);
-    for(PatchOperation op : d2)
+    for (PatchOperation op : d2)
     {
       op.apply(source);
     }
@@ -122,7 +122,7 @@ public class DiffTestCase
     assertEquals(d.size(), 0);
 
     List<PatchOperation> d2 = JsonUtils.diff(source, target, true);
-    for(PatchOperation op : d2)
+    for (PatchOperation op : d2)
     {
       op.apply(source);
     }
@@ -138,10 +138,10 @@ public class DiffTestCase
     d = JsonUtils.diff(source, target, false);
     assertEquals(d.size(), 1);
     assertTrue(d.contains(PatchOperation.replace((ObjectNode)
-        JsonUtils.getJsonNodeFactory().objectNode().set("name",name))));
+        JsonUtils.getJsonNodeFactory().objectNode().set("name", name))));
 
     d2 = JsonUtils.diff(source, target, true);
-    for(PatchOperation op : d2)
+    for (PatchOperation op : d2)
     {
       op.apply(source);
     }
@@ -161,7 +161,7 @@ public class DiffTestCase
         Path.root().attribute("name"))));
 
     d2 = JsonUtils.diff(source, target, true);
-    for(PatchOperation op : d2)
+    for (PatchOperation op : d2)
     {
       op.apply(source);
     }
@@ -181,7 +181,7 @@ public class DiffTestCase
         Path.root().attribute("name").attribute("honorificSuffix"))));
 
     d2 = JsonUtils.diff(source, target, true);
-    for(PatchOperation op : d2)
+    for (PatchOperation op : d2)
     {
       op.apply(source);
     }
@@ -202,7 +202,7 @@ public class DiffTestCase
     assertTrue(d.contains(PatchOperation.replace(replaceValue)));
 
     d2 = JsonUtils.diff(source, target, true);
-    for(PatchOperation op : d2)
+    for (PatchOperation op : d2)
     {
       op.apply(source);
     }
@@ -222,7 +222,7 @@ public class DiffTestCase
     assertEquals(d.size(), 0);
 
     d2 = JsonUtils.diff(source, target, true);
-    for(PatchOperation op : d2)
+    for (PatchOperation op : d2)
     {
       op.apply(source);
     }
@@ -297,7 +297,7 @@ public class DiffTestCase
     assertTrue(d.contains(PatchOperation.add(addValue)));
 
     List<PatchOperation> d2 = JsonUtils.diff(source, target, true);
-    for(PatchOperation op : d2)
+    for (PatchOperation op : d2)
     {
       op.apply(source);
     }
@@ -308,18 +308,18 @@ public class DiffTestCase
     JsonNode sourcePhotos = source.remove("photos");
     JsonNode targetPhotos = target.remove("photos");
     assertEquals(sourcePhotos.size(), targetPhotos.size());
-    for(JsonNode sourceValue : sourcePhotos)
+    for (JsonNode sourceValue : sourcePhotos)
     {
       boolean found = false;
-      for(JsonNode targetValue : targetPhotos)
+      for (JsonNode targetValue : targetPhotos)
       {
-        if(sourceValue.equals(targetValue))
+        if (sourceValue.equals(targetValue))
         {
           found = true;
           break;
         }
       }
-      if(!found)
+      if (!found)
       {
         fail("Source photo value " + sourceValue +
             " not in target photo array " + targetPhotos);
@@ -492,7 +492,7 @@ public class DiffTestCase
     assertTrue(d.contains(PatchOperation.add(addValue)));
 
     List<PatchOperation> d2 = JsonUtils.diff(source, target, true);
-    for(PatchOperation op : d2)
+    for (PatchOperation op : d2)
     {
       op.apply(source);
     }
@@ -694,7 +694,7 @@ public class DiffTestCase
 
     target = JsonUtils.getJsonNodeFactory().objectNode();
     List<PatchOperation> d2 = JsonUtils.diff(source, target, true);
-    for(PatchOperation op : d2)
+    for (PatchOperation op : d2)
     {
       op.apply(source);
     }
@@ -1096,10 +1096,10 @@ public class DiffTestCase
   private void removeNullNodes(JsonNode object)
   {
     Iterator<JsonNode> i = object.elements();
-    while(i.hasNext())
+    while (i.hasNext())
     {
       JsonNode field = i.next();
-      if(field.isNull() ||
+      if (field.isNull() ||
           (field.isArray() && field.size() == 0))
       {
         i.remove();

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GenericScimResourceObjectTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/GenericScimResourceObjectTest.java
@@ -117,7 +117,7 @@ public class GenericScimResourceObjectTest
         dateFormat.format(meta.getLastModified().getTime()),
         "2015-02-27T11:29:39.042Z");
 
-    ObjectNode metaNode = (ObjectNode)JsonUtils.getObjectReader().readTree(
+    ObjectNode metaNode = (ObjectNode) JsonUtils.getObjectReader().readTree(
         JsonUtils.getObjectWriter().writeValueAsString(gso.getMeta()));
     Assert.assertEquals(
         metaNode.get("created").asText(),
@@ -132,7 +132,7 @@ public class GenericScimResourceObjectTest
     Assert.assertEquals(meta.getVersion(), "1.0");
 
     Assert.assertEquals(
-        ((GenericScimResource)cso).getObjectNode().path("shoeSize").asText(),
+        ((GenericScimResource) cso).getObjectNode().path("shoeSize").asText(),
         "12W");
   }
 
@@ -621,9 +621,9 @@ public class GenericScimResourceObjectTest
       List<byte[]> byteArrayList, byte[] bytes)
   {
     boolean found = false;
-    for(byte[] bytesFromList : byteArrayList)
+    for (byte[] bytesFromList : byteArrayList)
     {
-      if(Arrays.equals(bytesFromList, bytes))
+      if (Arrays.equals(bytesFromList, bytes))
       {
         found = true;
         break;

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/PatchOpTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/PatchOpTestCase.java
@@ -347,7 +347,7 @@ public class PatchOpTestCase
             "}");
 
     GenericScimResource scimResource =
-        new GenericScimResource((ObjectNode)prePatchResource);
+        new GenericScimResource((ObjectNode) prePatchResource);
     patchOp.apply(scimResource);
     assertEquals(scimResource.getObjectNode(), postPatchResource);
 
@@ -387,7 +387,7 @@ public class PatchOpTestCase
               "  ]\n" +
               "}");
     }
-    catch(JsonMappingException e)
+    catch (JsonMappingException e)
     {
       assertEquals(
           ((BadRequestException) e.getCause()).getScimError().getScimType(),
@@ -411,7 +411,7 @@ public class PatchOpTestCase
             "  ]\n" +
             "}");
     }
-    catch(JsonMappingException e)
+    catch (JsonMappingException e)
     {
       assertEquals(
           ((BadRequestException) e.getCause()).getScimError().getScimType(),
@@ -436,7 +436,7 @@ public class PatchOpTestCase
             "  ]\n" +
             "}");
     }
-    catch(JsonMappingException e)
+    catch (JsonMappingException e)
     {
       assertEquals(
           ((BadRequestException) e.getCause()).getScimError().getScimType(),

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/SchemaGenerationTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/schema/SchemaGenerationTest.java
@@ -93,9 +93,9 @@ public class SchemaGenerationTest
         "integerField", "mutabilityReadWrite", "mutabilityReadOnly",
         "mutabilityWriteOnly", "mutabilityImmutable", "bigDecimal");
 
-    for(AttributeDefinition attribute : schemaDefinition.getAttributes())
+    for (AttributeDefinition attribute : schemaDefinition.getAttributes())
     {
-      if(attribute.getName().equals("stringField" ))
+      if (attribute.getName().equals("stringField" ))
       {
         //    @SchemaProperty(description = "description:stringField",
         //        isCaseExact = true, isRequired = true)
@@ -104,7 +104,7 @@ public class SchemaGenerationTest
             AttributeDefinition.Type.STRING, null,
             null, null, null, null);
       }
-      else if(attribute.getName().equals("booleanObjectField" ))
+      else if (attribute.getName().equals("booleanObjectField" ))
       {
         //    @SchemaProperty(description = "description:booleanObjectField",
         //        isCaseExact = true, isRequired = false,
@@ -115,7 +115,7 @@ public class SchemaGenerationTest
             AttributeDefinition.Returned.REQUEST,
             null, null, null, null);
       }
-      else if(attribute.getName().equals("booleanField" ))
+      else if (attribute.getName().equals("booleanField" ))
       {
         //    @SchemaProperty(description = "description:booleanField",
         //        isCaseExact = false, isRequired = false,
@@ -127,7 +127,7 @@ public class SchemaGenerationTest
             AttributeDefinition.Returned.NEVER,
             null, null, null, null);
       }
-      else if(attribute.getName().equals("integerObjectField" ))
+      else if (attribute.getName().equals("integerObjectField" ))
       {
         //    @SchemaProperty(description = "description:integerObjectField",
         //        isCaseExact = false, isRequired = true,
@@ -139,7 +139,7 @@ public class SchemaGenerationTest
             AttributeDefinition.Returned.DEFAULT,
             null, null, null, null);
       }
-      else if(attribute.getName().equals("integerField" ))
+      else if (attribute.getName().equals("integerField" ))
       {
         //    @SchemaProperty(description = "description:integerField",
         //        isCaseExact = true, isRequired = true,
@@ -150,7 +150,7 @@ public class SchemaGenerationTest
             AttributeDefinition.Returned.ALWAYS,
             null, null, null, null);
       }
-      else if(attribute.getName().equals("mutabilityReadWrite" ))
+      else if (attribute.getName().equals("mutabilityReadWrite" ))
       {
         //    @SchemaProperty(description = "description:mutabilityReadWrite",
         //        mutability = SCIM2Attribute.Mutability.READ_WRITE)
@@ -159,7 +159,7 @@ public class SchemaGenerationTest
             Multivalued.DEFAULT, AttributeDefinition.Type.STRING,
             null, AttributeDefinition.Mutability.READ_WRITE, null, null, null);
       }
-      else if(attribute.getName().equals("mutabilityReadOnly" ))
+      else if (attribute.getName().equals("mutabilityReadOnly" ))
       {
         //    @SchemaProperty(description = "description:mutabilityReadOnly",
         //        mutability = SCIM2Attribute.Mutability.READ_ONLY)
@@ -168,7 +168,7 @@ public class SchemaGenerationTest
             Multivalued.DEFAULT, AttributeDefinition.Type.STRING,
             null, AttributeDefinition.Mutability.READ_ONLY, null, null, null);
       }
-      else if(attribute.getName().equals("mutabilityWriteOnly" ))
+      else if (attribute.getName().equals("mutabilityWriteOnly" ))
       {
         //    @SchemaProperty(description = "description:mutabilityWriteOnly",
         //        mutability = SCIM2Attribute.Mutability.WRITE_ONLY)
@@ -178,7 +178,7 @@ public class SchemaGenerationTest
             AttributeDefinition.Mutability.WRITE_ONLY,
             null, null, null);
       }
-      else if(attribute.getName().equals("mutabilityImmutable" ))
+      else if (attribute.getName().equals("mutabilityImmutable" ))
       {
         //    @SchemaProperty(description = "description:mutabilityImmutable",
         //        mutability = SCIM2Attribute.Mutability.IMMUTABLE)
@@ -188,7 +188,7 @@ public class SchemaGenerationTest
             AttributeDefinition.Mutability.IMMUTABLE,
             null, null, null);
       }
-      else if(attribute.getName().equals("bigDecimal"))
+      else if (attribute.getName().equals("bigDecimal"))
       {
         //  @Attribute(description = "description:bigDecimal",
         //      mutability = AttributeDefinition.Mutability.READ_ONLY)
@@ -226,7 +226,7 @@ public class SchemaGenerationTest
       {
         tc3_checkComplexObject(attribute);
       }
-      else if(attribute.getName().equals("multiValuedString"))
+      else if (attribute.getName().equals("multiValuedString"))
       {
         tc3_checkMultiValuedString(attribute);
       }
@@ -260,9 +260,9 @@ public class SchemaGenerationTest
     Assert.assertTrue(subAttributes.size() > 0);
     List<String> expectedAttributes = makeModifiableList("stringField_3a");
 
-    for(AttributeDefinition subAttribute : subAttributes)
+    for (AttributeDefinition subAttribute : subAttributes)
     {
-      if(subAttribute.getName().equals("stringField_3a"))
+      if (subAttribute.getName().equals("stringField_3a"))
       {
         //   @SchemaProperty(description = "description:stringField_3a")
         checkAttribute(subAttribute, "description:stringField_3a",
@@ -295,7 +295,7 @@ public class SchemaGenerationTest
     List<String> expectedAttributes = new LinkedList<String>();
     addSubAttributeFields(expectedAttributes);
 
-    for(AttributeDefinition subAttribute : subAttributes)
+    for (AttributeDefinition subAttribute : subAttributes)
     {
       markAttributeFound(expectedAttributes, subAttribute);
     }
@@ -316,12 +316,12 @@ public class SchemaGenerationTest
       mutability = AttributeDefinition.Mutability.READ_WRITE;
     }
 
-    if(returned  == null)
+    if (returned  == null)
     {
       returned = AttributeDefinition.Returned.DEFAULT;
     }
 
-    if(uniqueness == null)
+    if (uniqueness == null)
     {
       uniqueness = AttributeDefinition.Uniqueness.NONE;
     }
@@ -331,7 +331,7 @@ public class SchemaGenerationTest
     Assert.assertEquals(attribute.getReturned(), returned);
     Assert.assertEquals(attribute.getUniqueness(), uniqueness);
 
-    switch(multivalued)
+    switch (multivalued)
     {
       case MULTIVALUED:
         Assert.assertTrue(attribute.isMultiValued());
@@ -343,7 +343,7 @@ public class SchemaGenerationTest
         break;
     }
 
-    switch(required)
+    switch (required)
     {
       case REQUIRED:
         Assert.assertTrue(attribute.isRequired());
@@ -355,7 +355,7 @@ public class SchemaGenerationTest
         break;
     }
 
-    switch(caseExact)
+    switch (caseExact)
     {
       case NOT_CASE_EXACT:
         Assert.assertFalse(attribute.isCaseExact());
@@ -374,7 +374,7 @@ public class SchemaGenerationTest
 
   private void checkAllAttributesFound(List<String> expectedAttributes)
   {
-    if(expectedAttributes.size() > 0)
+    if (expectedAttributes.size() > 0)
     {
       Assert.fail("Did not find all attributes : " + expectedAttributes);
     }
@@ -383,7 +383,7 @@ public class SchemaGenerationTest
   private void markAttributeFound(List<String> expectedAttributes,
                                   AttributeDefinition attribute)
   {
-    if(expectedAttributes.contains(attribute.getName()))
+    if (expectedAttributes.contains(attribute.getName()))
     {
       expectedAttributes.remove(attribute.getName());
     }

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/ListResponseWriter.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/ListResponseWriter.java
@@ -92,19 +92,19 @@ public class ListResponseWriter<T extends ScimResource>
    */
   void endResponse() throws IOException
   {
-    if(!sentTotalResults.get() && !deferredFields.has("totalResults"))
+    if (!sentTotalResults.get() && !deferredFields.has("totalResults"))
     {
       // The total results was never set. Set it to the calculated one.
       totalResults(resultsSent.get());
     }
-    if(startedResourcesArray.get())
+    if (startedResourcesArray.get())
     {
       // Close the resources array if currently writing it.
       jsonGenerator.writeEndArray();
     }
 
     Iterator<Map.Entry<String, JsonNode>> i = deferredFields.fields();
-    while(i.hasNext())
+    while (i.hasNext())
     {
       Map.Entry<String, JsonNode> field = i.next();
       jsonGenerator.writeObjectField(field.getKey(), field.getValue());
@@ -124,7 +124,7 @@ public class ListResponseWriter<T extends ScimResource>
    */
   public void startIndex(final int startIndex) throws IOException
   {
-    if(startedResourcesArray.get())
+    if (startedResourcesArray.get())
     {
       deferredFields.put("startIndex", startIndex);
     }
@@ -144,7 +144,7 @@ public class ListResponseWriter<T extends ScimResource>
    */
   public void itemsPerPage(final int itemsPerPage) throws IOException
   {
-    if(startedResourcesArray.get())
+    if (startedResourcesArray.get())
     {
       deferredFields.put("itemsPerPage", itemsPerPage);
     }
@@ -164,7 +164,7 @@ public class ListResponseWriter<T extends ScimResource>
    */
   public void totalResults(final int totalResults) throws IOException
   {
-    if(startedResourcesArray.get())
+    if (startedResourcesArray.get())
     {
       deferredFields.put("totalResults", totalResults);
     }
@@ -184,7 +184,7 @@ public class ListResponseWriter<T extends ScimResource>
    */
   public void resource(@Nullable final T scimResource) throws IOException
   {
-    if(startedResourcesArray.compareAndSet(false, true))
+    if (startedResourcesArray.compareAndSet(false, true))
     {
       jsonGenerator.writeArrayFieldStart("Resources");
     }

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/AuthenticatedSubjectAliasFilter.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/AuthenticatedSubjectAliasFilter.java
@@ -58,9 +58,9 @@ public class AuthenticatedSubjectAliasFilter implements ContainerRequestFilter
       throws IOException
   {
     String requestPath = requestContext.getUriInfo().getPath();
-    for(String alias : getAliases())
+    for (String alias : getAliases())
     {
-      if(requestPath.startsWith(alias + "/") || requestPath.equals(alias))
+      if (requestPath.startsWith(alias + "/") || requestPath.equals(alias))
       {
         String authSubjectPath;
         try
@@ -112,7 +112,7 @@ public class AuthenticatedSubjectAliasFilter implements ContainerRequestFilter
       @Nullable final SecurityContext securityContext)
           throws ScimException
   {
-    if(securityContext == null || securityContext.getUserPrincipal() == null)
+    if (securityContext == null || securityContext.getUserPrincipal() == null)
     {
       throw new NotImplementedException("/Me not supported");
     }

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/DefaultContentTypeFilter.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/DefaultContentTypeFilter.java
@@ -47,7 +47,7 @@ public class DefaultContentTypeFilter implements ContainerRequestFilter
   public void filter(@NotNull final ContainerRequestContext requestContext)
       throws IOException
   {
-    if((requestContext.getMethod().equals(HttpMethod.POST) ||
+    if ((requestContext.getMethod().equals(HttpMethod.POST) ||
         requestContext.getMethod().equals(HttpMethod.PUT) ||
         requestContext.getMethod().equals("PATCH")) &&
         requestContext.getMediaType() == null)

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/DotSearchFilter.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/DotSearchFilter.java
@@ -59,12 +59,12 @@ public class DotSearchFilter implements ContainerRequestFilter
   public void filter(@NotNull final ContainerRequestContext requestContext)
       throws IOException
   {
-    if(requestContext.getMethod().equals(HttpMethod.POST) &&
+    if (requestContext.getMethod().equals(HttpMethod.POST) &&
         requestContext.getUriInfo().getPath().endsWith(
             SEARCH_WITH_POST_PATH_EXTENSION))
 
     {
-      if(requestContext.getMediaType() == null ||
+      if (requestContext.getMediaType() == null ||
           !(requestContext.getMediaType().isCompatible(
               ServerUtils.MEDIA_TYPE_SCIM_TYPE) ||
               requestContext.getMediaType().isCompatible(
@@ -77,7 +77,7 @@ public class DotSearchFilter implements ContainerRequestFilter
           JsonUtils.getObjectReader().forType(SearchRequest.class);
       JsonParser p = reader.getFactory().createParser(
           requestContext.getEntityStream());
-      if(p.nextToken() == null)
+      if (p.nextToken() == null)
       {
         throw new BadRequestException(
             new NoContentException("Empty Entity"));
@@ -86,46 +86,46 @@ public class DotSearchFilter implements ContainerRequestFilter
       UriBuilder builder = requestContext.getUriInfo().getBaseUriBuilder();
       List<PathSegment> pathSegments =
           requestContext.getUriInfo().getPathSegments();
-      for(int i = 0; i < pathSegments.size() - 1; i ++)
+      for (int i = 0; i < pathSegments.size() - 1; i++)
       {
         builder.path(pathSegments.get(i).getPath());
       }
-      if(searchRequest.getAttributes() != null)
+      if (searchRequest.getAttributes() != null)
       {
         builder.queryParam(QUERY_PARAMETER_ATTRIBUTES,
             ServerUtils.encodeTemplateNames(
                 StaticUtils.collectionToString(
                     searchRequest.getAttributes(), ",")));
       }
-      if(searchRequest.getExcludedAttributes() != null)
+      if (searchRequest.getExcludedAttributes() != null)
       {
         builder.queryParam(QUERY_PARAMETER_EXCLUDED_ATTRIBUTES,
             ServerUtils.encodeTemplateNames(
                     StaticUtils.collectionToString(
                     searchRequest.getExcludedAttributes(), ",")));
       }
-      if(searchRequest.getFilter() != null)
+      if (searchRequest.getFilter() != null)
       {
         builder.queryParam(QUERY_PARAMETER_FILTER,
             ServerUtils.encodeTemplateNames(searchRequest.getFilter()));
       }
-      if(searchRequest.getSortBy() != null)
+      if (searchRequest.getSortBy() != null)
       {
         builder.queryParam(QUERY_PARAMETER_SORT_BY,
             ServerUtils.encodeTemplateNames(searchRequest.getSortBy()));
       }
-      if(searchRequest.getSortOrder() != null)
+      if (searchRequest.getSortOrder() != null)
       {
         builder.queryParam(QUERY_PARAMETER_SORT_ORDER,
             ServerUtils.encodeTemplateNames(
                 searchRequest.getSortOrder().getName()));
       }
-      if(searchRequest.getStartIndex() != null)
+      if (searchRequest.getStartIndex() != null)
       {
         builder.queryParam(QUERY_PARAMETER_PAGE_START_INDEX,
             searchRequest.getStartIndex());
       }
-      if(searchRequest.getCount() != null)
+      if (searchRequest.getCount() != null)
       {
         builder.queryParam(QUERY_PARAMETER_PAGE_SIZE,
             searchRequest.getCount());

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/JsonProcessingExceptionMapper.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/JsonProcessingExceptionMapper.java
@@ -57,13 +57,13 @@ public class JsonProcessingExceptionMapper implements
   public Response toResponse(@NotNull final JsonProcessingException exception)
   {
     ErrorResponse errorResponse;
-    if((exception instanceof JsonParseException) ||
+    if ((exception instanceof JsonParseException) ||
         (exception instanceof JsonMappingException))
     {
       StringBuilder builder = new StringBuilder();
       builder.append("Unable to parse request: ");
       builder.append(exception.getOriginalMessage());
-      if(exception.getLocation() != null)
+      if (exception.getLocation() != null)
       {
         builder.append(" at line: ");
         builder.append(exception.getLocation().getLineNr());
@@ -75,7 +75,7 @@ public class JsonProcessingExceptionMapper implements
     }
     else
     {
-      if(exception.getCause() != null &&
+      if (exception.getCause() != null &&
           exception.getCause() instanceof ScimException)
       {
         errorResponse = ((ScimException) exception.getCause()).getScimError();

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/RuntimeExceptionMapper.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/providers/RuntimeExceptionMapper.java
@@ -55,9 +55,9 @@ public class RuntimeExceptionMapper implements
   {
     ErrorResponse errorResponse;
 
-    if(exception instanceof WebApplicationException)
+    if (exception instanceof WebApplicationException)
     {
-      if(exception.getCause() != null && exception.getCause()
+      if (exception.getCause() != null && exception.getCause()
           instanceof NoContentException)
       {
         errorResponse = new ErrorResponse(400);

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/resources/ResourceTypesEndpoint.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/resources/ResourceTypesEndpoint.java
@@ -87,7 +87,7 @@ public class ResourceTypesEndpoint
       @NotNull @Context final UriInfo uriInfo)
           throws ScimException
   {
-    if(filterString != null)
+    if (filterString != null)
     {
       throw new ForbiddenException("Filtering not allowed");
     }
@@ -101,7 +101,7 @@ public class ResourceTypesEndpoint
     Collection<ResourceTypeResource> resourceTypes = getResourceTypes();
     Collection<GenericScimResource> preparedResources =
         new ArrayList<GenericScimResource>(resourceTypes.size());
-    for(ResourceTypeResource resourceType : resourceTypes)
+    for (ResourceTypeResource resourceType : resourceTypes)
     {
       GenericScimResource preparedResource =
           resourceType.asGenericScimResource();
@@ -133,10 +133,10 @@ public class ResourceTypesEndpoint
     ResourcePreparer<GenericScimResource> resourcePreparer =
         new ResourcePreparer<GenericScimResource>(
             RESOURCE_TYPE_DEFINITION, uriInfo);
-    for(ResourceTypeResource resourceType : getResourceTypes())
+    for (ResourceTypeResource resourceType : getResourceTypes())
     {
       GenericScimResource resource = resourceType.asGenericScimResource();
-      if(filter.visit(filterEvaluator, resource.getObjectNode()))
+      if (filter.visit(filterEvaluator, resource.getObjectNode()))
       {
         resourcePreparer.setResourceTypeAndLocation(resource);
         return resource;
@@ -161,22 +161,22 @@ public class ResourceTypesEndpoint
   {
     Set<ResourceTypeResource> resourceTypes =
         new HashSet<ResourceTypeResource>();
-    for(Class<?> resourceClass : application.getClasses())
+    for (Class<?> resourceClass : application.getClasses())
     {
       ResourceTypeDefinition resourceTypeDefinition =
           ResourceTypeDefinition.fromJaxRsResource(resourceClass);
-      if(resourceTypeDefinition != null &&
+      if (resourceTypeDefinition != null &&
           resourceTypeDefinition.isDiscoverable())
       {
         resourceTypes.add(resourceTypeDefinition.toScimResource());
       }
     }
 
-    for(Object resourceInstance : application.getSingletons())
+    for (Object resourceInstance : application.getSingletons())
     {
       ResourceTypeDefinition resourceTypeDefinition =
           ResourceTypeDefinition.fromJaxRsResource(resourceInstance.getClass());
-      if(resourceTypeDefinition != null &&
+      if (resourceTypeDefinition != null &&
           resourceTypeDefinition.isDiscoverable())
       {
         resourceTypes.add(resourceTypeDefinition.toScimResource());

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/resources/SchemasEndpoint.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/resources/SchemasEndpoint.java
@@ -88,7 +88,7 @@ public class SchemasEndpoint
       @NotNull @Context final UriInfo uriInfo)
           throws ScimException
   {
-    if(filterString != null)
+    if (filterString != null)
     {
       throw new ForbiddenException("Filtering not allowed");
     }
@@ -102,7 +102,7 @@ public class SchemasEndpoint
     Collection<SchemaResource> schemas = getSchemas();
     Collection<GenericScimResource> preparedResources =
         new ArrayList<GenericScimResource>(schemas.size());
-    for(SchemaResource schema : schemas)
+    for (SchemaResource schema : schemas)
     {
       GenericScimResource preparedResource = schema.asGenericScimResource();
       preparer.setResourceTypeAndLocation(preparedResource);
@@ -159,36 +159,36 @@ public class SchemasEndpoint
   {
     Set<SchemaResource> schemas =
         new HashSet<SchemaResource>();
-    for(Class<?> resourceClass : application.getClasses())
+    for (Class<?> resourceClass : application.getClasses())
     {
       ResourceTypeDefinition resourceTypeDefinition =
           ResourceTypeDefinition.fromJaxRsResource(resourceClass);
-      if(resourceTypeDefinition != null &&
+      if (resourceTypeDefinition != null &&
           resourceTypeDefinition.isDiscoverable())
       {
-        if(resourceTypeDefinition.getCoreSchema() != null)
+        if (resourceTypeDefinition.getCoreSchema() != null)
         {
           schemas.add(resourceTypeDefinition.getCoreSchema());
         }
-        for(SchemaResource schemaExtension :
+        for (SchemaResource schemaExtension :
             resourceTypeDefinition.getSchemaExtensions().keySet())
         {
           schemas.add(schemaExtension);
         }
       }
     }
-    for(Object resourceInstance : application.getSingletons())
+    for (Object resourceInstance : application.getSingletons())
     {
       ResourceTypeDefinition resourceTypeDefinition =
           ResourceTypeDefinition.fromJaxRsResource(resourceInstance.getClass());
-      if(resourceTypeDefinition != null &&
+      if (resourceTypeDefinition != null &&
           resourceTypeDefinition.isDiscoverable())
       {
-        if(resourceTypeDefinition.getCoreSchema() != null)
+        if (resourceTypeDefinition.getCoreSchema() != null)
         {
           schemas.add(resourceTypeDefinition.getCoreSchema());
         }
-        for(SchemaResource schemaExtension :
+        for (SchemaResource schemaExtension :
             resourceTypeDefinition.getSchemaExtensions().keySet())
         {
           schemas.add(schemaExtension);

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourceComparator.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourceComparator.java
@@ -95,7 +95,7 @@ public class ResourceComparator<T extends ScimResource>
     try
     {
       List<JsonNode> v1s = JsonUtils.findMatchingPaths(sortBy, n1);
-      if(!v1s.isEmpty())
+      if (!v1s.isEmpty())
       {
         // Always just use the primary or first value of the first found node.
         v1 = getPrimaryOrFirst(v1s.get(0));
@@ -109,7 +109,7 @@ public class ResourceComparator<T extends ScimResource>
     try
     {
       List<JsonNode> v2s = JsonUtils.findMatchingPaths(sortBy, n2);
-      if(!v2s.isEmpty())
+      if (!v2s.isEmpty())
       {
         // Always just use the primary or first value of the first found node.
         v2 = getPrimaryOrFirst(v2s.get(0));
@@ -120,18 +120,18 @@ public class ResourceComparator<T extends ScimResource>
       Debug.debugException(e);
     }
 
-    if(v1 == null && v2 == null)
+    if (v1 == null && v2 == null)
     {
       return 0;
     }
     // or all attribute types, if there is no data for the specified "sortBy"
     // value they are sorted via the "sortOrder" parameter; i.e., they are
     // ordered last if ascending and first if descending.
-    else if(v1 == null)
+    else if (v1 == null)
     {
       return sortOrder == SortOrder.ASCENDING ? 1 : -1;
     }
-    else if(v2 == null)
+    else if (v2 == null)
     {
       return sortOrder == SortOrder.ASCENDING ? -1 : 1;
     }
@@ -162,22 +162,22 @@ public class ResourceComparator<T extends ScimResource>
     // [I-D.ietf - scim - core - schema]), if any, or else the first value in
     // the list, if any.
 
-    if(!node.isArray())
+    if (!node.isArray())
     {
       return node;
     }
 
-    if(node.size() == 0)
+    if (node.size() == 0)
     {
       return null;
     }
 
     Iterator<JsonNode> i = node.elements();
-    while(i.hasNext())
+    while (i.hasNext())
     {
       JsonNode value = i.next();
       JsonNode primary = value.get("primary");
-      if(primary != null && primary.booleanValue())
+      if (primary != null && primary.booleanValue())
       {
         return value;
       }

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourcePreparer.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourcePreparer.java
@@ -125,12 +125,12 @@ public class ResourcePreparer<T extends ScimResource>
                    @NotNull final URI baseUri)
       throws BadRequestException
   {
-    if(attributesString != null && !attributesString.isEmpty())
+    if (attributesString != null && !attributesString.isEmpty())
     {
       Set<String> attributeSet = StaticUtils.arrayToSet(
           StaticUtils.splitCommaSeparatedString(attributesString));
       this.queryAttributes = new LinkedHashSet<Path>(attributeSet.size());
-      for(String attribute : attributeSet)
+      for (String attribute : attributeSet)
       {
         Path normalizedPath;
         try
@@ -149,13 +149,13 @@ public class ResourcePreparer<T extends ScimResource>
       }
       this.excluded = false;
     }
-    else if(excludedAttributesString != null &&
+    else if (excludedAttributesString != null &&
         !excludedAttributesString.isEmpty())
     {
       Set<String> attributeSet = StaticUtils.arrayToSet(
           StaticUtils.splitCommaSeparatedString(excludedAttributesString));
       this.queryAttributes = new LinkedHashSet<Path>(attributeSet.size());
-      for(String attribute : attributeSet)
+      for (String attribute : attributeSet)
       {
         Path normalizedPath;
         try
@@ -257,18 +257,18 @@ public class ResourcePreparer<T extends ScimResource>
     Meta meta = returnedResource.getMeta();
 
     boolean metaUpdated = false;
-    if(meta == null)
+    if (meta == null)
     {
       meta = new Meta();
     }
 
-    if(meta.getResourceType() == null)
+    if (meta.getResourceType() == null)
     {
       meta.setResourceType(resourceType.getName());
       metaUpdated = true;
     }
 
-    if(meta.getLocation() == null)
+    if (meta.getLocation() == null)
     {
       String id = returnedResource.getId();
       if (id != null)
@@ -284,7 +284,7 @@ public class ResourcePreparer<T extends ScimResource>
       metaUpdated = true;
     }
 
-    if(metaUpdated)
+    if (metaUpdated)
     {
       returnedResource.setMeta(meta);
     }
@@ -308,7 +308,7 @@ public class ResourcePreparer<T extends ScimResource>
       @Nullable final Iterable<PatchOperation> patchOperations)
   {
     Set<Path> requestAttributes = Collections.emptySet();
-    if(requestResource != null)
+    if (requestResource != null)
     {
       ObjectNode requestObject =
           requestResource.asGenericScimResource().getObjectNode();
@@ -316,7 +316,7 @@ public class ResourcePreparer<T extends ScimResource>
       collectAttributes(Path.root(), requestAttributes, requestObject);
     }
 
-    if(patchOperations != null)
+    if (patchOperations != null)
     {
       requestAttributes = new LinkedHashSet<Path>();
       collectAttributes(requestAttributes, patchOperations);
@@ -346,11 +346,11 @@ public class ResourcePreparer<T extends ScimResource>
                                  @NotNull final ObjectNode objectNode)
   {
     Iterator<Map.Entry<String, JsonNode>> i = objectNode.fields();
-    while(i.hasNext())
+    while (i.hasNext())
     {
       Map.Entry<String, JsonNode> field = i.next();
       Path path = parentPath.attribute(field.getKey());
-      if(path.size() > 1 || path.getSchemaUrn() == null)
+      if (path.size() > 1 || path.getSchemaUrn() == null)
       {
         // Don't add a path for the extension schema object itself.
         paths.add(path);
@@ -377,13 +377,13 @@ public class ResourcePreparer<T extends ScimResource>
                                  @NotNull final Set<Path> paths,
                                  @NotNull final ArrayNode arrayNode)
   {
-    for(JsonNode value : arrayNode)
+    for (JsonNode value : arrayNode)
     {
-      if(value.isArray())
+      if (value.isArray())
       {
         collectAttributes(parentPath, paths, (ArrayNode) value);
       }
-      else if(value.isObject())
+      else if (value.isObject())
       {
         collectAttributes(parentPath, paths, (ObjectNode) value);
       }
@@ -401,23 +401,23 @@ public class ResourcePreparer<T extends ScimResource>
       @NotNull final Iterable<PatchOperation> patchOperations)
 
   {
-    for(PatchOperation patchOperation : patchOperations)
+    for (PatchOperation patchOperation : patchOperations)
     {
       Path path = Path.root();
-      if(patchOperation.getPath() != null)
+      if (patchOperation.getPath() != null)
       {
         path = resourceType.normalizePath(patchOperation.getPath()).
             withoutFilters();
         paths.add(path);
       }
-      if(patchOperation.getJsonNode() != null)
+      if (patchOperation.getJsonNode() != null)
       {
-        if(patchOperation.getJsonNode().isArray())
+        if (patchOperation.getJsonNode().isArray())
         {
           collectAttributes(
               path, paths, (ArrayNode) patchOperation.getJsonNode());
         }
-        else if(patchOperation.getJsonNode().isObject())
+        else if (patchOperation.getJsonNode().isObject())
         {
           collectAttributes(
               path, paths, (ObjectNode) patchOperation.getJsonNode());

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourceTrimmer.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourceTrimmer.java
@@ -61,7 +61,7 @@ public abstract class ResourceTrimmer
   {
     ObjectNode objectToReturn = JsonUtils.getJsonNodeFactory().objectNode();
     Iterator<Map.Entry<String, JsonNode>> i = objectNode.fields();
-    while(i.hasNext())
+    while (i.hasNext())
     {
       Map.Entry<String, JsonNode> field = i.next();
       final Path path;
@@ -75,13 +75,13 @@ public abstract class ResourceTrimmer
         path = parentPath.attribute(field.getKey());
       }
 
-      if(path.isRoot() || shouldReturn(path))
+      if (path.isRoot() || shouldReturn(path))
       {
         if (field.getValue().isArray())
         {
           ArrayNode trimmedNode = trimArrayNode(
               (ArrayNode) field.getValue(), path);
-          if(trimmedNode.size() > 0)
+          if (trimmedNode.size() > 0)
           {
             objectToReturn.set(field.getKey(), trimmedNode);
           }
@@ -90,7 +90,7 @@ public abstract class ResourceTrimmer
         {
           ObjectNode trimmedNode = trimObjectNode(
               (ObjectNode) field.getValue(), path);
-          if(trimmedNode.size() > 0)
+          if (trimmedNode.size() > 0)
           {
             objectToReturn.set(field.getKey(), trimmedNode);
           }
@@ -116,21 +116,21 @@ public abstract class ResourceTrimmer
                                     @NotNull final Path parentPath)
   {
     ArrayNode arrayToReturn = JsonUtils.getJsonNodeFactory().arrayNode();
-    for(JsonNode value : arrayNode)
+    for (JsonNode value : arrayNode)
     {
-      if(value.isArray())
+      if (value.isArray())
       {
         ArrayNode trimmedNode = trimArrayNode((ArrayNode) value, parentPath);
-        if(trimmedNode.size() > 0)
+        if (trimmedNode.size() > 0)
         {
           arrayToReturn.add(trimmedNode);
         }
       }
-      else if(value.isObject())
+      else if (value.isObject())
       {
         ObjectNode trimmedNode = trimObjectNode(
             (ObjectNode) value, parentPath);
-        if(trimmedNode.size() > 0)
+        if (trimmedNode.size() > 0)
         {
           arrayToReturn.add(trimmedNode);
         }

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourceTypeDefinition.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourceTypeDefinition.java
@@ -104,11 +104,11 @@ public final class ResourceTypeDefinition
      */
     public Builder(@NotNull final String name, @NotNull final String endpoint)
     {
-      if(name == null)
+      if (name == null)
       {
         throw new IllegalArgumentException("name must not be null");
       }
-      if(endpoint == null)
+      if (endpoint == null)
       {
         throw new IllegalArgumentException("endpoint must not be null");
       }
@@ -212,11 +212,11 @@ public final class ResourceTypeDefinition
       Map<SchemaResource, Boolean> schemaExtensions =
           new HashMap<SchemaResource, Boolean>(requiredSchemaExtensions.size() +
               optionalSchemaExtensions.size());
-      for(SchemaResource schema : requiredSchemaExtensions)
+      for (SchemaResource schema : requiredSchemaExtensions)
       {
         schemaExtensions.put(schema, true);
       }
-      for(SchemaResource schema : optionalSchemaExtensions)
+      for (SchemaResource schema : optionalSchemaExtensions)
       {
         schemaExtensions.put(schema, false);
       }
@@ -255,13 +255,13 @@ public final class ResourceTypeDefinition
         SchemaUtils.COMMON_ATTRIBUTE_DEFINITIONS);
 
     // Add the core attributes
-    if(coreSchema != null)
+    if (coreSchema != null)
     {
       buildAttributeNotationMap(Path.root(), coreSchema.getAttributes());
     }
 
     // Add the extension attributes
-    for(SchemaResource schemaExtension : schemaExtensions.keySet())
+    for (SchemaResource schemaExtension : schemaExtensions.keySet())
     {
       buildAttributeNotationMap(Path.root(schemaExtension.getId()),
           schemaExtension.getAttributes());
@@ -272,11 +272,11 @@ public final class ResourceTypeDefinition
       @NotNull final Path parentPath,
       @NotNull final Collection<AttributeDefinition> attributes)
   {
-    for(AttributeDefinition attribute : attributes)
+    for (AttributeDefinition attribute : attributes)
     {
       Path path = parentPath.attribute(attribute.getName());
       attributeNotationMap.put(path, attribute);
-      if(attribute.getSubAttributes() != null)
+      if (attribute.getSubAttributes() != null)
       {
         buildAttributeNotationMap(path, attribute.getSubAttributes());
       }
@@ -372,7 +372,7 @@ public final class ResourceTypeDefinition
   @NotNull
   public Path normalizePath(@NotNull final Path path)
   {
-    if(path.getSchemaUrn() != null && coreSchema != null &&
+    if (path.getSchemaUrn() != null && coreSchema != null &&
         path.getSchemaUrn().equalsIgnoreCase(coreSchema.getId()))
     {
       return Path.root().attribute(path);
@@ -391,7 +391,7 @@ public final class ResourceTypeDefinition
     try
     {
       URI coreSchemaUri = null;
-      if(coreSchema != null)
+      if (coreSchema != null)
       {
         coreSchemaUri = new URI(coreSchema.getId());
       }
@@ -402,7 +402,7 @@ public final class ResourceTypeDefinition
             new ArrayList<ResourceTypeResource.SchemaExtension>(
                 schemaExtensions.size());
 
-        for(Map.Entry<SchemaResource, Boolean> schemaExtension :
+        for (Map.Entry<SchemaResource, Boolean> schemaExtension :
             schemaExtensions.entrySet())
         {
           schemaExtensionList.add(new ResourceTypeResource.SchemaExtension(
@@ -414,7 +414,7 @@ public final class ResourceTypeDefinition
       return new ResourceTypeResource(id == null ? name : id, name, description,
           URI.create(endpoint), coreSchemaUri, schemaExtensionList);
     }
-    catch(URISyntaxException e)
+    catch (URISyntaxException e)
     {
       throw new RuntimeException(e);
     }

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
@@ -132,22 +132,22 @@ public class SchemaChecker
     public void throwSchemaExceptions()
         throws BadRequestException
     {
-      if(syntaxIssues.size() > 0)
+      if (syntaxIssues.size() > 0)
       {
         throw BadRequestException.invalidSyntax(getErrorString(syntaxIssues));
       }
 
-      if(mutabilityIssues.size() > 0)
+      if (mutabilityIssues.size() > 0)
       {
         throw BadRequestException.mutability(getErrorString(mutabilityIssues));
       }
 
-      if(pathIssues.size() > 0)
+      if (pathIssues.size() > 0)
       {
         throw BadRequestException.invalidPath(getErrorString(pathIssues));
       }
 
-      if(filterIssues.size() > 0)
+      if (filterIssues.size() > 0)
       {
         throw BadRequestException.invalidFilter(getErrorString(filterIssues));
       }
@@ -342,7 +342,7 @@ public class SchemaChecker
 
     int i = 0;
     String prefix;
-    for(PatchOperation patchOp : patchOperations)
+    for (PatchOperation patchOp : patchOperations)
     {
       prefix = "Patch op[" + i + "]: ";
       Path path = patchOp.getPath();
@@ -352,20 +352,20 @@ public class SchemaChecker
               path.getElement(path.size() - 1).getValueFilter();
       AttributeDefinition attribute = path == null ? null :
           resourceType.getAttributeDefinition(path);
-      if(path != null && attribute == null)
+      if (path != null && attribute == null)
       {
         // Can't find the attribute definition for attribute in path.
         addMessageForUndefinedAttr(path, prefix, results.pathIssues);
         continue;
       }
-      if(valueFilter != null && attribute != null && !attribute.isMultiValued())
+      if (valueFilter != null && attribute != null && !attribute.isMultiValued())
       {
         results.pathIssues.add(prefix +
             "Attribute " + path.getElement(0)+ " in path " +
             path.toString() + " must not have a value selection filter " +
             "because it is not multi-valued");
       }
-      if(valueFilter != null && attribute != null)
+      if (valueFilter != null && attribute != null)
       {
         SchemaCheckFilterVisitor.checkValueFilter(
             path.withoutFilters(), valueFilter, resourceType, this,
@@ -374,19 +374,19 @@ public class SchemaChecker
       switch (patchOp.getOpType())
       {
         case REMOVE:
-          if(attribute == null)
+          if (attribute == null)
           {
             continue;
           }
           checkAttributeMutability(prefix, null, path, attribute, results,
               currentObjectNode, false, false, false);
-          if(valueFilter == null)
+          if (valueFilter == null)
           {
             checkAttributeRequired(prefix, path, attribute, results);
           }
           break;
         case REPLACE:
-          if(attribute == null)
+          if (attribute == null)
           {
             checkPartialResource(prefix, (ObjectNode) value, results,
                 copyCurrentNode, true, false);
@@ -395,7 +395,7 @@ public class SchemaChecker
           {
             checkAttributeMutability(prefix, value, path, attribute, results,
                 currentObjectNode, true, false, false);
-            if(valueFilter != null)
+            if (valueFilter != null)
             {
               checkAttributeValue(prefix, value, path, attribute, results,
                   currentObjectNode, true, false);
@@ -408,7 +408,7 @@ public class SchemaChecker
           }
           break;
         case ADD:
-          if(attribute == null)
+          if (attribute == null)
           {
             checkPartialResource(prefix, (ObjectNode) value, results,
                 copyCurrentNode, false, true);
@@ -417,7 +417,7 @@ public class SchemaChecker
           {
             checkAttributeMutability(prefix, value, path, attribute, results,
                 currentObjectNode, false, true, false);
-            if(valueFilter != null)
+            if (valueFilter != null)
             {
               checkAttributeValue(prefix, value, path, attribute, results,
                   currentObjectNode, false, true);
@@ -431,7 +431,7 @@ public class SchemaChecker
           break;
       }
 
-      if(appliedNode != null)
+      if (appliedNode != null)
       {
         // Apply the patch so we can later ensure these set of operations
         // wont' be removing the all the values from a
@@ -440,11 +440,11 @@ public class SchemaChecker
         {
           patchOp.apply(appliedNode);
         }
-        catch(BadRequestException e)
+        catch (BadRequestException e)
         {
           // No target exceptions are operational errors and not related
           // to the schema. Just ignore.
-          if(!e.getScimError().getScimType().equals(
+          if (!e.getScimError().getScimType().equals(
               BadRequestException.NO_TARGET))
           {
             throw e;
@@ -455,7 +455,7 @@ public class SchemaChecker
       i++;
     }
 
-    if(appliedNode != null)
+    if (appliedNode != null)
     {
       checkResource("Applying patch ops results in an invalid resource: ",
           appliedNode, results, copyCurrentNode, false);
@@ -536,11 +536,11 @@ public class SchemaChecker
       @NotNull final ObjectNode objectNode)
   {
     ObjectNode copyNode = objectNode.deepCopy();
-    for(SchemaResource schemaExtension :
+    for (SchemaResource schemaExtension :
         resourceType.getSchemaExtensions().keySet())
     {
       JsonNode extension = copyNode.get(schemaExtension.getId());
-      if(extension != null && extension.isObject())
+      if (extension != null && extension.isObject())
       {
         removeReadOnlyAttributes(schemaExtension.getAttributes(),
             (ObjectNode) extension);
@@ -584,14 +584,14 @@ public class SchemaChecker
                                   @NotNull final String messagePrefix,
                                   @NotNull final List<String> messages)
   {
-    if(path.size() > 1)
+    if (path.size() > 1)
     {
       // This is a path to a sub-attribute. See if the parent attribute is
       // defined.
-      if(resourceType.getAttributeDefinition(path.subPath(1)) == null)
+      if (resourceType.getAttributeDefinition(path.subPath(1)) == null)
       {
         // The parent attribute is also undefined.
-        if(!enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
+        if (!enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
         {
           messages.add(messagePrefix +
               "Attribute " + path.getElement(0)+ " in path " +
@@ -602,7 +602,7 @@ public class SchemaChecker
       {
         // The parent attribute is defined but the sub-attribute is
         // undefined.
-        if(!enabledOptions.contains(Option.ALLOW_UNDEFINED_SUB_ATTRIBUTES))
+        if (!enabledOptions.contains(Option.ALLOW_UNDEFINED_SUB_ATTRIBUTES))
         {
           messages.add(messagePrefix +
               "Sub-attribute " + path.getElement(1)+ " in path " +
@@ -610,7 +610,7 @@ public class SchemaChecker
         }
       }
     }
-    else if(!enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
+    else if (!enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
     {
       messages.add(messagePrefix +
           "Attribute " + path.getElement(0)+ " in path " +
@@ -630,14 +630,14 @@ public class SchemaChecker
       @NotNull final Collection<AttributeDefinition> attributes,
       @NotNull final ObjectNode objectNode)
   {
-    for(AttributeDefinition attribute : attributes)
+    for (AttributeDefinition attribute : attributes)
     {
-      if(attribute.getMutability() == AttributeDefinition.Mutability.READ_ONLY)
+      if (attribute.getMutability() == AttributeDefinition.Mutability.READ_ONLY)
       {
         objectNode.remove(attribute.getName());
         continue;
       }
-      if(attribute.getSubAttributes() != null)
+      if (attribute.getSubAttributes() != null)
       {
         JsonNode node = objectNode.path(attribute.getName());
         if (node.isObject())
@@ -682,12 +682,12 @@ public class SchemaChecker
   {
 
     Iterator<Map.Entry<String, JsonNode>> i = objectNode.fields();
-    while(i.hasNext())
+    while (i.hasNext())
     {
       Map.Entry<String, JsonNode> field = i.next();
-      if(SchemaUtils.isUrn(field.getKey()))
+      if (SchemaUtils.isUrn(field.getKey()))
       {
-        if(!field.getValue().isObject())
+        if (!field.getValue().isObject())
         {
           // Bail if the extension namespace is not valid
           results.syntaxIssues.add(prefix + "Extended attributes namespace " +
@@ -709,7 +709,7 @@ public class SchemaChecker
               break;
             }
           }
-          if(!found &&
+          if (!found &&
               !enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
           {
             results.syntaxIssues.add(prefix + "Undefined extended attributes " +
@@ -746,7 +746,7 @@ public class SchemaChecker
     // Iterate through the schemas
     JsonNode schemas = objectNode.get(
         SchemaUtils.SCHEMAS_ATTRIBUTE_DEFINITION.getName());
-    if(schemas != null && schemas.isArray())
+    if (schemas != null && schemas.isArray())
     {
       boolean coreFound = false;
       for (JsonNode schema : schemas)
@@ -846,10 +846,10 @@ public class SchemaChecker
     // Remove any additional extended attribute namespaces not included in
     // the schemas attribute.
     Iterator<Map.Entry<String, JsonNode>> i = objectNode.fields();
-    while(i.hasNext())
+    while (i.hasNext())
     {
       String fieldName = i.next().getKey();
-      if(SchemaUtils.isUrn(fieldName))
+      if (SchemaUtils.isUrn(fieldName))
       {
         results.syntaxIssues.add(prefix + "Extended attributes namespace "
             + fieldName + " must be included in the schemas attribute");
@@ -888,36 +888,36 @@ public class SchemaChecker
                                         final boolean isReplace)
       throws ScimException
   {
-    if(attribute.getMutability() ==
+    if (attribute.getMutability() ==
         AttributeDefinition.Mutability.READ_ONLY)
     {
       results.mutabilityIssues.add(prefix + "Attribute " + path +
           " is read-only");
     }
-    if(attribute.getMutability() ==
+    if (attribute.getMutability() ==
         AttributeDefinition.Mutability.IMMUTABLE )
     {
-      if(node == null)
+      if (node == null)
       {
         results.mutabilityIssues.add(prefix + "Attribute " + path +
             " is immutable and value(s) may not be removed");
       }
-      if(isPartialReplace && !isReplace)
+      if (isPartialReplace && !isReplace)
       {
         results.mutabilityIssues.add(prefix + "Attribute " + path +
             " is immutable and value(s) may not be replaced");
       }
-      else if(isPartialAdd && currentObjectNode != null &&
+      else if (isPartialAdd && currentObjectNode != null &&
           JsonUtils.pathExists(path, currentObjectNode))
       {
         results.mutabilityIssues.add(prefix + "Attribute " + path +
             " is immutable and value(s) may not be added");
       }
-      else if(currentObjectNode != null)
+      else if (currentObjectNode != null)
       {
         List<JsonNode> currentValues =
             JsonUtils.findMatchingPaths(path, currentObjectNode);
-        if(currentValues.size() > 1 ||
+        if (currentValues.size() > 1 ||
             (currentValues.size() == 1 && !currentValues.get(0).equals(node)))
         {
           results.mutabilityIssues.add(prefix + "Attribute " + path +
@@ -927,7 +927,7 @@ public class SchemaChecker
     }
 
     Filter valueFilter = path.getElement(path.size() - 1).getValueFilter();
-    if(attribute.equals(SchemaUtils.SCHEMAS_ATTRIBUTE_DEFINITION) &&
+    if (attribute.equals(SchemaUtils.SCHEMAS_ATTRIBUTE_DEFINITION) &&
         valueFilter != null)
     {
       // Make sure the core schema and/or required schemas extensions are
@@ -971,7 +971,7 @@ public class SchemaChecker
       @NotNull final Results results)
   {
     // Check required attributes are all present.
-    if(attribute.isRequired())
+    if (attribute.isRequired())
     {
       results.syntaxIssues.add(prefix + "Attribute " + path +
           " is required and must have a value");
@@ -1002,27 +1002,27 @@ public class SchemaChecker
       final boolean isPartialAdd)
           throws ScimException
   {
-    if(attribute.isMultiValued() && !node.isArray())
+    if (attribute.isMultiValued() && !node.isArray())
     {
       results.syntaxIssues.add(prefix + "Value for multi-valued attribute " +
           path + " must be a JSON array");
       return;
     }
-    if(!attribute.isMultiValued() && node.isArray())
+    if (!attribute.isMultiValued() && node.isArray())
     {
       results.syntaxIssues.add(prefix + "Value for single-valued attribute " +
           path + " must not be a JSON array");
       return;
     }
 
-    if(node.isArray())
+    if (node.isArray())
     {
       int i = 0;
       for (JsonNode value : node)
       {
         // Use a special notation attr[index] to refer to a value of an JSON
         // array.
-        if(path.isRoot())
+        if (path.isRoot())
         {
           throw new NullPointerException(
               "Path should always point to an attribute");
@@ -1066,13 +1066,13 @@ public class SchemaChecker
       final boolean isPartialAdd)
           throws ScimException
   {
-    if(node.isNull())
+    if (node.isNull())
     {
       return;
     }
 
     // Check the node type.
-    switch(attribute.getType())
+    switch (attribute.getType())
     {
       case STRING:
       case DATETIME:
@@ -1123,7 +1123,7 @@ public class SchemaChecker
     }
 
     // If the node type checks out, check the actual value.
-    switch(attribute.getType())
+    switch (attribute.getType())
     {
       case DATETIME:
         try
@@ -1165,7 +1165,7 @@ public class SchemaChecker
         }
         break;
       case INTEGER:
-        if(!node.isIntegralNumber())
+        if (!node.isIntegralNumber())
         {
           results.syntaxIssues.add(prefix + "Value for attribute " + path +
               " is not an integral number");
@@ -1218,11 +1218,11 @@ public class SchemaChecker
           break;
         }
       }
-      if(!found)
+      if (!found)
       {
         found = node.textValue().equals(resourceType.getCoreSchema().getId());
       }
-      if(!found && !enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
+      if (!found && !enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
       {
         results.syntaxIssues.add(prefix + "Schema URI " + node.textValue() +
             " is not a valid value for attribute " + path + " because it is " +
@@ -1256,17 +1256,17 @@ public class SchemaChecker
       final boolean isPartialAdd,
       final boolean isReplace) throws ScimException
   {
-    if(attributes == null)
+    if (attributes == null)
     {
       return;
     }
 
-    for(AttributeDefinition attribute : attributes)
+    for (AttributeDefinition attribute : attributes)
     {
       JsonNode node = objectNode.remove(attribute.getName());
       Path path = parentPath.attribute((attribute.getName()));
 
-      if(node == null || node.isNull() || (node.isArray() && node.size() == 0))
+      if (node == null || node.isNull() || (node.isArray() && node.size() == 0))
       {
         // From SCIM's perspective, these are the same thing.
         if (!isPartialAdd && !isPartialReplace)
@@ -1274,7 +1274,7 @@ public class SchemaChecker
           checkAttributeRequired(prefix, path, attribute, results);
         }
       }
-      if(node != null)
+      if (node != null)
       {
         // Additional checks for when the field is present
         checkAttributeMutability(prefix, node, path, attribute, results,
@@ -1287,22 +1287,22 @@ public class SchemaChecker
     // All defined attributes should be removed. Remove any additional
     // undefined attributes.
     Iterator<Map.Entry<String, JsonNode>> i = objectNode.fields();
-    while(i.hasNext())
+    while (i.hasNext())
     {
       String undefinedAttribute = i.next().getKey();
-      if(parentPath.size() == 0)
+      if (parentPath.size() == 0)
       {
-        if(!enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
+        if (!enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
         {
           results.syntaxIssues.add(prefix + "Core attribute " +
               undefinedAttribute + " is undefined for schema " +
               resourceType.getCoreSchema().getId());
         }
       }
-      else if(parentPath.isRoot() &&
+      else if (parentPath.isRoot() &&
           parentPath.getSchemaUrn() != null)
       {
-        if(!enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
+        if (!enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
         {
           results.syntaxIssues.add(prefix + "Extended attribute " +
               undefinedAttribute + " is undefined for schema " +
@@ -1311,7 +1311,7 @@ public class SchemaChecker
       }
       else
       {
-        if(!enabledOptions.contains(Option.ALLOW_UNDEFINED_SUB_ATTRIBUTES))
+        if (!enabledOptions.contains(Option.ALLOW_UNDEFINED_SUB_ATTRIBUTES))
         {
           results.syntaxIssues.add(prefix + "Sub-attribute " +
               undefinedAttribute + " is undefined for attribute " + parentPath);

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ScimResourceTrimmer.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ScimResourceTrimmer.java
@@ -81,7 +81,7 @@ public class ScimResourceTrimmer extends ResourceTrimmer
         AttributeDefinition.Returned.DEFAULT :
         attributeDefinition.getReturned();
 
-    switch(returned)
+    switch (returned)
     {
       case ALWAYS:
         return true;
@@ -98,7 +98,7 @@ public class ScimResourceTrimmer extends ResourceTrimmer
         // Return if it is not one of the excluded query attributes and no
         // override query attributes are provided. If override query attributes
         // are provided, only return if it is one of them.
-        if(excluded)
+        if (excluded)
         {
           return !pathContains(queryAttributes, path);
         }

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ServerUtils.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ServerUtils.java
@@ -52,14 +52,14 @@ public class ServerUtils
       @NotNull final List<MediaType> acceptableTypes)
   {
     MediaType responseType = null;
-    for(MediaType mediaType : acceptableTypes)
+    for (MediaType mediaType : acceptableTypes)
     {
-      if(mediaType.isCompatible(MEDIA_TYPE_SCIM_TYPE))
+      if (mediaType.isCompatible(MEDIA_TYPE_SCIM_TYPE))
       {
         responseType = MEDIA_TYPE_SCIM_TYPE;
         break;
       }
-      else if(mediaType.isCompatible(MediaType.APPLICATION_JSON_TYPE))
+      else if (mediaType.isCompatible(MediaType.APPLICATION_JSON_TYPE))
       {
         responseType = MediaType.APPLICATION_JSON_TYPE;
         break;

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SimpleSearchResults.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SimpleSearchResults.java
@@ -93,7 +93,7 @@ public class SimpleSearchResults<T extends ScimResource>
     String sortByString = queryParams.getFirst(QUERY_PARAMETER_SORT_BY);
     String  sortOrderString = queryParams.getFirst(QUERY_PARAMETER_SORT_ORDER);
 
-    if(filterString != null)
+    if (filterString != null)
     {
       this.filter = Filter.fromString(filterString);
     }
@@ -102,7 +102,7 @@ public class SimpleSearchResults<T extends ScimResource>
       this.filter = null;
     }
 
-    if(startIndexString != null)
+    if (startIndexString != null)
     {
       int i = Integer.valueOf(startIndexString);
       // 3.4.2.4: A value less than 1 SHALL be interpreted as 1.
@@ -113,7 +113,7 @@ public class SimpleSearchResults<T extends ScimResource>
       startIndex = null;
     }
 
-    if(countString != null)
+    if (countString != null)
     {
       int i = Integer.valueOf(countString);
       // 3.4.2.4: A negative value SHALL be interpreted as 0.
@@ -137,7 +137,7 @@ public class SimpleSearchResults<T extends ScimResource>
     }
     SortOrder sortOrder = sortOrderString == null ?
         SortOrder.ASCENDING : SortOrder.fromName(sortOrderString);
-    if(sortBy != null)
+    if (sortBy != null)
     {
       this.resourceComparator = new ResourceComparator<ScimResource>(
           sortBy, sortOrder, resourceType);
@@ -161,7 +161,7 @@ public class SimpleSearchResults<T extends ScimResource>
   {
     // Convert to GenericScimResource
     GenericScimResource genericResource;
-    if(resource instanceof GenericScimResource)
+    if (resource instanceof GenericScimResource)
     {
       // Make a copy
       genericResource = new GenericScimResource(
@@ -175,7 +175,7 @@ public class SimpleSearchResults<T extends ScimResource>
     // Set meta attributes so they can be used in the following filter eval
     responsePreparer.setResourceTypeAndLocation(genericResource);
 
-    if(filter == null || filter.visit(filterEvaluator,
+    if (filter == null || filter.visit(filterEvaluator,
         genericResource.getObjectNode()))
     {
       resources.add(genericResource);
@@ -196,7 +196,7 @@ public class SimpleSearchResults<T extends ScimResource>
   public SimpleSearchResults addAll(@NotNull final Collection<T> resources)
       throws ScimException
   {
-    for(T resource : resources)
+    for (T resource : resources)
     {
       add(resource);
     }
@@ -211,14 +211,14 @@ public class SimpleSearchResults<T extends ScimResource>
   public void write(@NotNull final ListResponseWriter<T> os)
       throws IOException
   {
-    if(resourceComparator != null)
+    if (resourceComparator != null)
     {
       Collections.sort(resources, resourceComparator);
     }
     List<ScimResource> resultsToReturn = resources;
-    if(startIndex != null)
+    if (startIndex != null)
     {
-      if(startIndex > resources.size())
+      if (startIndex > resources.size())
       {
         resultsToReturn = Collections.emptyList();
       }
@@ -227,18 +227,18 @@ public class SimpleSearchResults<T extends ScimResource>
         resultsToReturn = resources.subList(startIndex - 1, resources.size());
       }
     }
-    if(count != null && !resultsToReturn.isEmpty())
+    if (count != null && !resultsToReturn.isEmpty())
     {
       resultsToReturn = resultsToReturn.subList(
           0, Math.min(count, resultsToReturn.size()));
     }
     os.totalResults(resources.size());
-    if(startIndex != null || count != null)
+    if (startIndex != null || count != null)
     {
       os.startIndex(startIndex == null ? 1 : startIndex);
       os.itemsPerPage(resultsToReturn.size());
     }
-    for(ScimResource resource : resultsToReturn)
+    for (ScimResource resource : resultsToReturn)
     {
       os.resource((T) responsePreparer.trimRetrievedResource(resource));
     }

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/ETagTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/ETagTestCase.java
@@ -330,7 +330,7 @@ public class ETagTestCase extends JerseyTestNg.ContainerPerClassTest
       boolean shouldContainIfMatch, boolean shouldContainIfNoneMatch)
       throws ScimException
   {
-    if(shouldContainIfMatch)
+    if (shouldContainIfMatch)
     {
       List<String> ifMatchValues =
           resource.getStringValueList(HttpHeaders.IF_MATCH);
@@ -343,7 +343,7 @@ public class ETagTestCase extends JerseyTestNg.ContainerPerClassTest
           path(HttpHeaders.IF_MATCH).isMissingNode());
     }
 
-    if(shouldContainIfNoneMatch)
+    if (shouldContainIfNoneMatch)
     {
       List<String> ifNoneMatchValues =
           resource.getStringValueList(HttpHeaders.IF_NONE_MATCH);

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/ETagTestEndpoint.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/ETagTestEndpoint.java
@@ -200,13 +200,13 @@ public class ETagTestEndpoint
       throws ScimException
   {
     GenericScimResource gsr = new GenericScimResource();
-    if(headers.getRequestHeaders().containsKey(HttpHeaders.IF_NONE_MATCH))
+    if (headers.getRequestHeaders().containsKey(HttpHeaders.IF_NONE_MATCH))
     {
       gsr.addStringValues(HttpHeaders.IF_NONE_MATCH,
           headers.getRequestHeader(HttpHeaders.IF_NONE_MATCH));
     }
 
-    if(headers.getRequestHeaders().containsKey(HttpHeaders.IF_MATCH))
+    if (headers.getRequestHeaders().containsKey(HttpHeaders.IF_MATCH))
     {
       gsr.addStringValues(HttpHeaders.IF_MATCH,
           headers.getRequestHeader(HttpHeaders.IF_MATCH));

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
@@ -235,7 +235,7 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
       new ScimService(target()).retrieve("badPath", "id", UserResource.class);
       fail();
     }
-    catch(ScimException e)
+    catch (ScimException e)
     {
       assertTrue(e instanceof ResourceNotFoundException);
     }
@@ -488,7 +488,7 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
       scimService.retrieve(subResourceUri.build(), UserResource.class);
       fail("Sub-resource should not exist");
     }
-    catch(ScimException e)
+    catch (ScimException e)
     {
       // Expected.
     }
@@ -520,7 +520,7 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
     assertNull(user.getNickName());
 
     user = scimService.retrieveRequest(ScimService.ME_URI).
-        attributes("nickName","Meta").invoke(UserResource.class);
+        attributes("nickName", "Meta").invoke(UserResource.class);
     assertEquals(user.getId(), "123");
     assertEquals(user.getMeta().getResourceType(), "User");
     assertNull(user.getDisplayName());
@@ -593,7 +593,7 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
       scimService.retrieve(createdUser);
       fail("Resource should have been deleted");
     }
-    catch(ResourceNotFoundException e)
+    catch (ResourceNotFoundException e)
     {
       // expected
     }
@@ -945,7 +945,7 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
             invoke(UserResource.class);
         fail("Expected BadRequestException");
       }
-      catch(BadRequestException e)
+      catch (BadRequestException e)
       {
         // Expected.
       }
@@ -1033,7 +1033,7 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
             invoke(UserResource.class);
         fail("Expected BadRequestException");
       }
-      catch(BadRequestException e)
+      catch (BadRequestException e)
       {
         // Expected.
       }
@@ -1139,7 +1139,7 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
           new GenericScimResource());
       Assert.fail("Expecting a ScimServiceException");
     }
-    catch(ScimServiceException ex)
+    catch (ScimServiceException ex)
     {
       ErrorResponse response = ex.getScimError();
       Assert.assertNotNull(response);
@@ -1157,7 +1157,7 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
           .invoke(GenericScimResource.class);
       Assert.fail("Expecting a ScimServiceException");
     }
-    catch(ScimServiceException ex)
+    catch (ScimServiceException ex)
     {
       ErrorResponse response = ex.getScimError();
       Assert.assertNotNull(response);
@@ -1184,7 +1184,7 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
       service.create("Users/schema", new GenericScimResource());
       Assert.fail("Expecting a MethodNotFoundException");
     }
-    catch(MethodNotAllowedException ex)
+    catch (MethodNotAllowedException ex)
     {
       ErrorResponse response = ex.getScimError();
       Assert.assertEquals(response.getStatus(), Integer.valueOf(405));
@@ -1243,7 +1243,7 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
           invoke(byte[].class));
       Assert.fail("Expected illegal argument exception");
     }
-    catch(IllegalArgumentException ex)
+    catch (IllegalArgumentException ex)
     {
       // Expected.  Ignore.
     }
@@ -1254,7 +1254,7 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
           invoke(byte[].class));
       Assert.fail("Expected illegal argument exception");
     }
-    catch(IllegalArgumentException ex)
+    catch (IllegalArgumentException ex)
     {
       // Expected.  Ignore.
     }
@@ -1269,13 +1269,13 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
     UriBuilder locationBuilder =
         UriBuilder.fromUri(getBaseUri()).path(
             resourceType.getEndpoint().getPath());
-    if(scimResource.getId() != null)
+    if (scimResource.getId() != null)
     {
       locationBuilder.path(scimResource.getId());
     }
 
     Meta meta = scimResource.getMeta();
-    if(meta == null)
+    if (meta == null)
     {
       meta = new Meta();
       scimResource.setMeta(meta);
@@ -1286,9 +1286,9 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
 
   private <T> boolean contains(Iterable<T> list, T resource)
   {
-    for(T r : list)
+    for (T r : list)
     {
-      if(r.equals(resource))
+      if (r.equals(resource))
       {
         return true;
       }

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestRequestFilter.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestRequestFilter.java
@@ -102,16 +102,16 @@ class TestRequestFilter implements ContainerRequestFilter
                                MultivaluedMap<String, String> expected,
                                boolean isCommaDelimited)
   {
-    if(!expected.isEmpty())
+    if (!expected.isEmpty())
     {
-      for(Map.Entry<String, List<String>> expectedEntry : expected.entrySet())
+      for (Map.Entry<String, List<String>> expectedEntry : expected.entrySet())
       {
         List<String> actualEntry = actual.get(expectedEntry.getKey());
-        if(actualEntry != null && !actualEntry.isEmpty())
+        if (actualEntry != null && !actualEntry.isEmpty())
         {
           List<String> actualValues;
           // Checking a header.
-          if(isCommaDelimited)
+          if (isCommaDelimited)
           {
             actualValues =
                 Arrays.asList(StaticUtils.splitCommaSeparatedString(
@@ -122,7 +122,7 @@ class TestRequestFilter implements ContainerRequestFilter
           {
             actualValues = actual.get(expectedEntry.getKey());
           }
-          if(actualValues.containsAll(expectedEntry.getValue()))
+          if (actualValues.containsAll(expectedEntry.getValue()))
           {
             continue;
           }

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestResourceEndpoint.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestResourceEndpoint.java
@@ -136,7 +136,7 @@ public class TestResourceEndpoint
       @PathParam("id") final String id, @Context final UriInfo uriInfo)
       throws ScimException
   {
-    if(id.equals("123"))
+    if (id.equals("123"))
     {
       UserResource resource = new UserResource().setUserName("test");
       resource.setId("123");

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestSingletonResourceEndpoint.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestSingletonResourceEndpoint.java
@@ -101,7 +101,7 @@ public class TestSingletonResourceEndpoint
       throws ScimException
   {
     UserResource found = users.get(id);
-    if(found == null)
+    if (found == null)
     {
       throw new ResourceNotFoundException("No resource with ID " + id);
     }
@@ -145,7 +145,7 @@ public class TestSingletonResourceEndpoint
   public void delete(@PathParam("id") final String id) throws ScimException
   {
     UserResource found = users.remove(id);
-    if(found == null)
+    if (found == null)
     {
       throw new ResourceNotFoundException("No resource with ID " + id);
     }
@@ -169,7 +169,7 @@ public class TestSingletonResourceEndpoint
                               @Context final UriInfo uriInfo)
       throws ScimException
   {
-    if(!users.containsKey(id))
+    if (!users.containsKey(id))
     {
       throw new ResourceNotFoundException("No resource with ID " + id);
     }
@@ -198,12 +198,12 @@ public class TestSingletonResourceEndpoint
       throws ScimException
   {
     UserResource found = users.get(id);
-    if(found == null)
+    if (found == null)
     {
       throw new ResourceNotFoundException("No resource with ID " + id);
     }
     ObjectNode node = JsonUtils.valueToNode(found);
-    for(PatchOperation operation : patchRequest)
+    for (PatchOperation operation : patchRequest)
     {
       operation.apply(node);
     }

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/ResourcePreparerTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/ResourcePreparerTestCase.java
@@ -242,9 +242,9 @@ public class ResourcePreparerTestCase
 
     GenericScimResource prepared = preparer.trimRetrievedResource(testResource);
     assertTrue(prepared.getObjectNode().has("always"));
-    ObjectNode innerNode = (ObjectNode)prepared.getObjectNode().get("always");
+    ObjectNode innerNode = (ObjectNode) prepared.getObjectNode().get("always");
     assertTrue(innerNode.has("always"));
-    if(excludedAttributes != null &&
+    if (excludedAttributes != null &&
         excludedAttributes.equalsIgnoreCase("always.default"))
     {
       assertFalse(innerNode.has("default"));
@@ -253,7 +253,7 @@ public class ResourcePreparerTestCase
 
     assertFalse(prepared.getObjectNode().has("never"));
 
-    if((attributes == null && excludedAttributes == null) ||
+    if ((attributes == null && excludedAttributes == null) ||
         (excludedAttributes != null &&
             !excludedAttributes.equalsIgnoreCase("urn:test:default") &&
             !excludedAttributes.equalsIgnoreCase("default.default")) ||
@@ -262,13 +262,13 @@ public class ResourcePreparerTestCase
                 attributes.equalsIgnoreCase("default.default"))))
     {
       assertTrue(prepared.getObjectNode().has("default"));
-      if(attributes != null && attributes.equalsIgnoreCase("default.default"))
+      if (attributes != null && attributes.equalsIgnoreCase("default.default"))
       {
         // Only the requested default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
         assertFalse(prepared.getObjectNode().get("default").has("notDeclared"));
       }
-      if(attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
+      if (attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
       {
         // All default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
@@ -291,10 +291,10 @@ public class ResourcePreparerTestCase
       }
     }
 
-    if(attributes != null && attributes.equalsIgnoreCase("request"))
+    if (attributes != null && attributes.equalsIgnoreCase("request"))
     {
       assertTrue(prepared.getObjectNode().has("request"));
-      innerNode = (ObjectNode)prepared.getObjectNode().get("request");
+      innerNode = (ObjectNode) prepared.getObjectNode().get("request");
       assertTrue(innerNode.has("always"));
       assertFalse(innerNode.has("never"));
       assertTrue(innerNode.has("request"), prepared.toString());
@@ -305,10 +305,10 @@ public class ResourcePreparerTestCase
     }
 
     assertTrue(prepared.getObjectNode().has("urn:ext:1"));
-    ObjectNode extNode = (ObjectNode)prepared.getObjectNode().get("urn:ext:1");
+    ObjectNode extNode = (ObjectNode) prepared.getObjectNode().get("urn:ext:1");
     assertTrue(extNode.has("always"));
     assertFalse(extNode.has("never"));
-    if((attributes == null && excludedAttributes == null) ||
+    if ((attributes == null && excludedAttributes == null) ||
         (excludedAttributes != null &&
             !excludedAttributes.equalsIgnoreCase("urn:ext:1:default")) ||
         (attributes != null &&
@@ -320,7 +320,7 @@ public class ResourcePreparerTestCase
     {
       assertFalse(extNode.has("default"));
     }
-    if(attributes != null && attributes.equalsIgnoreCase("urn:ext:1:request"))
+    if (attributes != null && attributes.equalsIgnoreCase("urn:ext:1:request"))
     {
       assertTrue(extNode.has("request"));
     }
@@ -350,13 +350,13 @@ public class ResourcePreparerTestCase
     GenericScimResource prepared =
         preparer.trimCreatedResource(testResource, null);
     assertTrue(prepared.getObjectNode().has("always"));
-    if(excludedAttributes != null &&
+    if (excludedAttributes != null &&
         excludedAttributes.equalsIgnoreCase("always.default"))
     {
       assertFalse(prepared.getObjectNode().get("always").has("default"));
     }
     assertFalse(prepared.getObjectNode().has("never"));
-    if((attributes == null && excludedAttributes == null) ||
+    if ((attributes == null && excludedAttributes == null) ||
         (excludedAttributes != null &&
             !excludedAttributes.equalsIgnoreCase("urn:test:default") &&
             !excludedAttributes.equalsIgnoreCase("default.default")) ||
@@ -365,13 +365,13 @@ public class ResourcePreparerTestCase
                 attributes.equalsIgnoreCase("default.default"))))
     {
       assertTrue(prepared.getObjectNode().has("default"));
-      if(attributes != null && attributes.equalsIgnoreCase("default.default"))
+      if (attributes != null && attributes.equalsIgnoreCase("default.default"))
       {
         // Only the requested default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
         assertFalse(prepared.getObjectNode().get("default").has("notDeclared"));
       }
-      if(attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
+      if (attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
       {
         // All default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
@@ -394,7 +394,7 @@ public class ResourcePreparerTestCase
       }
     }
 
-    if(attributes != null && attributes.equalsIgnoreCase("request"))
+    if (attributes != null && attributes.equalsIgnoreCase("request"))
     {
       assertTrue(prepared.getObjectNode().has("request"));
     }
@@ -405,13 +405,13 @@ public class ResourcePreparerTestCase
 
     prepared = preparer.trimCreatedResource(testResource, testResource);
     assertTrue(prepared.getObjectNode().has("always"));
-    if(excludedAttributes != null &&
+    if (excludedAttributes != null &&
         excludedAttributes.equalsIgnoreCase("always.default"))
     {
       assertFalse(prepared.getObjectNode().get("always").has("default"));
     }
     assertFalse(prepared.getObjectNode().has("never"));
-    if((attributes == null && excludedAttributes == null) ||
+    if ((attributes == null && excludedAttributes == null) ||
         (excludedAttributes != null &&
             !excludedAttributes.equalsIgnoreCase("urn:test:default") &&
             !excludedAttributes.equalsIgnoreCase("default.default")) ||
@@ -420,13 +420,13 @@ public class ResourcePreparerTestCase
                 attributes.equalsIgnoreCase("default.default"))))
     {
       assertTrue(prepared.getObjectNode().has("default"));
-      if(attributes != null && attributes.equalsIgnoreCase("default.default"))
+      if (attributes != null && attributes.equalsIgnoreCase("default.default"))
       {
         // Only the requested default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
         assertFalse(prepared.getObjectNode().get("default").has("notDeclared"));
       }
-      if(attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
+      if (attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
       {
         // All default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
@@ -469,13 +469,13 @@ public class ResourcePreparerTestCase
     GenericScimResource prepared =
         preparer.trimReplacedResource(testResource, null);
     assertTrue(prepared.getObjectNode().has("always"));
-    if(excludedAttributes != null &&
+    if (excludedAttributes != null &&
         excludedAttributes.equalsIgnoreCase("always.default"))
     {
       assertFalse(prepared.getObjectNode().get("always").has("default"));
     }
     assertFalse(prepared.getObjectNode().has("never"));
-    if((attributes == null && excludedAttributes == null) ||
+    if ((attributes == null && excludedAttributes == null) ||
         (excludedAttributes != null &&
             !excludedAttributes.equalsIgnoreCase("urn:test:default") &&
             !excludedAttributes.equalsIgnoreCase("default.default")) ||
@@ -484,13 +484,13 @@ public class ResourcePreparerTestCase
                 attributes.equalsIgnoreCase("default.default"))))
     {
       assertTrue(prepared.getObjectNode().has("default"));
-      if(attributes != null && attributes.equalsIgnoreCase("default.default"))
+      if (attributes != null && attributes.equalsIgnoreCase("default.default"))
       {
         // Only the requested default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
         assertFalse(prepared.getObjectNode().get("default").has("notDeclared"));
       }
-      if(attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
+      if (attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
       {
         // All default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
@@ -512,7 +512,7 @@ public class ResourcePreparerTestCase
         assertFalse(prepared.getObjectNode().has("default"));
       }
     }
-    if(attributes != null && attributes.equalsIgnoreCase("request"))
+    if (attributes != null && attributes.equalsIgnoreCase("request"))
     {
       assertTrue(prepared.getObjectNode().has("request"));
     }
@@ -523,13 +523,13 @@ public class ResourcePreparerTestCase
 
     prepared = preparer.trimReplacedResource(testResource, testResource);
     assertTrue(prepared.getObjectNode().has("always"));
-    if(excludedAttributes != null &&
+    if (excludedAttributes != null &&
         excludedAttributes.equalsIgnoreCase("always.default"))
     {
       assertFalse(prepared.getObjectNode().get("always").has("default"));
     }
     assertFalse(prepared.getObjectNode().has("never"));
-    if((attributes == null && excludedAttributes == null) ||
+    if ((attributes == null && excludedAttributes == null) ||
         (excludedAttributes != null &&
             !excludedAttributes.equalsIgnoreCase("urn:test:default") &&
             !excludedAttributes.equalsIgnoreCase("default.default")) ||
@@ -538,13 +538,13 @@ public class ResourcePreparerTestCase
                 attributes.equalsIgnoreCase("default.default"))))
     {
       assertTrue(prepared.getObjectNode().has("default"));
-      if(attributes != null && attributes.equalsIgnoreCase("default.default"))
+      if (attributes != null && attributes.equalsIgnoreCase("default.default"))
       {
         // Only the requested default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
         assertFalse(prepared.getObjectNode().get("default").has("notDeclared"));
       }
-      if(attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
+      if (attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
       {
         // All default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
@@ -589,13 +589,13 @@ public class ResourcePreparerTestCase
     GenericScimResource prepared =
         preparer.trimModifiedResource(testResource, null);
     assertTrue(prepared.getObjectNode().has("always"));
-    if(excludedAttributes != null &&
+    if (excludedAttributes != null &&
         excludedAttributes.equalsIgnoreCase("always.default"))
     {
       assertFalse(prepared.getObjectNode().get("always").has("default"));
     }
     assertFalse(prepared.getObjectNode().has("never"));
-    if((attributes == null && excludedAttributes == null) ||
+    if ((attributes == null && excludedAttributes == null) ||
         (excludedAttributes != null &&
             !excludedAttributes.equalsIgnoreCase("urn:test:default") &&
             !excludedAttributes.equalsIgnoreCase("default.default")) ||
@@ -604,13 +604,13 @@ public class ResourcePreparerTestCase
                 attributes.equalsIgnoreCase("default.default"))))
     {
       assertTrue(prepared.getObjectNode().has("default"));
-      if(attributes != null && attributes.equalsIgnoreCase("default.default"))
+      if (attributes != null && attributes.equalsIgnoreCase("default.default"))
       {
         // Only the requested default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
         assertFalse(prepared.getObjectNode().get("default").has("notDeclared"));
       }
-      if(attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
+      if (attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
       {
         // All default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
@@ -632,7 +632,7 @@ public class ResourcePreparerTestCase
         assertFalse(prepared.getObjectNode().has("default"));
       }
     }
-    if(attributes != null && attributes.equalsIgnoreCase("request"))
+    if (attributes != null && attributes.equalsIgnoreCase("request"))
     {
       assertTrue(prepared.getObjectNode().has("request"));
     }
@@ -643,13 +643,13 @@ public class ResourcePreparerTestCase
 
     prepared = preparer.trimModifiedResource(testResource, testPatch);
     assertTrue(prepared.getObjectNode().has("always"));
-    if(excludedAttributes != null &&
+    if (excludedAttributes != null &&
         excludedAttributes.equalsIgnoreCase("always.default"))
     {
       assertFalse(prepared.getObjectNode().get("always").has("default"));
     }
     assertFalse(prepared.getObjectNode().has("never"));
-    if((attributes == null && excludedAttributes == null) ||
+    if ((attributes == null && excludedAttributes == null) ||
         (excludedAttributes != null &&
             !excludedAttributes.equalsIgnoreCase("urn:test:default") &&
             !excludedAttributes.equalsIgnoreCase("default.default")) ||
@@ -658,13 +658,13 @@ public class ResourcePreparerTestCase
                 attributes.equalsIgnoreCase("default.default"))))
     {
       assertTrue(prepared.getObjectNode().has("default"));
-      if(attributes != null && attributes.equalsIgnoreCase("default.default"))
+      if (attributes != null && attributes.equalsIgnoreCase("default.default"))
       {
         // Only the requested default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));
         assertFalse(prepared.getObjectNode().get("default").has("notDeclared"));
       }
-      if(attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
+      if (attributes != null && attributes.equalsIgnoreCase("urn:test:default"))
       {
         // All default returned sub-attribute should be included
         assertTrue(prepared.getObjectNode().get("default").has("default"));

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaCheckerTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaCheckerTestCase.java
@@ -988,7 +988,7 @@ public class SchemaCheckerTestCase
         results.getSyntaxIssues().toString());
 
     // Can't remove required attributes in patch
-    if(attributeDefinition.isRequired())
+    if (attributeDefinition.isRequired())
     {
       // Check for case insensitive behavior
       results = checker.checkModify(Collections.singleton(
@@ -996,7 +996,7 @@ public class SchemaCheckerTestCase
       assertEquals(results.getSyntaxIssues().size(), 1,
           results.getSyntaxIssues().toString());
     }
-    if(attributeDefinition.getSubAttributes() != null &&
+    if (attributeDefinition.getSubAttributes() != null &&
         attributeDefinition.getSubAttributes().iterator().next().isRequired())
     {
       results = checker.checkModify(Collections.singleton(
@@ -1044,7 +1044,7 @@ public class SchemaCheckerTestCase
                             PatchOperation.replace(
                                     Path.root().attribute(
                                             "mvstring",
-                                            Filter.eq("value","value3")
+                                            Filter.eq("value", "value3")
                                     ),
                                     "replacedValue4"
                             )
@@ -1058,7 +1058,7 @@ public class SchemaCheckerTestCase
     results = checker.checkModify(
             Collections.singleton(PatchOperation.remove(
                     Path.root().attribute("mvstring",
-                            Filter.eq("value","value1")))),
+                            Filter.eq("value", "value1")))),
             null);
     assertEquals(results.getFilterIssues().size(), 0,
                  Arrays.toString(results.getFilterIssues().toArray(
@@ -1806,7 +1806,7 @@ public class SchemaCheckerTestCase
         results.getSyntaxIssues().toString());
     assertTrue(containsIssueWith(results.getSyntaxIssues(), "Value"));
 
-    if(!((node.isArray() || node.isObject()) && node.size() == 0))
+    if (!((node.isArray() || node.isObject()) && node.size() == 0))
     {
       // Partial patch
       results = checker.checkModify(Collections.singleton(
@@ -1844,7 +1844,7 @@ public class SchemaCheckerTestCase
     }
 
     // Then test a an sub-attribute
-    if(!field.equals("complex"))
+    if (!field.equals("complex"))
     {
       o = JsonUtils.getJsonNodeFactory().objectNode();
       o.putArray("schemas").add("urn:id:test");
@@ -1854,7 +1854,7 @@ public class SchemaCheckerTestCase
           results.getSyntaxIssues().toString());
       assertTrue(containsIssueWith(results.getSyntaxIssues(), "Value"));
 
-      if(!((node.isArray() || node.isObject()) && node.size() == 0))
+      if (!((node.isArray() || node.isObject()) && node.size() == 0))
       {
         // Partial patch
         results = checker.checkModify(Collections.singleton(
@@ -1887,7 +1887,7 @@ public class SchemaCheckerTestCase
     }
 
     // Then test as a single-value for multi-valued attributes
-    if(!node.isArray())
+    if (!node.isArray())
     {
       o = JsonUtils.getJsonNodeFactory().objectNode();
       o.putArray("schemas").add("urn:id:test");
@@ -1897,7 +1897,7 @@ public class SchemaCheckerTestCase
           results.getSyntaxIssues().toString());
       assertTrue(containsIssueWith(results.getSyntaxIssues(), "Value"));
 
-      if(!((node.isArray() || node.isObject()) && node.size() == 0))
+      if (!((node.isArray() || node.isObject()) && node.size() == 0))
       {
         // Partial patch
         results = checker.checkModify(Collections.singleton(
@@ -1937,7 +1937,7 @@ public class SchemaCheckerTestCase
         results.getSyntaxIssues().toString());
     assertTrue(containsIssueWith(results.getSyntaxIssues(), "Value"));
 
-    if(!((node.isArray() || node.isObject()) && node.size() == 0))
+    if (!((node.isArray() || node.isObject()) && node.size() == 0))
     {
       // Partial patch
       results = checker.checkModify(Collections.singleton(
@@ -1970,7 +1970,7 @@ public class SchemaCheckerTestCase
     }
 
     // Finally test as a sub-attribute of a multi-valued attribute
-    if(!field.equals("complex"))
+    if (!field.equals("complex"))
     {
       o = JsonUtils.getJsonNodeFactory().objectNode();
       o.putArray("schemas").add("urn:id:test");
@@ -1980,7 +1980,7 @@ public class SchemaCheckerTestCase
           results.getSyntaxIssues().toString());
       assertTrue(containsIssueWith(results.getSyntaxIssues(), "Value"));
 
-      if(!((node.isArray() || node.isObject()) && node.size() == 0))
+      if (!((node.isArray() || node.isObject()) && node.size() == 0))
       {
         // Partial patch
         results = checker.checkModify(Collections.singleton(
@@ -2235,7 +2235,7 @@ public class SchemaCheckerTestCase
     {
       results.throwSchemaExceptions();
     }
-    catch(BadRequestException ex)
+    catch (BadRequestException ex)
     {
       caughtException = ex;
       Assert.assertEquals(caughtException.getMessage(), expectedMsg);
@@ -2317,9 +2317,9 @@ public class SchemaCheckerTestCase
 
   private boolean containsIssueWith(Collection<String> issues, String issueText)
   {
-    for(String issue: issues)
+    for (String issue: issues)
     {
-      if(issue.contains(issueText))
+      if (issue.contains(issueText))
       {
         return true;
       }


### PR DESCRIPTION
This commit updates the spacing in the project to utilize consistent patterns, such as the use of a space after Java keywords such as 'if', 'for', etc.

These changes will appear in the GitHub blame history, but will not be seen within IDEs like InteeliJ that utilize
'git blame --ignore-all-space'.

Reviewer: vyhhuang