### PR TITLE
Fix ListResponse deserialization from strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ exception for a client that has entered potentially-sensitive information via UR
 This exception encourages SCIM clients to re-issue these requests as a POST search request that is
 less susceptible to leaking this information from web browsers or log data.
 
+Fixed an issue where deserialization of `ListResponse` objects could result in `ClassCastException`
+errors if an application tried to use fields stored in the `Resources` array. Now, the SCIM SDK
+supports these conversions (via Jackson `TypeReference` objects). See the class-level Javadoc of
+ListResponse for more information. As a result of this change, the map-based constructor,
+`com.unboundid.scim2.common.messages.ListResponse.ListResponse(java.util.Map)`, is now deprecated
+and will be removed in a future release.
+
 ## v4.0.0 - 2025-Jun-10
 Removed support for Java 11. The UnboundID SCIM 2 SDK now requires Java 17 or a later release.
 

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ListResponseBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/ListResponseBuilder.java
@@ -23,13 +23,12 @@ import com.unboundid.scim2.common.annotations.NotNull;
 import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.messages.ListResponse;
 
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 
 /**
- * A builder for ListResponses that is also a SearchResultHandler
+ * A builder for {@link ListResponse} that is also a SearchResultHandler
  * implementation.
  */
 public class ListResponseBuilder<T>
@@ -92,19 +91,18 @@ public class ListResponseBuilder<T>
   }
 
   /**
-   * Builds a List Response.
+   * Builds a {@link ListResponse} based on the values supplied to the builder.
    *
-   * @return generated ListResponse.
+   * @return A generated ListResponse.
    */
   @NotNull
   public ListResponse<T> build()
   {
-    final Map<String, Object> properties = new LinkedHashMap<>();
-    properties.put("totalResults", totalResults == null ?
-      resources.size() : totalResults);
-    properties.put("resources", resources);
-    properties.put("startIndex", startIndex);
-    properties.put("itemsPerPage", itemsPerPage);
-    return new ListResponse<>(properties);
+    return new ListResponse<>(
+        Optional.ofNullable(totalResults).orElse(resources.size()),
+        resources,
+        startIndex,
+        itemsPerPage
+    );
   }
 }


### PR DESCRIPTION
Converting JSON strings into ListResponses was previously not working correctly if a client application attempted to use objects within the Resources array. Specifically, this would result in ClassCastException errors. The main problem was that the class used a "delegating" constructor for deserialization, which does not allow a caller to specify the Java type for the "inner class" contained within the Resources array.

The class has been updated to support the use of TypeReferences during deserialization, now allowing callers to specify the nested Java type. An explanation for how to accomplish this has been added to the class-level Javadoc.

Since the delegating constructor is no longer needed for deserializing, it is now deprecated and will be removed in a future release.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-50506
Resolves #261 