### PR TITLE
Update SearchRequestBuilder#invoke processing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ set the following property in your application:
 PatchOperation.APPEND_NEW_PATCH_VALUES_PROPERTY = true;
 ```
 
+Updated `SearchRequestBuilder` to be more permissive of ListResponses with non-standard attribute
+casing (e.g., if a response includes a `"resources"` array instead of `"Resources"`).
+
 ## v3.2.0 - 2024-Dec-04
 Fixed an issue where `AndFilter.equals()` and `OrFilter.equals()` could incorrectly evaluate to
 true.

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RequestBuilder.java
@@ -267,12 +267,11 @@ public class RequestBuilder<T extends RequestBuilder>
   Invocation.Builder buildRequest()
   {
     Invocation.Builder builder =
-        buildTarget().request(accept.toArray(new String[accept.size()]));
+        buildTarget().request(accept.toArray(new String[0]));
     for (Map.Entry<String, List<Object>> header : headers.entrySet())
     {
-      builder = builder.header(header.getKey(),
-                               StaticUtils.listToString(header.getValue(),
-                                                        ", "));
+      String stringValue = StaticUtils.listToString(header.getValue(), ", ");
+      builder = builder.header(header.getKey(), stringValue);
     }
     return builder;
   }

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ResourceReturningRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ResourceReturningRequestBuilder.java
@@ -37,7 +37,7 @@ public abstract class ResourceReturningRequestBuilder
   protected boolean excluded;
 
   /**
-   * The attribute list of include or exclude.
+   * The attribute list to include or exclude.
    */
   @Nullable
   protected Set<String> attributes;

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/SearchRequest.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/SearchRequest.java
@@ -23,14 +23,70 @@ import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.annotations.Schema;
 import com.unboundid.scim2.common.annotations.Attribute;
 import com.unboundid.scim2.common.BaseScimResource;
+import com.unboundid.scim2.common.filters.Filter;
 
 import java.util.Set;
 
 import static com.unboundid.scim2.common.utils.ApiConstants.*;
 
 /**
- * Class representing a SCIM 2 search request.
+ * This class represents a SCIM 2.0 search request.
+ * <br><br>
+ *
+ * A SCIM search involves requests to endpoints such as {@code /Users} or
+ * {@code /Groups}, where multiple results may be returned. When a client sends
+ * a search request, the HTTP response that they will receive from the SCIM
+ * service will be a {@link ListResponse}, which will provide a list of
+ * resources.
+ * <br><br>
+ *
+ * Search requests can include the following parameters to fine-tune the result
+ * set:
+ * <ul>
+ *   <li> {@code filter}: A SCIM {@link Filter} that requests specific resources
+ *        that match a given filter criteria.
+ *   <li> {@code attributes}: A set of values indicating which attributes
+ *        should be included in the response. For example, including "userName"
+ *        would ensure that the returned resources will only display the value
+ *        of the {@code userName} attribute. Note that the {@code id} attribute
+ *        is always returned.
+ *   <li> {@code excludedAttributes}: A set of values indicating attributes
+ *        that should not be included on the returned resources.
+ *   <li> {@code sortBy}: Indicates the attribute whose value should be used to
+ *         sort the resources, if the SCIM service supports sorting.
+ *   <li> {@code sortOrder}: The order that the {@code sortBy} parameter is
+ *        applied. This may be set to "ascending" (the default) or "descending".
+ *   <li> {@code startIndex}: The page number of the ListResponse, if the SCIM
+ *        service provider supports pagination.
+ *   <li> {@code count}: The maximum number of resources to return.
+ * </ul>
+ *
+ * Search requests can be issued in two ways: with GET requests or POST
+ * requests. A GET search request involves the use of HTTP query parameters,
+ * e.g.:
+ * <pre>
+ *   GET  https://example.com/v2/Users?filter=userName eq "K.Dot"
+ *
+ *   // Sometimes URLs must encode characters.
+ *   GET  https://example.com/v2/Users?filter=userName%20eq%20%K.Dot%22
+ * </pre>
+ *
+ * A POST search request is typically issued to an endpoint ending in
+ * {@code /.search}, e.g., {@code /Users/.search}. This allows clients to pass
+ * search criteria in a JSON body instead of passing them as query parameters.
+ * An example request is shown below:
+ * <pre>
+ *    POST https://example.com/v2/Users/.search
+ *
+ *    {
+ *      "schemas": [ "urn:ietf:params:scim:api:messages:2.0:SearchRequest" ],
+ *      "attributes": [ "userName", "displayName" ],
+ *      "filter": "userName eq \"K.Dot\"",
+ *      "count": 2
+ *    }
+ * </pre>
  */
+@SuppressWarnings("JavadocLinkAsPlainText")
 @Schema(id="urn:ietf:params:scim:api:messages:2.0:SearchRequest",
     name="Search Operation", description = "SCIM 2.0 Search Request")
 public final class SearchRequest extends BaseScimResource

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
@@ -86,6 +86,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.unboundid.scim2.common.utils.ApiConstants.MEDIA_TYPE_SCIM;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -1166,6 +1167,34 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
       Assert.assertEquals(ex.getMessage(), response.getDetail());
       Assert.assertEquals(response.getDetail(), "Unauthorized");
     }
+  }
+
+  /**
+   * This test validates the SDK's parsing of the ListResponse defined in
+   * {@link TestResourceEndpoint#testListResponseCaseSensitivity}.
+   */
+  @Test
+  public void testListResponseParsingCaseSensitivity() throws Exception
+  {
+    final ScimService service = new ScimService(target());
+    ListResponse<UserResource> response =
+        service.searchRequest("Users/testListResponseCaseSensitivity")
+        .invoke(UserResource.class);
+
+    // Even though the attribute casing is varied, all named fields should
+    // have been successfully parsed.
+    assertThat(response.getSchemaUrns())
+        .hasSize(1)
+        .first()
+        .isEqualTo("urn:ietf:params:scim:api:messages:2.0:ListResponse");
+    assertThat(response.getTotalResults()).isEqualTo(2);
+    assertThat(response.getItemsPerPage()).isEqualTo(1);
+    assertThat(response.getResources())
+        .hasSize(1)
+        .first().isEqualTo(new UserResource().setUserName("k.dot"));
+
+    // startIndex was not included, so it should not have a value.
+    assertThat(response.getStartIndex()).isNull();
   }
 
 

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestResourceEndpoint.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestResourceEndpoint.java
@@ -39,7 +39,10 @@ import jakarta.ws.rs.core.UriInfo;
 import static com.unboundid.scim2.common.utils.ApiConstants.MEDIA_TYPE_SCIM;
 
 /**
- * A per resource life cycle Resource Endpoint implementation.
+ * This class is used in conjunction with the {@link EndpointTestCase} to test
+ * response handling (e.g., ensuring that a specific exception is thrown for a
+ * particular HTTP error code). Each endpoint defined in this file allows
+ * specific behavior to be triggered easily.
  */
 @ResourceType(
     description = "User Account",
@@ -148,5 +151,33 @@ public class TestResourceEndpoint
       return resourcePreparer.trimRetrievedResource(resource);
     }
     throw new ResourceNotFoundException("No resource with ID " + id);
+  }
+
+  /**
+   * An example response of unconventional attribute casing in a ListResponse.
+   * This tests the parsing logic in
+   * {@link com.unboundid.scim2.client.requests.SearchRequestBuilder}.
+   *
+   * @return  A response to test.
+   */
+  @GET
+  @Path("testListResponseCaseSensitivity")
+  @Produces({MEDIA_TYPE_SCIM, MediaType.APPLICATION_JSON})
+  public Response testListResponseCaseSensitivity()
+  {
+    return Response.status(Response.Status.OK)
+        .type(MEDIA_TYPE_SCIM)
+        .entity("{ "
+            + "  \"SCHEMAS\": ["
+            + "    \"urn:ietf:params:scim:api:messages:2.0:ListResponse\""
+            + "  ],"
+            + "  \"tOtAlReSuLtS\": 2,"
+            + "  \"ItemsPerPage\": 1,"
+            + "  \"resources\": ["
+            + "    {"
+            + "      \"userName\": \"k.dot\""
+            + "    }"
+            + "  ]"
+            + "}").build();
   }
 }


### PR DESCRIPTION
This commit updates the SearchRequestBuilder's parsing of ListResponses returned from SCIM services to be permissive of improperly-cased attributes in the response (e.g., "resources" instead of "Resources"). This is intended to broaden compatibility.

This change includes:
* Documentation updates to give more information about SearchRequests.
* Simplify the invoke() logic by including try-with-resources blocks.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-49756

Resolves #97 
Resolves #150 