### PR TITLE
Fix curly brace usages.

### DIFF
--- a/config/scim2-parent-checkstyle.xml
+++ b/config/scim2-parent-checkstyle.xml
@@ -110,6 +110,23 @@
     <module name="NeedBraces" />
 
 
+    <!-- Check for a newline before all curly braces, except for lambdas. -->
+    <module name="LeftCurly">
+      <property name="option" value="nl"/>
+      <property name="tokens"
+                value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                       INTERFACE_DEF, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT, LITERAL_DO,
+                       LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_SWITCH,
+                       LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF, OBJBLOCK,
+                       STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+
+
+    <module name="RightCurly">
+      <property name="option" value="alone"/>
+    </module>
+
+
     <!-- Ensure that any class containing an equals method includes an
          equals(Object) method. -->
     <module name="CovariantEquals" />

--- a/config/scim2-parent-unit-checkstyle.xml
+++ b/config/scim2-parent-unit-checkstyle.xml
@@ -107,6 +107,23 @@
     <module name="NeedBraces" />
 
 
+    <!-- Check for a newline before all curly braces, except for lambdas. -->
+    <module name="LeftCurly">
+      <property name="option" value="nl"/>
+      <property name="tokens"
+                value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                       INTERFACE_DEF, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT, LITERAL_DO,
+                       LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_SWITCH,
+                       LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF, OBJBLOCK,
+                       STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+
+
+    <module name="RightCurly">
+      <property name="option" value="alone"/>
+    </module>
+
+
     <!-- Ensure that any class containing an equals method includes an
          equals(Object) method. -->
     <module name="CovariantEquals" />

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/FilterEvaluator.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/FilterEvaluator.java
@@ -450,7 +450,8 @@ public class FilterEvaluator implements FilterVisitor<Boolean, JsonNode>
     if (node.isArray())
     {
       Iterator<JsonNode> iterator = node.elements();
-      while (iterator.hasNext()) {
+      while (iterator.hasNext())
+      {
         if (!isEmpty(iterator.next()))
         {
           return false;
@@ -473,8 +474,10 @@ public class FilterEvaluator implements FilterVisitor<Boolean, JsonNode>
    */
   private boolean isEmpty(@NotNull final Iterable<JsonNode> nodes)
   {
-    for (JsonNode node : nodes) {
-      if (!isEmpty(node)) {
+    for (JsonNode node : nodes)
+    {
+      if (!isEmpty(node))
+      {
         return false;
       }
     }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
@@ -531,7 +531,8 @@ public class JsonUtils
         {
           setPathPresent();
         }
-      } else if (! node.isMissingNode())
+      }
+      else if (! node.isMissingNode())
       {
         setPathPresent();
       }
@@ -1130,7 +1131,8 @@ public class JsonUtils
     {
       return SDK_OBJECT_MAPPER.readValue(
           SDK_OBJECT_MAPPER.treeAsTokens(fromNode), collectionType);
-    } catch (JsonProcessingException e)
+    }
+    catch (JsonProcessingException e)
     {
       throw e;
     }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
@@ -710,42 +710,43 @@ public class Parser
                 "Unexpected end of filter string");
           }
 
-          if (op.equalsIgnoreCase(FilterType.EQUAL.getStringValue()))
+          if (equalsIgnoreCase(op, FilterType.EQUAL))
           {
             outputStack.push(Filter.eq(filterAttribute, valueNode));
-          } else if (op.equalsIgnoreCase(
-              FilterType.NOT_EQUAL.getStringValue()))
+          }
+          else if (equalsIgnoreCase(op, FilterType.NOT_EQUAL))
           {
             outputStack.push(Filter.ne(filterAttribute, valueNode));
-          } else if (op.equalsIgnoreCase(
-              FilterType.CONTAINS.getStringValue()))
+          }
+          else if (equalsIgnoreCase(op, FilterType.CONTAINS))
           {
             outputStack.push(Filter.co(filterAttribute, valueNode));
-          } else if (op.equalsIgnoreCase(
-              FilterType.STARTS_WITH.getStringValue()))
+          }
+          else if (equalsIgnoreCase(op, FilterType.STARTS_WITH))
           {
             outputStack.push(Filter.sw(filterAttribute, valueNode));
-          } else if (op.equalsIgnoreCase(
-              FilterType.ENDS_WITH.getStringValue()))
+          }
+          else if (equalsIgnoreCase(op, FilterType.ENDS_WITH))
           {
             outputStack.push(Filter.ew(filterAttribute, valueNode));
-          } else if (op.equalsIgnoreCase(
-              FilterType.GREATER_THAN.getStringValue()))
+          }
+          else if (equalsIgnoreCase(op, FilterType.GREATER_THAN))
           {
             outputStack.push(Filter.gt(filterAttribute, valueNode));
-          } else if (op.equalsIgnoreCase(
-              FilterType.GREATER_OR_EQUAL.getStringValue()))
+          }
+          else if (equalsIgnoreCase(op, FilterType.GREATER_OR_EQUAL))
           {
             outputStack.push(Filter.ge(filterAttribute, valueNode));
-          } else if (op.equalsIgnoreCase(
-              FilterType.LESS_THAN.getStringValue()))
+          }
+          else if (equalsIgnoreCase(op, FilterType.LESS_THAN))
           {
             outputStack.push(Filter.lt(filterAttribute, valueNode));
-          } else if (op.equalsIgnoreCase(
-              FilterType.LESS_OR_EQUAL.getStringValue()))
+          }
+          else if (equalsIgnoreCase(op, FilterType.LESS_OR_EQUAL))
           {
             outputStack.push(Filter.le(filterAttribute, valueNode));
-          } else
+          }
+          else
           {
             final String msg = String.format(
                 "Unrecognized attribute operator '%s' at position %d. " +
@@ -873,5 +874,15 @@ public class Parser
         previousToken.equalsIgnoreCase(FilterType.NOT.getStringValue()) ||
         previousToken.equalsIgnoreCase(FilterType.AND.getStringValue()) ||
         previousToken.equalsIgnoreCase(FilterType.OR.getStringValue());
+  }
+
+  /**
+   * Evaluates whether a string value is equivalent to the provided filter type
+   * in a case-insensitive manner.
+   */
+  private static boolean equalsIgnoreCase(@Nullable final String operator,
+                                          @NotNull final FilterType filterType)
+  {
+    return filterType.toString().equalsIgnoreCase(operator);
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StaticUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StaticUtils.java
@@ -79,9 +79,11 @@ public final class StaticUtils
                                     @Nullable final String separator)
   {
     StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < list.size(); i++) {
+    for (int i = 0; i < list.size(); i++)
+    {
       sb.append(list.get(i));
-      if (i < list.size() - 1) {
+      if (i < list.size() - 1)
+      {
         sb.append(separator);
       }
     }
@@ -105,9 +107,11 @@ public final class StaticUtils
       @Nullable final String separator)
   {
     StringBuilder sb = new StringBuilder();
-    for (Iterator<?> iter = collection.iterator(); iter.hasNext();) {
+    for (Iterator<?> iter = collection.iterator(); iter.hasNext();)
+    {
       sb.append(iter.next());
-      if (iter.hasNext()) {
+      if (iter.hasNext())
+      {
         sb.append(separator);
       }
     }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/ListResponseTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/ListResponseTestCase.java
@@ -140,7 +140,7 @@ public class ListResponseTestCase
     String serialized = JsonUtils.getObjectWriter().
         writeValueAsString(response);
     assertEquals(JsonUtils.getObjectReader().forType(
-            new TypeReference<ListResponse<ResourceTypeResource>>() { }).
+            new TypeReference<ListResponse<ResourceTypeResource>>() {}).
             readValue(serialized),
         response);
   }

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
@@ -597,7 +597,8 @@ public class SchemaChecker
         {
           removeReadOnlyAttributes(attribute.getSubAttributes(),
               (ObjectNode) node);
-        } else if (node.isArray())
+        }
+        else if (node.isArray())
         {
           for (JsonNode value : node)
           {
@@ -735,7 +736,8 @@ public class SchemaChecker
           // Skip the core schema.
           coreFound = true;
           continue;
-        } else
+        }
+        else
         {
           for (Map.Entry<SchemaResource, Boolean> schemaExtension :
               resourceType.getSchemaExtensions().entrySet())

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaCheckerTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/utils/SchemaCheckerTestCase.java
@@ -2218,7 +2218,8 @@ public class SchemaCheckerTestCase
       Assert.assertNotNull(caughtException);
       Assert.assertEquals(caughtException.getScimError().getScimType(),
           BadRequestException.INVALID_SYNTAX);
-    } else if (!mutabilityIssues.isEmpty())
+    }
+    else if (!mutabilityIssues.isEmpty())
     {
       Assert.assertNotNull(caughtException);
       Assert.assertEquals(caughtException.getScimError().getScimType(),
@@ -2229,7 +2230,8 @@ public class SchemaCheckerTestCase
       Assert.assertNotNull(caughtException);
       Assert.assertEquals(caughtException.getScimError().getScimType(),
           BadRequestException.INVALID_PATH);
-    } else
+    }
+    else
     {
       Assert.assertNull(caughtException, "Bad exception thrown");
     }


### PR DESCRIPTION
Added Checkstyle rules to ensure consistency around curly brace usages in the project. Curly braces for if-statements should generally be followed by a newline, except in the case of lambda expressions.

Reviewer: vyhhuang