### PR TITLE
feat: add maxResults param in SimpleSearchResults

### DIFF
--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
@@ -373,14 +373,14 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
     final ListResponse<UserResource> returnedUsers =
         service.searchRequest("Users").
             filter("meta.resourceType eq \"User\"").
-            page(1, 10).
+            page(1, 1000).
             sort("id", SortOrder.ASCENDING).
             attributes("id", "name", "Meta").
             invoke(UserResource.class);
 
-    assertEquals(returnedUsers.getTotalResults(), 1);
+    assertEquals(returnedUsers.getTotalResults(), 100);
     assertEquals(returnedUsers.getStartIndex(), Integer.valueOf(1));
-    assertEquals(returnedUsers.getItemsPerPage(), Integer.valueOf(1));
+    assertEquals(returnedUsers.getItemsPerPage(), Integer.valueOf(10));
 
     final UserResource r = returnedUsers.getResources().get(0);
     service.retrieve(r);
@@ -397,14 +397,14 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
     final ListResponse<UserResource> returnedUsers =
         new ScimService(target()).searchRequest("Users").
             filter("meta.resourceType eq \"User\"").
-            page(1, 10).
+            page(1, 5).
             sort("id", SortOrder.DESCENDING).
             excludedAttributes("addresses", "phoneNumbers").
             invokePost(UserResource.class);
 
-    assertEquals(returnedUsers.getTotalResults(), 1);
+    assertEquals(returnedUsers.getTotalResults(), 100);
     assertEquals(returnedUsers.getStartIndex(), Integer.valueOf(1));
-    assertEquals(returnedUsers.getItemsPerPage(), Integer.valueOf(1));
+    assertEquals(returnedUsers.getItemsPerPage(), Integer.valueOf(5));
 
     // Now with application/json
     WebTarget target = target().register(

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestResourceEndpoint.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestResourceEndpoint.java
@@ -36,6 +36,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import java.util.Random;
+
 import static com.unboundid.scim2.common.utils.ApiConstants.MEDIA_TYPE_SCIM;
 
 /**
@@ -117,8 +119,16 @@ public class TestResourceEndpoint
     resource.setId("123");
 
     SimpleSearchResults<UserResource> results =
-        new SimpleSearchResults<>(RESOURCE_TYPE_DEFINITION, uriInfo);
+        new SimpleSearchResults<>(RESOURCE_TYPE_DEFINITION, uriInfo, 10);
     results.add(resource);
+
+    Random random = new Random();
+    for (int i = 0; i < 99; i++)
+    {
+      resource = new UserResource().setUserName(String.format("test_%d", i));
+      resource.setId(random.ints().findFirst().toString());
+      results.add(resource);
+    }
 
     return results;
   }


### PR DESCRIPTION
Add a param `maxResults` to limit the number of elements returns when using a `SimpleSearchResults` object (see com.unboundid.scim2.common.types.FilterConfig#maxResults).

When using `null` value , no limitation is used.


