### PR TITLE
Make GenericScimResource extendable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ that several model classes are no longer `final`, allowing applications to `exte
 The following classes were updated:
 * scim2-sdk-client builder classes such as `CreateRequestBuilder.java`
 * `ErrorResponse.java`
+* `GenericScimResource.java`
 * `ListResponse.java`
 * `Meta.java`
 * `SearchRequest.java`

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
@@ -94,7 +94,7 @@ import java.util.Objects;
  */
 @JsonDeserialize(using = GenericScimObjectDeserializer.class)
 @JsonSerialize(using = GenericScimObjectSerializer.class)
-public final class GenericScimResource implements ScimResource
+public class GenericScimResource implements ScimResource
 {
   @NotNull
   private static final Path SCHEMAS = Path.root().attribute("schemas");


### PR DESCRIPTION
The 4.0.0 release will have several classes that are no longer final. One object that should be included is GenericScimResource. Much like how custom resource types can be created today by extending BaseScimResource, this change allows library clients to create their own resource types that extend GenericScimResource with a dedicated class name.