### PR TITLE
Enhance the Filter classes and their documentation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ simplifies calls such as `builder.filter(filterObj.toString())` to `builder.filt
 you have any calls that pass in the `null` keyword, they may be updated to `filter((String) null)`
 to address compilation errors.
 
+Updated the filter documentation to provide more details, particularly with regard to AND, OR, and
+complex filters. The method Javadocs have also been updated to point to relevant classes for more
+information. For example, the documentation for `Filter.eq()` now includes a link to the
+`EqualFilter` class documentation.
+
+Created new `Filter.complex()` methods that will create a complex value filter. This is equivalent
+to the existing `Filter.hasComplexValue()` methods, but with a less ambiguous name. The existing
+`hasComplexValue` methods are not deprecated and may still be used.
+
 ## v3.2.0 - 2024-Dec-04
 Fixed an issue where `AndFilter.equals()` and `OrFilter.equals()` could incorrectly evaluate to
 true.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ Updated the `Meta` class so that its setters may be chained together with the bu
 `new Meta().setResourceType("User").setVersion("version")`). A new class-level Javadoc describing
 this attribute has been added, and explains how the new pattern may be used.
 
+Added a new variant of `SearchRequestBuilder.filter()` that accepts a `Filter` object directly. This
+simplifies calls such as `builder.filter(filterObj.toString())` to `builder.filter(filterObj)`. If
+you have any calls that pass in the `null` keyword, they may be updated to `filter((String) null)`
+to address compilation errors.
+
 ## v3.2.0 - 2024-Dec-04
 Fixed an issue where `AndFilter.equals()` and `OrFilter.equals()` could incorrectly evaluate to
 true.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ scimService.modifyRequest("Users", user.getId())
 // Search for users with the same last name as our user
 ListResponse<UserResource> searchResponse =
   scimService.searchRequest("Users")
-        .filter(Filter.eq("name.familyName", user.getName().getFamilyName()).toString())
+        .filter(Filter.eq("name.familyName", user.getName().getFamilyName()))
         .page(1, 5)
         .attributes("name")
         .invoke(UserResource.class);

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/SearchRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/SearchRequestBuilder.java
@@ -26,6 +26,7 @@ import com.unboundid.scim2.common.ScimResource;
 import com.unboundid.scim2.common.annotations.NotNull;
 import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.exceptions.ScimException;
+import com.unboundid.scim2.common.filters.Filter;
 import com.unboundid.scim2.common.messages.ListResponse;
 import com.unboundid.scim2.common.messages.SearchRequest;
 import com.unboundid.scim2.common.messages.SortOrder;
@@ -88,7 +89,8 @@ public class SearchRequestBuilder
   }
 
   /**
-   * Request filtering of resources.
+   * Request filtering of resources from a string representation of a
+   * {@link Filter}.
    *
    * @param filter the filter string used to request a subset of resources.
    * @return This builder.
@@ -98,6 +100,19 @@ public class SearchRequestBuilder
   {
     this.filter = filter;
     return this;
+  }
+
+  /**
+   * Request filtering of resources from a {@link Filter} object.
+   *
+   * @param filter the filter object used to request a subset of resources.
+   * @return This builder.
+   */
+  @NotNull
+  public SearchRequestBuilder filter(@Nullable final Filter filter)
+  {
+    String stringFilter = (filter == null) ? null : filter.toString();
+    return filter(stringFilter);
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/AndFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/AndFilter.java
@@ -29,6 +29,7 @@ import java.util.List;
  * SCIM client to specify multiple filter criteria, where all criteria must
  * match a resource.
  * <br><br>
+ *
  * For instance, consider the following filter. Parentheses have been added for
  * clarity.
  * <pre>
@@ -40,19 +41,23 @@ import java.util.List;
  * filter that matches {@code User} resources. As an example, this filter would
  * match a {@link UserResource} whose {@code userName} is {@code "wind"}.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Filter andFilter = Filter.and(
  *           Filter.sw("userName", "win"),
  *           Filter.eq("meta.resourceType", "User")
  *   );
- * </pre>
+ * </code></pre>
+ *
+ * It is also possible to create an AND filter from the contents of a list:
+ * <pre><code>
+ *   List&lt;Filter&gt; existingList = getExistingFilters();
+ *   Filter andFilter = Filter.and(existingList);
+ * </code></pre>
  *
  * A SCIM resource will match an AND filter if all of its subordinate filters
  * (also referred to as "filter components") match the resource.
- * <br><br>
- * This class allows for the use of multiple filter components, but {@code and}
- * filters generally only have two components.
  */
 public final class AndFilter extends CombiningFilter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/CombiningFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/CombiningFilter.java
@@ -26,14 +26,16 @@ import java.util.List;
  * This class is the superclass of filter types that contains two filters. There
  * are two types of combining filters:
  * <ul>
- *   <li>{@link AndFilter}
- *   <li>{@link OrFilter}
+ *   <li> {@link AndFilter}
+ *   <li> {@link OrFilter}
  * </ul>
  * <br><br>
+ *
  * "Combining" filters contain subordinate filters, which are also referred to
  * as "filter components". To obtain the filter components that comprise a
  * combining filter, use the {@link #getCombinedFilters()} method.
  * <br><br>
+ *
  * For more information, see the class-level documentation of the subclasses of
  * CombiningFilter.
  */

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ComparisonFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ComparisonFilter.java
@@ -27,11 +27,13 @@ import com.unboundid.scim2.common.utils.JsonUtils;
  * This superclass represents filter types that are used to compare attribute
  * values of SCIM resources.
  * <br><br>
+ *
  * For example, an {@link EqualFilter} is a comparison filter. A filter such as
  * {@code preferredLanguage eq "en-US"} is used to perform a comparison between
  * the filter value, {@code "en-US"}, and the value of a SCIM resource's
  * {@code preferredLanguage} attribute.
  * <br><br>
+ *
  * To determine whether a filter is a comparison filter, use the
  * {@link Filter#isComparisonFilter()} method.
  */

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ComplexValueFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ComplexValueFilter.java
@@ -29,29 +29,29 @@ import java.util.Objects;
  * used to match specific values on multi-valued attributes. This is generally
  * used to filter based on a sub-attribute (e.g., {@code addresses.type}).
  * <br><br>
- * For example, consider the case where a SCIM client wants to find all users
- * whose work email uses the {@code example.com} domain. Since the
- * {@code emails} attribute can contain multiple emails, the {@code type} field
- * must be explicitly specified. This can be represented by the following SCIM
- * filter:
+ *
+ * For example, consider the case where a SCIM client wants to find emails
+ * explicitly listed as "work" emails. This value is stored in the
+ * {@code emails.type} attribute. This request can be represented by the
+ * following SCIM filter:
  * <pre>
- *   emails[type eq "work" and value ew "@example.com"]
+ *   emails[type eq "work"]
  * </pre>
  *
- * Since other email types (e.g., "home") should be ignored, this filter
- * requests {@code work} emails that end with {@code "@example.com"}. This
- * example filter can be represented with the following Java code:
- * <pre>
- *   Filter complexFilter = Filter.hasComplexValue("emails",
- *           Filter.and(
- *               Filter.eq("type", "work"),
- *               Filter.ew("value", "@example.com")
- *           )
- *   );
- * </pre>
+ * This example filter can be represented with the following Java code:
+ * <pre><code>
+ *   Filter complexFilter = Filter.complex("emails", Filter.eq("type", "work"));
+ * </code></pre>
  *
- * To determine whether a filter is a ComplexValueFilter, use the
- * {@link Filter#isComplexValueFilter()} method.
+ * The following utility methods can be used for complex filters:
+ * <ul>
+ *   <li> {@link Filter#isComplexValueFilter()}: Determines whether a filter
+ *        object is a complex value filter.
+ *   <li> {@link Filter#getAttributePath()}: Fetches the filter attribute. In
+ *        the example above, this is the {@code emails} field.
+ *   <li> {@link Filter#getValueFilter()}: Fetches the inner filter of a complex
+ *        value filter, or {@code null} if the filter is a different type.
+ * </ul>
  */
 public final class ComplexValueFilter extends Filter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ContainsFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ContainsFilter.java
@@ -30,6 +30,7 @@ import java.util.Objects;
  * to determine if the provided filter value is a substring of a SCIM resource's
  * attribute value.
  * <br><br>
+ *
  * For instance, consider the following filter:
  * <pre>
  *   displayName co "eet"
@@ -40,10 +41,11 @@ import java.util.Objects;
  * {@code "eet"} substring within it. As an example, it would match a
  * resource with a {@code displayName} attribute value of {@code "meeting"}.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Filter containsFilter = Filter.co("displayName", "eet");
- * </pre>
+ * </code></pre>
  */
 public final class ContainsFilter extends ComparisonFilter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EndsWithFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EndsWithFilter.java
@@ -30,6 +30,7 @@ import java.util.Objects;
  * to determine if a SCIM resource's attribute value ends with the provided
  * filter value.
  * <br><br>
+ *
  * For instance, consider the following filter:
  * <pre>
  *   displayName ew "alice"
@@ -40,10 +41,11 @@ import java.util.Objects;
  * example, it would match a SCIM resource with a {@code displayName} attribute
  * value of {@code "malice"}.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Filter ewFilter = Filter.ew("displayName", "alice");
- * </pre>
+ * </code></pre>
  */
 public final class EndsWithFilter extends ComparisonFilter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EqualFilter.java
@@ -30,6 +30,7 @@ import java.util.Objects;
  * determine if a SCIM resource's attribute value is identical to the provided
  * filter value.
  * <br><br>
+ *
  * For instance, consider the following filter:
  * <pre>
  *   displayName eq "Static"
@@ -39,10 +40,11 @@ import java.util.Objects;
  * resources that have a {@code displayName} attribute value that equals
  * {@code "Static"}.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Filter displayNameFilter = Filter.eq("displayName", "Static");
- * </pre>
+ * </code></pre>
  */
 public final class EqualFilter extends ComparisonFilter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/Filter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/Filter.java
@@ -33,11 +33,14 @@ import java.util.Date;
 import java.util.List;
 
 /**
- * This class represents a SCIM 2 filter expression. A filter can be used by a
- * SCIM client to request a subset of SCIM resources that match a criteria. For
- * example, the SCIM filter {@code nickName eq "Alice"} would match all
- * resources whose {@code nickName} field equals "Alice".
+ * This class represents a SCIM 2 filter expression as defined by
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.2">
+ * RFC 7644 Section 3.4.2.2</a>. A filter can be used by a SCIM client to
+ * request a subset of SCIM resources that match a criteria. For example, the
+ * SCIM filter {@code nickName eq "Alice"} would match all resources whose
+ * {@code nickName} field equals "Alice".
  * <br><br>
+ *
  * In general, filters are comprised of up to three parts. For the
  * {@code nickName eq "Alice"} filter expression, these are:
  * <ul>
@@ -47,6 +50,7 @@ import java.util.List;
  * </ul>
  * Attribute paths and filter operators are not case-sensitive.
  * <br><br>
+ *
  * The following filter operator types are defined:
  * <ul>
  *   <li> {@code eq}:
@@ -92,42 +96,54 @@ import java.util.List;
  *   <li> {@code not}:
  *        A {@link NotFilter} inverts another filter. It will match a SCIM
  *        resource if the other filter is not a match.
+ *   <li> {@code []}:
+ *        A {@link ComplexValueFilter} (e.g., {@code emails[primary eq true]})
+ *        will match a subset of values within a multi-valued attribute.
  * </ul>
  * <br><br>
+ *
  * To create a new SCIM filter, use the static methods defined on this parent
  * Filter class. For example, to create an equality filter, use:
- * <pre>
+ * <pre><code>
  *   Filter equalFilter = Filter.eq("nickName", "Alice");
- * </pre>
+ * </code></pre>
  *
  * A Filter Java object can also be created from a string. This method is most
  * useful when a SCIM filter is received as a string, such as if a filter was
  * provided by a client. Note that creating a filter from a hard-coded string
  * in code is generally discouraged, since it can be easy to cause errors with
  * typos.
- * <pre>
+ * <pre><code>
  *   Filter filterObject = Filter.fromString("nickName eq \"Alice\");
- * </pre>
+ * </code></pre>
+ *
  * Similarly, to retrieve the string representation of a Filter object, use
  * {@link Filter#toString()}.
- * <pre>
+ * <pre><code>
  *   String stringRepresentation = filterObject.toString();
- * </pre>
+ * </code></pre>
  *
- * A Filter object must be one of the following types (except for
- * {@link PresentFilter}).
+ * All Filter objects are one of the following types. To determine the type for
+ * a particular filter object, use the corresponding helper function:
  * <ul>
- *   <li> {@link CombiningFilter} ({@code and}, {@code or})
- *   <li> {@link ComparisonFilter} ({@code eq}, {@code gt}, {@code le}, etc.)
- *   <li> {@link ComplexValueFilter} (used to signify a specific value within a
- *                                    multi-valued attribute)
- *   <li> {@link NotFilter} ({@code not})
+ * <li> {@link CombiningFilter} (and, or): {@link #isCombiningFilter()}
+ * <li> {@link ComparisonFilter} (eq, gt, etc.): {@link #isComparisonFilter()}
+ * <li> {@link ComplexValueFilter} ({@code []}): {@link #isComplexValueFilter()}
+ * <li> {@link NotFilter} (not): {@link #isNotFilter()}
+ * <li> {@link PresentFilter} (pr): {@link #isPresentFilter()}
  * </ul>
- * To determine whether a filter is one of these types, use methods like
- * {@link Filter#isCombiningFilter()} and {@link Filter#isNotFilter()}.
- * <br><br>
- * For more information on a particular filter type, see the class-level Javadoc
- * representing the filter type (e.g., {@link EqualFilter}).
+ *
+ * For example:
+ * <pre><code>
+ *   Filter clientFilter = getClientFilter();
+ *   if (clientFilter.isCombiningFilter())
+ *   {
+ *     // Logic that is specific to AND/OR filter types.
+ *   }
+ * </code></pre>
+ *
+ * For more information on a particular filter type, see its class-level Javadoc
+ * (e.g., {@link EqualFilter}).
  */
 public abstract class Filter
 {
@@ -272,6 +288,19 @@ public abstract class Filter
   }
 
   /**
+   * Whether this filter instance is a {@link PresentFilter}.
+   *
+   * @return {@code true} if this is a presence filter or {@code false}
+   * otherwise.
+   *
+   * @since 4.0.0
+   */
+  public boolean isPresentFilter()
+  {
+    return false;
+  }
+
+  /**
    * Retrieves a string representation of this filter.
    *
    * @return  A string representation of this filter.
@@ -286,7 +315,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code equal} filter.
+   * Create a new {@link EqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -300,7 +329,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code equal} filter.
+   * Create a new {@link EqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -317,7 +346,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code equal} filter.
+   * Create a new {@link EqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -334,7 +363,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code equal} filter.
+   * Create a new {@link EqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -351,7 +380,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code equal} filter.
+   * Create a new {@link EqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -368,7 +397,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code equal} filter.
+   * Create a new {@link EqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -385,7 +414,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code equal} filter.
+   * Create a new {@link EqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -402,7 +431,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code equal} filter.
+   * Create a new {@link EqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -419,7 +448,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code equal} filter.
+   * Create a new {@link EqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -437,7 +466,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code not equal} filter.
+   * Create a new {@link NotEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -451,7 +480,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code not equal} filter.
+   * Create a new {@link NotEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -468,7 +497,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code not equal} filter.
+   * Create a new {@link NotEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -485,7 +514,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code not equal} filter.
+   * Create a new {@link NotEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -502,7 +531,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code not equal} filter.
+   * Create a new {@link NotEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -519,7 +548,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code not equal} filter.
+   * Create a new {@link NotEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -536,7 +565,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code not equal} filter.
+   * Create a new {@link NotEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -553,7 +582,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code not equal} filter.
+   * Create a new {@link NotEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -570,7 +599,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code not equal} filter.
+   * Create a new {@link NotEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -588,7 +617,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code contains} filter.
+   * Create a new {@link ContainsFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -602,7 +631,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code contains} filter.
+   * Create a new {@link ContainsFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -619,7 +648,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code starts with} filter.
+   * Create a new {@link StartsWithFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -633,7 +662,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code starts with} filter.
+   * Create a new {@link StartsWithFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -650,7 +679,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code ends with} filter.
+   * Create a new {@link EndsWithFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -664,7 +693,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code ends with} filter.
+   * Create a new {@link EndsWithFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -681,7 +710,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code present} filter.
+   * Create a new {@link PresentFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @return A new {@code present} filter.
@@ -693,7 +722,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code present} filter.
+   * Create a new {@link PresentFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @return A new {@code present} filter.
@@ -707,7 +736,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than} filter.
+   * Create a new {@link GreaterThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -721,7 +750,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than} filter.
+   * Create a new {@link GreaterThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -738,7 +767,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than} filter.
+   * Create a new {@link GreaterThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -755,7 +784,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than} filter.
+   * Create a new {@link GreaterThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -772,7 +801,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than} filter.
+   * Create a new {@link GreaterThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -789,7 +818,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than} filter.
+   * Create a new {@link GreaterThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -806,7 +835,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than} filter.
+   * Create a new {@link GreaterThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -824,7 +853,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than or equal} filter.
+   * Create a new {@link GreaterThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -838,7 +867,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than or equal} filter.
+   * Create a new {@link GreaterThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -855,7 +884,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than or equal} filter.
+   * Create a new {@link GreaterThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -872,7 +901,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than or equal} filter.
+   * Create a new {@link GreaterThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -889,7 +918,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than or equal} filter.
+   * Create a new {@link GreaterThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -906,7 +935,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than or equal} filter.
+   * Create a new {@link GreaterThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -923,7 +952,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code greater than or equal} filter.
+   * Create a new {@link GreaterThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -941,7 +970,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than} filter.
+   * Create a new {@link LessThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -955,7 +984,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than} filter.
+   * Create a new {@link LessThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -972,7 +1001,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than} filter.
+   * Create a new {@link LessThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -989,7 +1018,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than} filter.
+   * Create a new {@link LessThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -1006,7 +1035,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than} filter.
+   * Create a new {@link LessThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -1023,7 +1052,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than} filter.
+   * Create a new {@link LessThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -1040,7 +1069,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than} filter.
+   * Create a new {@link LessThanFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -1058,7 +1087,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than or equal} filter.
+   * Create a new {@link LessThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -1072,7 +1101,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than or equal} filter.
+   * Create a new {@link LessThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -1089,7 +1118,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than or equal} filter.
+   * Create a new {@link LessThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -1106,7 +1135,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than or equal} filter.
+   * Create a new {@link LessThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -1123,7 +1152,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than or equal} filter.
+   * Create a new {@link LessThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -1140,7 +1169,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than or equal} filter.
+   * Create a new {@link LessThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -1157,7 +1186,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code less than or equal} filter.
+   * Create a new {@link LessThanOrEqualFilter}.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param filterValue   The filter attribute value.
@@ -1175,7 +1204,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code and} filter.
+   * Create a new {@link AndFilter}.
    *
    * @param filter1 The first filter.
    * @param filter2 The second filter.
@@ -1199,7 +1228,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code and} filter.
+   * Create a new {@link AndFilter}.
    *
    * @param filter1 The first filter.
    * @param filter2 The second filter.
@@ -1228,7 +1257,24 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code or} filter.
+   * Create a new {@link AndFilter}.
+   *
+   * @param filters The filter components.
+   * @return A new {@code and} filter.
+   */
+  @NotNull
+  public static Filter and(@NotNull final List<Filter> filters)
+  {
+    if (filters.size() < 2)
+    {
+      throw new IllegalArgumentException(
+          "and logical filter must combine at least 2 filters");
+    }
+    return new AndFilter(new ArrayList<>(filters));
+  }
+
+  /**
+   * Create a new {@link OrFilter}.
    *
    * @param filter1 The first filter.
    * @param filter2 The second filter.
@@ -1252,7 +1298,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code or} filter.
+   * Create a new {@link OrFilter}.
    *
    * @param filter1 The first filter.
    * @param filter2 The second filter.
@@ -1281,24 +1327,7 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code and} filter.
-   *
-   * @param filters The filter components.
-   * @return A new {@code and} filter.
-   */
-  @NotNull
-  public static Filter and(@NotNull final List<Filter> filters)
-  {
-    if (filters.size() < 2)
-    {
-      throw new IllegalArgumentException(
-          "and logical filter must combine at least 2 filters");
-    }
-    return new AndFilter(new ArrayList<>(filters));
-  }
-
-  /**
-   * Create a new {@code or} filter.
+   * Create a new {@link OrFilter}.
    *
    * @param filters The filter components.
    * @return A new {@code or} filter.
@@ -1315,9 +1344,9 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code not} filter.
+   * Create a new {@link NotFilter}.
    *
-   * @param filter The inverted filter.
+   * @param filter The filter that should be inverted.
    * @return A new {@code not} filter.
    */
   @NotNull
@@ -1327,9 +1356,9 @@ public abstract class Filter
   }
 
   /**
-   * Create a new {@code not} filter.
+   * Create a new {@link NotFilter}.
    *
-   * @param filter The inverted filter.
+   * @param filter The filter that should be inverted.
    * @return A new {@code not} filter.
    * @throws BadRequestException If the filter could not be parsed.
    */
@@ -1341,7 +1370,9 @@ public abstract class Filter
   }
 
   /**
-   * Create a new complex multi-valued attribute value filter.
+   * Identical to the {@link #complex(Path, Filter)} method, which creates a
+   * {@link ComplexValueFilter}. It is encouraged to use the other method, but
+   * this one may still be used.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param valueFilter   The value filter.
@@ -1351,11 +1382,13 @@ public abstract class Filter
   public static Filter hasComplexValue(@NotNull final Path attributePath,
                                        @Nullable final Filter valueFilter)
   {
-    return new ComplexValueFilter(attributePath, valueFilter);
+    return Filter.complex(attributePath, valueFilter);
   }
 
   /**
-   * Create a new complex multi-valued attribute value filter.
+   * Identical to the {@link #complex(String, Filter)} method, which creates a
+   * {@link ComplexValueFilter}. It is encouraged to use the other method, but
+   * this one may still be used.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param valueFilter   The value filter.
@@ -1367,11 +1400,13 @@ public abstract class Filter
                                        @Nullable final Filter valueFilter)
       throws BadRequestException
   {
-    return new ComplexValueFilter(Path.fromString(attributePath), valueFilter);
+    return Filter.complex(attributePath, valueFilter);
   }
 
   /**
-   * Create a new complex multi-valued attribute value filter.
+   * Identical to the {@link #complex(String, String)} method, which creates a
+   * {@link ComplexValueFilter}. It is encouraged to use the other method, but
+   * this one may still be used.
    *
    * @param attributePath The path to the attribute to filter by.
    * @param valueFilter   The value filter.
@@ -1381,6 +1416,79 @@ public abstract class Filter
   @NotNull
   public static Filter hasComplexValue(@NotNull final String attributePath,
                                        @Nullable final String valueFilter)
+      throws BadRequestException
+  {
+    return Filter.complex(attributePath, valueFilter);
+  }
+
+  /**
+   * Create a new complex multi-valued attribute value filter (i.e., a
+   * {@link ComplexValueFilter}). For example, to create a filter representing
+   * {@code addresses[postalCode eq \"12345\"]}, use the following Java code:
+   *
+   * <pre><code>
+   *   Filter complexFilter =
+   *       Filter.complex("addresses", Filter.eq("postalCode", "12345"));
+   * </code></pre>
+   *
+   * @param attributePath The path to the attribute to filter by.
+   * @param valueFilter   The value filter.
+   * @return A new complex multi-valued attribute value filter.
+   *
+   * @since 4.0.0
+   */
+  @NotNull
+  public static Filter complex(@NotNull final Path attributePath,
+                               @Nullable final Filter valueFilter)
+  {
+    return new ComplexValueFilter(attributePath, valueFilter);
+  }
+
+  /**
+   * Create a new complex multi-valued attribute value filter (i.e., a
+   * {@link ComplexValueFilter}). For example, to create a filter representing
+   * {@code addresses[postalCode eq \"12345\"]}, use the following Java code:
+   *
+   * <pre><code>
+   *   Filter complexFilter =
+   *       Filter.complex("addresses", Filter.eq("postalCode", "12345"));
+   * </code></pre>
+   *
+   * @param attributePath The path to the attribute to filter by.
+   * @param valueFilter   The value filter.
+   * @return A new complex multi-valued attribute value filter.
+   *
+   * @since 4.0.0
+   * @throws BadRequestException  If the path could not be parsed.
+   */
+  @NotNull
+  public static Filter complex(@NotNull final String attributePath,
+                               @Nullable final Filter valueFilter)
+      throws BadRequestException
+  {
+    return new ComplexValueFilter(Path.fromString(attributePath), valueFilter);
+  }
+
+  /**
+   * Create a new complex multi-valued attribute value filter (i.e., a
+   * {@link ComplexValueFilter}). For example, to create a filter representing
+   * {@code addresses[postalCode eq \"12345\"]}, use the following Java code:
+   *
+   * <pre><code>
+   *   Filter complexFilter =
+   *       Filter.complex("addresses", Filter.eq("postalCode", "12345"));
+   * </code></pre>
+   *
+   * @param attributePath The path to the attribute to filter by.
+   * @param valueFilter   The value filter.
+   * @return A new complex multi-valued attribute value filter.
+   *
+   * @since 4.0.0
+   * @throws BadRequestException  If the path or filter could not be parsed.
+   */
+  @NotNull
+  public static Filter complex(@NotNull final String attributePath,
+                               @Nullable final String valueFilter)
       throws BadRequestException
   {
     return new ComplexValueFilter(Path.fromString(attributePath),

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanFilter.java
@@ -30,6 +30,7 @@ import java.util.Objects;
  * "Greater Than" filters are used to match SCIM resources that contain a larger
  * value than the provided filter value.
  * <br><br>
+ *
  * For instance, consider the following filter:
  * <pre>
  *   meta.created gt "2023-07-25T08:00:00.000Z"
@@ -40,12 +41,13 @@ import java.util.Objects;
  * value. In other words, it matches any resource that was created after the
  * provided timestamp.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Calendar calendar = Calendar.getInstance();
  *   calendar.set(2023, Calendar.JULY, 25, 8, 0);
  *   Filter gtFilter = Filter.gt("meta.created", calendar.getTime());
- * </pre>
+ * </code></pre>
  */
 public final class GreaterThanFilter extends ComparisonFilter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanOrEqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanOrEqualFilter.java
@@ -30,6 +30,7 @@ import java.util.Objects;
  * "Greater Than Or Equal To" filters match SCIM resources that contain a larger
  * or equivalent value when compared to the provided filter value.
  * <br><br>
+ *
  * For instance, consider the following filter:
  * <pre>
  *   meta.created ge "2023-07-25T08:00:00.000Z"
@@ -40,12 +41,13 @@ import java.util.Objects;
  * equivalent to the filter value. In other words, it matches any resource that
  * was created at or after the provided timestamp.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Calendar calendar = Calendar.getInstance();
  *   calendar.set(2023, Calendar.JULY, 25, 8, 0);
  *   Filter geFilter = Filter.ge("meta.created", calendar.getTime());
- * </pre>
+ * </code></pre>
  */
 public final class GreaterThanOrEqualFilter extends ComparisonFilter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanFilter.java
@@ -30,6 +30,7 @@ import java.util.Objects;
  * "Less Than" filters match SCIM resources that contain a smaller value than
  * the provided filter value.
  * <br><br>
+ *
  * For instance, consider the following filter:
  * <pre>
  *   meta.created lt "2023-07-25T08:00:00.000Z"
@@ -40,12 +41,13 @@ import java.util.Objects;
  * value. In other words, it matches any resource that was created before the
  * provided timestamp.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Calendar calendar = Calendar.getInstance();
  *   calendar.set(2023, Calendar.JULY, 25, 8, 0);
  *   Filter ltFilter = Filter.lt("meta.created", calendar.getTime());
- * </pre>
+ * </code></pre>
  */
 public final class LessThanFilter extends ComparisonFilter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanOrEqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanOrEqualFilter.java
@@ -30,6 +30,7 @@ import java.util.Objects;
  * "Less Than Or Equal To" filters match SCIM resources that contain a smaller
  * or equivalent value when compared to the provided filter value.
  * <br><br>
+ *
  * For instance, consider the following filter:
  * <pre>
  *   meta.created le "2023-07-25T08:00:00.000Z"
@@ -40,12 +41,13 @@ import java.util.Objects;
  * equivalent to the filter value. In other words, it matches any resource that
  * was created at or before the provided timestamp.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Calendar calendar = Calendar.getInstance();
  *   calendar.set(2023, Calendar.JULY, 25, 8, 0);
  *   Filter leFilter = Filter.le("meta.created", calendar.getTime());
- * </pre>
+ * </code></pre>
  */
 public final class LessThanOrEqualFilter extends ComparisonFilter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotEqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotEqualFilter.java
@@ -30,6 +30,7 @@ import java.util.Objects;
  * to determine if a SCIM resource's attribute value is not equivalent to the
  * provided filter value.
  * <br><br>
+ *
  * For instance, consider the following filter:
  * <pre>
  *   name.familyName ne "Traffic"
@@ -41,10 +42,11 @@ import java.util.Objects;
  * of {@code "Neighbors"}. This would also match a resource that does not have a
  * value for {@code name.familyName}.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Filter notEqualFilter = Filter.ne("name.familyName", "Traffic");
- * </pre>
+ * </code></pre>
  */
 public final class NotEqualFilter extends ComparisonFilter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotFilter.java
@@ -28,19 +28,21 @@ import com.unboundid.scim2.common.exceptions.ScimException;
  * <pre>
  *   not (type eq "Rabbit")
  * </pre>
+ *
  * A SCIM resource will match this filter if the resource does not have a
  * {@code type} attribute with a value of {@code "Rabbit"}. This example filter
  * can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Filter notFilter = Filter.not(
  *           Filter.eq("type", "Rabbit")
  *   );
- * </pre>
+ * </code></pre>
  *
  * Similar to a {@link CombiningFilter}, NOT filters store the original filter
  * that is inverted. This original filter can be obtained by invoking the
- * {@link #getInvertedFilter()} method.
+ * {@link Filter#getInvertedFilter()} method.
  * <br><br>
+ *
  * To determine whether any Filter is a NOT filter, use the
  * {@link Filter#isNotFilter()} method.
  */

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/OrFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/OrFilter.java
@@ -28,11 +28,13 @@ import java.util.List;
  * a client to specify multiple filter criteria, where at least one of the
  * criteria must match.
  * <br><br>
+ *
  * For instance, consider the following filter. Parentheses have been added for
  * clarity.
  * <pre>
  *   (name.familyName sw "Sa") or (nickName sw "Sa")
  * </pre>
+ *
  * This is a filter with two components: a {@code sw} filter that matches SCIM
  * resources with a {@code familyName} starting with {@code "Sa"}, and another
  * {@code sw} filter that matches resources with a {@code nickName} starting
@@ -40,18 +42,23 @@ import java.util.List;
  * {@code name.familyName} is {@code "Neighbors"} and has a {@code nickName} of
  * {@code "Sails"}.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Filter orFilter = Filter.or(
  *           Filter.sw("name.familyName", "Sa"),
  *           Filter.sw("nickName", "Sa")
  *   );
- * </pre>
+ * </code></pre>
+ *
+ * It is also possible to create an OR filter from the contents of a list:
+ * <pre><code>
+ *   List&lt;Filter&gt; existingList = getExistingFilters();
+ *   Filter orFilter = Filter.or(existingList);
+ * </code></pre>
+ *
  * A SCIM resource will match an OR filter if one of its subordinate filters
  * (also referred to as "filter components") match the resource.
- * <br><br>
- * This class allows for the use of multiple filter components, but {@code or}
- * filters generally only have two components.
  */
 public final class OrFilter extends CombiningFilter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/PresentFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/PresentFilter.java
@@ -29,6 +29,7 @@ import com.unboundid.scim2.common.types.UserResource;
  * exists on a SCIM resource, and that the attribute value is both non-null and
  * non-empty. Unlike most filters, presence filters do not contain a value.
  * <br><br>
+ *
  * Consider the following filter:
  * <pre>
  *   profileUrl pr
@@ -39,10 +40,11 @@ import com.unboundid.scim2.common.types.UserResource;
  * words, it requests any resource (likely a {@link UserResource}) that has a
  * profile picture.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Filter presentFilter = Filter.pr("profileUrl");
- * </pre>
+ * </code></pre>
  */
 public final class PresentFilter extends Filter
 {
@@ -67,6 +69,15 @@ public final class PresentFilter extends Filter
   public Path getAttributePath()
   {
     return filterAttribute;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isPresentFilter()
+  {
+    return true;
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/StartsWithFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/StartsWithFilter.java
@@ -30,6 +30,7 @@ import java.util.Objects;
  * used to determine if a SCIM resource's attribute value begins with the
  * provided filter value.
  * <br><br>
+ *
  * For instance, consider the following filter:
  * <pre>
  *   title sw "New"
@@ -40,10 +41,11 @@ import java.util.Objects;
  * {@code "New"}. As an example, it would match a resource with a {@code title}
  * value of {@code "Newspaperman"}.
  * <br><br>
+ *
  * This example filter can be represented with the following Java code:
- * <pre>
+ * <pre><code>
  *   Filter swFilter = Filter.sw("title", "New");
- * </pre>
+ * </code></pre>
  */
 public final class StartsWithFilter extends ComparisonFilter
 {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
@@ -616,7 +616,7 @@ public class Parser
           throw BadRequestException.invalidFilter(msg);
         }
 
-        outputStack.push(Filter.hasComplexValue(
+        outputStack.push(Filter.complex(
             filterAttribute, readFilter(reader, true)));
       }
       else if (isValueFilter && token.equals("]") &&

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterParsingTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterParsingTestCase.java
@@ -86,10 +86,10 @@ public class FilterParsingTestCase
             new Object[] { "urn:extension:isActive eq false",
                 eq("urn:extension:isActive", false) },
             new Object[] { "addresses[zipcode eq 88283 and city ne \"Austin\"]",
-                hasComplexValue("addresses",
+                Filter.complex("addresses",
                     and(eq("zipcode", 88283), ne("city", "Austin"))) },
             new Object[] { "not(addresses[city ne \"Austin\"])",
-                not(hasComplexValue("addresses", ne("city", "Austin"))) },
+                not(Filter.complex("addresses", ne("city", "Austin"))) },
 
             // Precedence tests
             new Object[] { "title pr and email pr or userType pr",

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
@@ -31,6 +31,7 @@ import com.unboundid.scim2.common.exceptions.BadRequestException;
 import com.unboundid.scim2.common.exceptions.MethodNotAllowedException;
 import com.unboundid.scim2.common.exceptions.ResourceNotFoundException;
 import com.unboundid.scim2.common.exceptions.ScimException;
+import com.unboundid.scim2.common.filters.Filter;
 import com.unboundid.scim2.common.messages.ErrorResponse;
 import com.unboundid.scim2.common.messages.ListResponse;
 import com.unboundid.scim2.common.messages.PatchOperation;
@@ -1035,12 +1036,12 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
           invoke();
 
       service.searchRequest("Users").
-          filter("meta.resourceType eq \"User\"").
+          filter(Filter.eq("meta.resourceType", "User")).
           header(expectedKey, expectedValue).
           invoke(UserResource.class);
 
       service.searchRequest("Users").
-          filter("meta.resourceType eq \"User\"").
+          filter(Filter.eq("meta.resourceType", "User")).
           header(expectedKey, expectedValue).
           invokePost(UserResource.class);
 


### PR DESCRIPTION
This commit enhances the use and descriptions of the Filter classes.
Particular focus has been given to combining and complex value filters.
Previously, complex filters were not documented on the parent class. New
static methods have also been added to create these filters with a
clearer name.

This commit also:
* Reorganizes the and() methods to be grouped together.
* Adds isPresentFilter() so that all filter types have a helper method.
* Updates the method Javadocs to link to the class of filter created,
  which provides another resource for information.
* Adds a new filter method for SearchRequestBuilder, accepting a
  Filter object.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-50037