### PR TITLE
Update StaticUtils#toLowerCase

### DIFF
--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StaticUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StaticUtils.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
@@ -59,100 +60,7 @@ public final class StaticUtils
       return null;
     }
 
-    final int length = s.length();
-    final char[] charArray = s.toCharArray();
-    for (int i=0; i < length; i++)
-    {
-      switch (charArray[i])
-      {
-        case 'A':
-          charArray[i] = 'a';
-          break;
-        case 'B':
-          charArray[i] = 'b';
-          break;
-        case 'C':
-          charArray[i] = 'c';
-          break;
-        case 'D':
-          charArray[i] = 'd';
-          break;
-        case 'E':
-          charArray[i] = 'e';
-          break;
-        case 'F':
-          charArray[i] = 'f';
-          break;
-        case 'G':
-          charArray[i] = 'g';
-          break;
-        case 'H':
-          charArray[i] = 'h';
-          break;
-        case 'I':
-          charArray[i] = 'i';
-          break;
-        case 'J':
-          charArray[i] = 'j';
-          break;
-        case 'K':
-          charArray[i] = 'k';
-          break;
-        case 'L':
-          charArray[i] = 'l';
-          break;
-        case 'M':
-          charArray[i] = 'm';
-          break;
-        case 'N':
-          charArray[i] = 'n';
-          break;
-        case 'O':
-          charArray[i] = 'o';
-          break;
-        case 'P':
-          charArray[i] = 'p';
-          break;
-        case 'Q':
-          charArray[i] = 'q';
-          break;
-        case 'R':
-          charArray[i] = 'r';
-          break;
-        case 'S':
-          charArray[i] = 's';
-          break;
-        case 'T':
-          charArray[i] = 't';
-          break;
-        case 'U':
-          charArray[i] = 'u';
-          break;
-        case 'V':
-          charArray[i] = 'v';
-          break;
-        case 'W':
-          charArray[i] = 'w';
-          break;
-        case 'X':
-          charArray[i] = 'x';
-          break;
-        case 'Y':
-          charArray[i] = 'y';
-          break;
-        case 'Z':
-          charArray[i] = 'z';
-          break;
-        default:
-          if (charArray[i] > 0x7F)
-          {
-            return s.toLowerCase();
-          }
-          break;
-      }
-    }
-
-    return new String(charArray);
+    return s.toLowerCase(Locale.ROOT);
   }
 
 

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/StaticUtilsTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/StaticUtilsTest.java
@@ -17,6 +17,7 @@
 
 package com.unboundid.scim2.common;
 
+import com.unboundid.scim2.common.utils.StaticUtils;
 import org.testng.annotations.Test;
 
 import static com.unboundid.scim2.common.utils.StaticUtils.splitCommaSeparatedString;
@@ -85,5 +86,24 @@ public class StaticUtilsTest
 
     assertThat(splitCommaSeparatedString("   value1 ,    , value3  "))
         .containsExactly("value1", "", "value3");
+  }
+
+  /**
+   * Basic test for {@link StaticUtils#toLowerCase} that ensures it can accept
+   * {@code null} inputs.
+   */
+  @Test
+  public void testToLowercase()
+  {
+    // A null input should not cause an exception.
+    //
+    // noinspection ConstantValue
+    assertThat(StaticUtils.toLowerCase(null)).isNull();
+
+    // These test cases are not extensive since the method is a wrapper around
+    // String#toLowerCase().
+    assertThat(StaticUtils.toLowerCase("lowerstring")).isEqualTo("lowerstring");
+    assertThat(StaticUtils.toLowerCase("sPoNgEbOb tExT"))
+        .isEqualTo("spongebob text");
   }
 }


### PR DESCRIPTION
The previous implementation of StaticUtils.toLowerCase() was optimized for ASCII characters. However, this no longer appears to provide a reasonable performance benefit in comparison to passing the call to the JDK. More background on this is available on Jira.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-49717