### PR TITLE
Simplify Jackson calls to fix deprecation warnings

### DIFF
--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
@@ -37,7 +37,6 @@ import com.unboundid.scim2.common.utils.SchemaUtils;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -276,10 +275,8 @@ public abstract class BaseScimResource
   protected Map<String, Object> getAny()
   {
     HashMap<String, Object> map = new HashMap<>(extensionObjectNode.size());
-    Iterator<Map.Entry<String, JsonNode>> i = extensionObjectNode.fields();
-    while (i.hasNext())
+    for (Map.Entry<String, JsonNode> field : extensionObjectNode.properties())
     {
-      Map.Entry<String, JsonNode> field = i.next();
       map.put(field.getKey(), field.getValue());
     }
     return map;

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
@@ -229,7 +229,7 @@ public class GenericScimResource implements ScimResource
     try
     {
       JsonNode value = JsonUtils.getValue(SCHEMAS, objectNode);
-      if (value.isNull() || !value.isArray())
+      if (!(value instanceof ArrayNode valueArray))
       {
         return Collections.emptyList();
       }
@@ -237,7 +237,7 @@ public class GenericScimResource implements ScimResource
       // This will not return null since the input value is non-null.
       //
       //noinspection DataFlowIssue
-      return JsonUtils.nodeToValues((ArrayNode) value, String.class);
+      return JsonUtils.nodeToValues(valueArray, String.class);
     }
     catch (Exception e)
     {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -418,7 +418,7 @@ public abstract class PatchOperation
         // prepare to add this value ourselves.
         jsonAttribute = JsonUtils.getJsonNodeFactory().arrayNode(1);
       }
-      if (!jsonAttribute.isArray())
+      if (!(jsonAttribute instanceof ArrayNode attr))
       {
         throw BadRequestException.invalidSyntax(
             "The patch operation could not be processed because a complex"
@@ -426,7 +426,6 @@ public abstract class PatchOperation
                 + "' is single-valued"
         );
       }
-      ArrayNode attribute = (ArrayNode) jsonAttribute;
 
       // When operations with a value filter add data, we can either append
       // the data to a new value in the multi-valued attribute, or we can update
@@ -440,7 +439,7 @@ public abstract class PatchOperation
       ObjectNode matchedValue = null;
       if (!APPEND_NEW_PATCH_VALUES_PROPERTY)
       {
-        matchedValue = fetchExistingValue(attribute, valueFilter, attributeName);
+        matchedValue = fetchExistingValue(attr, valueFilter, attributeName);
       }
 
       // If there are no existing values that match the filter, or if no values
@@ -453,8 +452,8 @@ public abstract class PatchOperation
         newValue.set(subAttributeName, value);
         newValue.set(filterAttributeName, filterValue);
 
-        attribute.add(newValue);
-        existingResource.replace(attributeName, attribute);
+        attr.add(newValue);
+        existingResource.replace(attributeName, attr);
         return;
       }
 
@@ -918,9 +917,8 @@ public abstract class PatchOperation
     // schemas attribute.
     JsonNode schemasNode =
         node.path(SchemaUtils.SCHEMAS_ATTRIBUTE_DEFINITION.getName());
