### PR TITLE
Enhance the Path class with new methods and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## v4.0.1 - TBD
+Added new methods to the Path class to simplify certain usages and make interaction, especially
+instantiation, less verbose. These include:
+* Creation of simple attributes (e.g., `username`) previously had to be performed with
+  `Path.root().attribute("userName")`, but can now be done with `Path.of("userName")`. Note that
+  this may only be used for simple, top-level attributes that are typically hard-coded.
+* For fetching the last element in a path, library calls such as
+  `path.getElement(path.size() - 1)` can now be shortened to `path.getLastElement()`.
+
+Updated the documentation of the Path class to elaborate on the definition of an attribute path, as
+well as provide examples for how to interface with the class.
+
 Simplified integration with the `scim2-sdk-client` library by updating subclasses of
 `RequestBuilder` to always provide `GenericScimResource` objects for JSON payloads. In previous
 releases, applications needed to use the right JSON properties in the environment so that the client

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/GenericScimResource.java
@@ -97,16 +97,16 @@ import java.util.Objects;
 public class GenericScimResource implements ScimResource
 {
   @NotNull
-  private static final Path SCHEMAS = Path.root().attribute("schemas");
+  private static final Path SCHEMAS = Path.of("schemas");
 
   @NotNull
-  private static final Path ID = Path.root().attribute("id");
+  private static final Path ID = Path.of("id");
 
   @NotNull
-  private static final Path EXTERNAL_ID = Path.root().attribute("externalId");
+  private static final Path EXTERNAL_ID = Path.of("externalId");
 
   @NotNull
-  private static final Path META = Path.root().attribute("meta");
+  private static final Path META = Path.of("meta");
 
   @NotNull
   private final ObjectNode objectNode;

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
@@ -122,8 +122,11 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toLowerCase;
  * The following Java code represents ways to target fields in the example
  * resource shown above:
  * <pre><code>
- *  // These are equivalent, and both target the 'userName' attribute.
+ *  // Primary way to create a path. This targets the 'userName' attribute.
  *  Path.root().attribute("userName");
+ *
+ *  // An alternate way to target the 'userName' attribute. This method is
+ *  // mostly useful for hard-coded string inputs.
  *  Path.of("userName");
  *
  *  // Target values within the 'addresses' array with postal code values that
@@ -132,7 +135,7 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toLowerCase;
  *
  *  // Target the 'givenName' sub-attribute that is nested within the complex
  *  // 'name' attribute.
- *  Path.of("name").attribute("givenName");
+ *  Path.root("name").attribute("givenName");
  *
  *  // Target a schema extension object. Schema extension URNs are considered
  *  // part of the root.
@@ -523,7 +526,7 @@ public final class Path implements Iterable<Path.Element>
 
   /**
    * Create a new top-level attribute. This is typically used for hard-coded
-   * values, since this method is shorthand for:
+   * strings, since this method is shorthand for:
    * <pre><code>
    *   Path.root().attribute("attributeName");
    * </code></pre>
@@ -534,23 +537,20 @@ public final class Path implements Iterable<Path.Element>
    * <pre>
    *   {
    *     "schemas": [ "urn:ietf:params:scim:schemas:core:2.0:User" ],
-   *     "id": "0xdeadbeef",
+   *     "id": "5ca1e",
    *     "name": {
    *       "givenName": "Clark"
    *     }
    *   }
    * </pre>
    *
-   * This method may be used to construct the following paths:
+   * This method may be used to construct the following paths. Note that
+   * {@code name.givenName} is not permitted as an input.
    * <pre><code>
    *   // Target the top-level attributes.
    *   Path schemas = Path.of("schemas");
    *   Path id = Path.of("id");
    *   Path name = Path.of("name");
-   *
-   *   // Target the 'givenName' sub-attribute. Note that 'name.givenName' is
-   *   // not permitted as an input.
-   *   Path familyPath = Path.of("name").attribute("givenName");
    * </code></pre>
    *
    * @param attribute The name of the top-level attribute. It should not be a

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -234,7 +234,6 @@ public abstract class PatchOperation
     {
       return path != null
           && path.size() > 0
-          && path.getElement(0) != null
           && path.getElement(0).getValueFilter() != null;
     }
 

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/FilterEvaluator.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/FilterEvaluator.java
@@ -57,7 +57,7 @@ public class FilterEvaluator implements FilterVisitor<Boolean, JsonNode>
   private static final FilterEvaluator SINGLETON = new FilterEvaluator();
 
   @NotNull
-  private static final Path VALUE_PATH = Path.root().attribute("value");
+  private static final Path VALUE_PATH = Path.of("value");
 
   /**
    * Evaluate the provided filter against the provided JsonNode.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonDiff.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonDiff.java
@@ -446,10 +446,10 @@ public class JsonDiff
   @Nullable
   private Filter generateValueFilter(@NotNull final JsonNode value)
   {
-    if (value.isValueNode())
+    if (value instanceof ValueNode valueNode)
     {
       // Use the implicit "value" sub-attribute to reference this value.
-      return Filter.eq(Path.root().attribute("value"), (ValueNode) value);
+      return Filter.eq(Path.of("value"), valueNode);
     }
     if (value.isObject())
     {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/Parser.java
@@ -294,8 +294,7 @@ public class Parser
       {
         // the only time this is allowed to occur is if the previous attribute
         // had a value filter, in which case, consume the token and move on.
-        if (path.isRoot() ||
-            path.getElement(path.size()-1).getValueFilter() == null)
+        if (path.isRoot() || path.getLastElement().getValueFilter() == null)
         {
           final String msg = String.format(
               "Attribute name expected at position %d", reader.mark);

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
@@ -537,9 +537,9 @@ public class FilterEvaluatorTestCase
         }""");
 
     // Test the variant that takes Path and Filter objects.
-    complexFilter = Filter.complex(Path.root().attribute("addresses"),
+    complexFilter = Filter.complex(Path.of("addresses"),
         Filter.eq("postalCode", "12345"));
-    alternateFilter = Filter.hasComplexValue(Path.root().attribute("addresses"),
+    alternateFilter = Filter.hasComplexValue(Path.of("addresses"),
         Filter.eq("postalCode", "12345"));
 
     // The filters should be equivalent, and both should match only the

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/JsonUtilsTestCase.java
@@ -1060,31 +1060,28 @@ public class JsonUtilsTestCase
 
     return new Object[][] {
         {
-            "{}", Path.root().attribute("simpleString"), false
+            "{}", Path.of("simpleString"), false
         },
         {
-            jsonString, Path.root().attribute("simpleString"), true
+            jsonString, Path.of("simpleString"), true
         },
         {
-            jsonString, Path.root().attribute("nullValue"), true
-        },
-        {
-            jsonString,
-            Path.root().attribute("singleComplex").attribute("address").
-                attribute("l1"), true
+            jsonString, Path.of("nullValue"), true
         },
         {
             jsonString,
-            Path.root().attribute("singleComplex").attribute("address").
-                attribute("l3"), false
+            Path.of("singleComplex").attribute("address").attribute("l1"), true
         },
         {
             jsonString,
-            Path.root().attribute("missing"), false
+            Path.of("singleComplex").attribute("address").attribute("l3"), false
+        },
+        {
+            jsonString, Path.of("missing"), false
         },
         {
             jsonString,
-            Path.root().attribute("singleComplex").attribute("address").
+            Path.of("singleComplex").attribute("address").
                 attribute("nullValue"),
             true
         },

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/utils/SchemaChecker.java
@@ -317,8 +317,7 @@ public class SchemaChecker
       Path path = patchOp.getPath();
       JsonNode value = patchOp.getJsonNode();
       Filter valueFilter =
-          path == null ? null :
-              path.getElement(path.size() - 1).getValueFilter();
+          path == null ? null : path.getLastElement().getValueFilter();
       AttributeDefinition attribute = path == null ? null :
           resourceType.getAttributeDefinition(path);
       if (path != null && attribute == null)
@@ -877,7 +876,7 @@ public class SchemaChecker
       }
     }
 
-    Filter valueFilter = path.getElement(path.size() - 1).getValueFilter();
+    Filter valueFilter = path.getLastElement().getValueFilter();
     if (attribute.equals(SchemaUtils.SCHEMAS_ATTRIBUTE_DEFINITION) &&
         valueFilter != null)
     {
@@ -980,7 +979,7 @@ public class SchemaChecker
         }
         Path parentPath = path.subPath(path.size() - 1);
         Path valuePath = parentPath.attribute(
-            path.getElement(path.size() - 1).getAttribute() + "[" + i + "]");
+            path.getLastElement().getAttribute() + "[" + i + "]");
         checkAttributeValue(prefix, value, valuePath, attribute, results,
             currentObjectNode, isPartialReplace, isPartialAdd);
         i++;


### PR DESCRIPTION
Added two new methods, Path.of() and Path.getLastElement(), to simplify interactions with the Path class. In particular, this aims to make the creation of hard-coded simple attributes less verbose. As part of this update, the class-level Javadoc has been updated with more background and examples on how to interface with the class.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-50434