### PR TITLE
Update default behavior for PATCH ADDs with filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## v3.2.1 - TBD
+## v4.0.0 - TBD
+Updated the default behavior for ADD patch requests with value filters (e.g.,
+`emails[type eq "work"].display`). The SCIM SDK will now target existing values within the
+multi-valued attribute. For more background on this type of patch request, see the release notes for
+the 3.2.0 release where this was introduced (but not made the default). To restore the old behavior,
+set the following property in your application:
+```
+PatchOperation.APPEND_NEW_PATCH_VALUES_PROPERTY = true;
+```
 
 ## v3.2.0 - 2024-Dec-04
 Fixed an issue where `AndFilter.equals()` and `OrFilter.equals()` could incorrectly evaluate to

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.unboundid.product.scim2</groupId>
   <artifactId>scim2-parent</artifactId>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>UnboundID SCIM2 SDK Parent</name>
   <description>

--- a/scim2-assembly/pom.xml
+++ b/scim2-assembly/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-assembly</artifactId>
   <packaging>pom</packaging>

--- a/scim2-sdk-client/pom.xml
+++ b/scim2-sdk-client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>scim2-sdk-client</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-common/pom.xml
+++ b/scim2-sdk-common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>scim2-sdk-common</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/AddOperationValueFilterTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/AddOperationValueFilterTestCase.java
@@ -49,7 +49,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *     "value": "sissel@example.com"
  *   }
  * </pre>
+ *
+ * For more background on this type of patch operation, see the Javadoc for
+ * {@link PatchOperation.AddOperation#applyAddWithValueFilter}.
  */
+@SuppressWarnings("JavadocReference")
 public class AddOperationValueFilterTestCase
 {
   /**
@@ -58,7 +62,7 @@ public class AddOperationValueFilterTestCase
   @AfterMethod
   public void tearDown()
   {
-    PatchOperation.APPEND_NEW_PATCH_VALUES_PROPERTY = true;
+    PatchOperation.APPEND_NEW_PATCH_VALUES_PROPERTY = false;
   }
 
   /**
@@ -106,9 +110,6 @@ public class AddOperationValueFilterTestCase
     Path path;
     PatchRequest request;
     UserResource resource = new UserResource();
-
-    // Unset the property to use the new behavior.
-    PatchOperation.APPEND_NEW_PATCH_VALUES_PROPERTY = false;
 
     // Add a work email to a list of existing emails.
     resource.setEmails(

--- a/scim2-sdk-server/pom.xml
+++ b/scim2-sdk-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-sdk-server</artifactId>
   <packaging>jar</packaging>

--- a/scim2-ubid-extensions/pom.xml
+++ b/scim2-ubid-extensions/pom.xml
@@ -19,7 +19,7 @@
   <parent>
       <artifactId>scim2-parent</artifactId>
       <groupId>com.unboundid.product.scim2</groupId>
-      <version>3.2.1-SNAPSHOT</version>
+      <version>4.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-ubid-extensions</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
In the 3.2.0 release, we updated the SCIM SDK so that add operations with a filter could target existing values on the resource via a configurable property on the PatchOperation class. This is more appropriate than the previous behavior, but was not made the default.

This commit updates the SDK to target existing values by default. The project version has been updated to 4.0.0-SNAPSHOT signify this change.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-49617