-    if (schemasNode.isArray())
+    if (schemasNode instanceof ArrayNode schemas)
     {
-      ArrayNode schemas = (ArrayNode) schemasNode;
       if (getPath() == null)
       {
         Iterator<String> i = getJsonNode().fieldNames();

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
@@ -74,7 +74,7 @@ public class JsonUtils
     @NotNull
     abstract JsonNode visitInnerNode(@NotNull final ObjectNode parent,
                                      @Nullable final String field,
-                                     @NotNull final Filter valueFilter)
+                                     @Nullable final Filter valueFilter)
         throws ScimException;
 
     /**
@@ -154,9 +154,9 @@ public class JsonUtils
         throws ScimException
     {
       JsonNode node = parent.path(field);
-      if (node.isArray() && valueFilter != null)
+      if (node instanceof ArrayNode arrayNode && valueFilter != null)
       {
-        return filterArray((ArrayNode) node, valueFilter, false);
+        return filterArray(arrayNode, valueFilter, false);
       }
       return node;
     }
@@ -170,14 +170,11 @@ public class JsonUtils
         throws ScimException
     {
       JsonNode node = parent.path(field);
-      if (node.isArray())
+      if (node instanceof ArrayNode arrayNode)
       {
-        ArrayNode arrayNode = (ArrayNode) node;
-
         if (valueFilter != null)
         {
-          arrayNode = filterArray((ArrayNode) node, valueFilter,
-              removeValues);
+          arrayNode = filterArray(arrayNode, valueFilter, removeValues);
         }
         if (!arrayNode.isEmpty())
         {
@@ -257,9 +254,8 @@ public class JsonUtils
         parent.set(field, newObjectNode);
         return newObjectNode;
       }
-      else if (node.isArray())
+      else if (node instanceof ArrayNode arrayNode)
       {
-        ArrayNode arrayNode = (ArrayNode) node;
         if (valueFilter != null)
         {
           arrayNode = filterArray(arrayNode, valueFilter, false);
@@ -303,9 +299,8 @@ public class JsonUtils
       // in replace mode, a value filter requires that the target node
       // be an array and that we can find matching value(s)
       JsonNode node = parent.path(field);
-      if (node.isArray())
+      if (node instanceof ArrayNode array)
       {
-        var array = (ArrayNode) node;
         matchesFound = processArrayReplace(parent, field, array, valueFilter);
       }
       // exception: this allows filters on singular values if
@@ -370,9 +365,9 @@ public class JsonUtils
         nodeUpdated = true;
 
 
-        if (attributeValue.isObject() && value.isObject())
+        if (attributeValue instanceof ObjectNode attribute && value.isObject())
         {
-          updateNode((ObjectNode) attributeValue, null, value);
+          updateNode(attribute, null, value);
         }
         else if (isDelete && attributeValue.isObject())
         {
@@ -436,17 +431,13 @@ public class JsonUtils
 
       // When key is null, the node to update is the parent itself.
       JsonNode node = key == null ? parent : parent.path(key);
-      if (node.isObject())
+      if (node instanceof ObjectNode targetObject)
       {
-        if (value.isObject())
+        if (value instanceof ObjectNode valueObject)
         {
           // Go through the fields of both objects and merge them.
-          ObjectNode targetObject = (ObjectNode) node;
-          ObjectNode valueObject = (ObjectNode) value;
-          Iterator<Map.Entry<String, JsonNode>> i = valueObject.fields();
-          while (i.hasNext())
+          for (Map.Entry<String, JsonNode> field : valueObject.properties())
           {
-            Map.Entry<String, JsonNode> field = i.next();
             updateNode(targetObject, field.getKey(), field.getValue());
           }
         }
@@ -456,13 +447,11 @@ public class JsonUtils
           parent.set(key, value);
         }
       }
-      else if (node.isArray())
+      else if (node instanceof ArrayNode targetArray)
       {
-        if (value.isArray() && appendValues)
+        if (appendValues && value instanceof ArrayNode valueArray)
         {
           // Append the new values to the existing ones.
-          ArrayNode targetArray = (ArrayNode) node;
-          ArrayNode valueArray = (ArrayNode) value;
           for (JsonNode valueNode : valueArray)
           {
             boolean valueFound = false;
@@ -506,9 +495,9 @@ public class JsonUtils
         throws ScimException
     {
       JsonNode node = parent.path(field);
-      if (node.isArray() && valueFilter != null)
+      if (node instanceof ArrayNode arrayNode && valueFilter != null)
       {
-        return filterArray((ArrayNode) node, valueFilter, false);
+        return filterArray(arrayNode, valueFilter, false);
       }
       return node;
     }
@@ -520,9 +509,9 @@ public class JsonUtils
         throws ScimException
     {
       JsonNode node = parent.path(field);
-      if (node.isArray() && valueFilter != null)
+      if (node instanceof ArrayNode arrayNode && valueFilter != null)
       {
-        node = filterArray((ArrayNode) node, valueFilter, false);
+        node = filterArray(arrayNode, valueFilter, false);
       }
 
       if (node.isArray())
@@ -1019,15 +1008,15 @@ public class JsonUtils
       {
         for (JsonNode value : child)
         {
-          if (value.isObject())
+          if (value instanceof ObjectNode valueObject)
           {
-            traverseValues(nodeVisitor, (ObjectNode) value, index + 1, path);
+            traverseValues(nodeVisitor, valueObject, index + 1, path);
           }
         }
       }
-      else if (child.isObject())
+      else if (child instanceof ObjectNode childObject)
       {
-        traverseValues(nodeVisitor, (ObjectNode) child, index + 1, path);
+        traverseValues(nodeVisitor, childObject, index + 1, path);
       }
     }
     else

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/ListResponseWriter.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/ListResponseWriter.java
@@ -27,7 +27,6 @@ import com.unboundid.scim2.common.utils.JsonUtils;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -103,10 +102,8 @@ public class ListResponseWriter<T extends ScimResource>
       jsonGenerator.writeEndArray();
     }
 
-    Iterator<Map.Entry<String, JsonNode>> i = deferredFields.fields();
-    while (i.hasNext())
+    for (Map.Entry<String, JsonNode> field : deferredFields.properties())
     {
-      Map.Entry<String, JsonNode> field = i.next();
       jsonGenerator.writeObjectField(field.getKey(), field.getValue());
     }
     jsonGenerator.writeEndObject();

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourceTrimmer.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/ResourceTrimmer.java
@@ -25,7 +25,6 @@ import com.unboundid.scim2.common.annotations.NotNull;
 import com.unboundid.scim2.common.utils.JsonUtils;
 import com.unboundid.scim2.common.utils.SchemaUtils;
 
-import java.util.Iterator;
 import java.util.Map;
 
 
@@ -60,10 +59,8 @@ public abstract class ResourceTrimmer
                                     @NotNull final Path parentPath)
   {
     ObjectNode objectToReturn = JsonUtils.getJsonNodeFactory().objectNode();
-    Iterator<Map.Entry<String, JsonNode>> i = objectNode.fields();
-    while (i.hasNext())
+    for (Map.Entry<String, JsonNode> field : objectNode.properties())
     {
-      Map.Entry<String, JsonNode> field = i.next();
       final Path path;
       if (parentPath.isRoot() && parentPath.getSchemaUrn() == null &&
           SchemaUtils.isUrn(field.getKey()))
@@ -77,19 +74,17 @@ public abstract class ResourceTrimmer
 
       if (path.isRoot() || shouldReturn(path))
       {
-        if (field.getValue().isArray())
+        if (field.getValue() instanceof ArrayNode valueArray)
         {
-          ArrayNode trimmedNode = trimArrayNode(
-              (ArrayNode) field.getValue(), path);
+          ArrayNode trimmedNode = trimArrayNode(valueArray, path);
           if (!trimmedNode.isEmpty())
           {
             objectToReturn.set(field.getKey(), trimmedNode);
           }
         }
-        else if (field.getValue().isObject())
+        else if (field.getValue() instanceof ObjectNode valueObject)
         {
-          ObjectNode trimmedNode = trimObjectNode(
-              (ObjectNode) field.getValue(), path);
+          ObjectNode trimmedNode = trimObjectNode(valueObject, path);
           if (!trimmedNode.isEmpty())
           {
             objectToReturn.set(field.getKey(), trimmedNode);
@@ -118,17 +113,17 @@ public abstract class ResourceTrimmer
     ArrayNode arrayToReturn = JsonUtils.getJsonNodeFactory().arrayNode();
     for (JsonNode value : arrayNode)
     {
-      if (value.isArray())
+      if (value instanceof ArrayNode valueArray)
       {
-        ArrayNode trimmedNode = trimArrayNode((ArrayNode) value, parentPath);
+        ArrayNode trimmedNode = trimArrayNode(valueArray, parentPath);
         if (!trimmedNode.isEmpty())
         {
           arrayToReturn.add(trimmedNode);
         }
       }
-      else if (value.isObject())
+      else if (value instanceof ObjectNode valueObject)
       {
-        ObjectNode trimmedNode = trimObjectNode((ObjectNode) value, parentPath);
+        ObjectNode trimmedNode = trimObjectNode(valueObject, parentPath);
         if (!trimmedNode.isEmpty())
         {
           arrayToReturn.add(trimmedNode);

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
@@ -493,10 +493,9 @@ public class SchemaChecker
         resourceType.getSchemaExtensions().keySet())
     {
       JsonNode extension = copyNode.get(schemaExtension.getId());
-      if (extension != null && extension.isObject())
+      if (extension instanceof ObjectNode extensionObj)
       {
-        removeReadOnlyAttributes(schemaExtension.getAttributes(),
-            (ObjectNode) extension);
+        removeReadOnlyAttributes(schemaExtension.getAttributes(), extensionObj);
       }
     }
     removeReadOnlyAttributes(commonAndCoreAttributes, copyNode);
@@ -593,19 +592,17 @@ public class SchemaChecker
       if (attribute.getSubAttributes() != null)
       {
         JsonNode node = objectNode.path(attribute.getName());
-        if (node.isObject())
+        if (node instanceof ObjectNode nodeObject)
         {
-          removeReadOnlyAttributes(attribute.getSubAttributes(),
-              (ObjectNode) node);
+          removeReadOnlyAttributes(attribute.getSubAttributes(), nodeObject);
         }
         else if (node.isArray())
         {
           for (JsonNode value : node)
           {
-            if (value.isObject())
+            if (value instanceof ObjectNode valueObj)
             {
-              removeReadOnlyAttributes(attribute.getSubAttributes(),
-                  (ObjectNode) value);
+              removeReadOnlyAttributes(attribute.getSubAttributes(), valueObj);
             }
           }
         }
@@ -634,9 +631,8 @@ public class SchemaChecker
       final boolean isPartialAdd)
           throws ScimException
   {
-
-    Iterator<Map.Entry<String, JsonNode>> i = objectNode.fields();
-    while (i.hasNext())
+    Iterator<Map.Entry<String, JsonNode>> i;
+    for (i = objectNode.properties().iterator(); i.hasNext();)
     {
       Map.Entry<String, JsonNode> field = i.next();
       if (SchemaUtils.isUrn(field.getKey()))
@@ -800,8 +796,8 @@ public class SchemaChecker
     // All defined schema extensions should be removed.
     // Remove any additional extended attribute namespaces not included in
     // the schemas attribute.
-    Iterator<Map.Entry<String, JsonNode>> i = objectNode.fields();
-    while (i.hasNext())
+    Iterator<Map.Entry<String, JsonNode>> i;
+    for (i = objectNode.properties().iterator(); i.hasNext();)
     {
       String fieldName = i.next().getKey();
       if (SchemaUtils.isUrn(fieldName))
@@ -1241,8 +1237,8 @@ public class SchemaChecker
 
     // All defined attributes should be removed. Remove any additional
     // undefined attributes.
-    Iterator<Map.Entry<String, JsonNode>> i = objectNode.fields();
-    while (i.hasNext())
+    Iterator<Map.Entry<String, JsonNode>> i;
+    for (i = objectNode.properties().iterator(); i.hasNext();)
     {
       String undefinedAttribute = i.next().getKey();
       if (parentPath.size() == 0)
@@ -1254,8 +1250,7 @@ public class SchemaChecker
               resourceType.getCoreSchema().getId());
         }
       }
-      else if (parentPath.isRoot() &&
-          parentPath.getSchemaUrn() != null)
+      else if (parentPath.isRoot() && parentPath.getSchemaUrn() != null)
       {
         if (!enabledOptions.contains(Option.ALLOW_UNDEFINED_ATTRIBUTES))
         {


### PR DESCRIPTION
ObjectNode.fields() is now deprecated in Jackson 2.19. As a result, the SDK has been updated to use the ObjectNode.properties() method instead, which is friendlier to iteration in most cases.

Evaluation of objects and arrays has also been updated to use Java pattern variables, as this provides an easy (and cleaner) way to obtain an ObjectNode or ArrayNode reference.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-50361