### PR TITLE
Deprecate BaseScimResource#addExtensionValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ exception for a client that has entered potentially-sensitive information via UR
 This exception encourages SCIM clients to re-issue these requests as a POST search request that is
 less susceptible to leaking this information from web browsers or log data.
 
+Deprecated the `BaseScimResource#addExtensionValue` methods, since they allowed creating schema
+extension attributes whose values are arrays instead of objects. Since this is a form that is not
+used in practice, these methods will be removed in a future release.
+
 Fixed an issue where deserialization of `ListResponse` objects could result in `ClassCastException`
 errors if an application tried to use fields stored in the `Resources` array. Now, the SCIM SDK
 supports these conversions (via Jackson `TypeReference` objects). See the class-level Javadoc of

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
@@ -56,14 +56,16 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  * object since you will just have plain old getters and setters
  * for core attributes. Extension attributes cannot be bound to
  * members of the class but they can still be accessed using the
- * {@link #getExtensionObjectNode} method or the {@link #getExtensionValues},
- * {@link #replaceExtensionValue}, and {@link #addExtensionValue} methods.</p>
+ * {@link #getExtensionObjectNode} method or the {@link #getExtensionValues}
+ * and {@link #replaceExtensionValue} methods.
  *
  * <p>If you have a BaseScimResource derived object, you can always get a
  * {@link GenericScimResource} by calling {@link #asGenericScimResource()}.
  * You could also go the other way by calling
  * {@link GenericScimResource#getObjectNode()}, followed by
  * {@link JsonUtils#nodeToValue(JsonNode, Class)}.</p>
+ * See the {@code GenericScimResource} class-level documentation for more
+ * information.
  *
  * @see GenericScimResource
  */
@@ -464,7 +466,15 @@ public abstract class BaseScimResource
    * @param path The path to the attribute whose values to add.
    * @param values The value(s) to add.
    * @throws ScimException If the path is invalid.
+   *
+   * @deprecated  This method adds a schema extension whose value is an array,
+   *              which is not used in practice. Additionally, the SCIM SDK does
+   *              not support deserialization of JSON with array extensions into
+   *              a POJO. If necessary, this behavior can still be achieved by
+   *              fetching the ObjectNode with {@link #getExtensionObjectNode()}
+   *              and adding the array value manually.
    */
+  @Deprecated(since = "4.0.1")
   public void addExtensionValue(@Nullable final String path,
                                 @NotNull final ArrayNode values)
       throws ScimException
@@ -482,7 +492,15 @@ public abstract class BaseScimResource
    * @param path The path to the attribute whose values to add.
    * @param values The value(s) to add.
    * @throws ScimException If the path is invalid.
+   *
+   * @deprecated  This method adds a schema extension whose value is an array,
+   *              which is not used in practice. Additionally, the SCIM SDK does
+   *              not support deserialization of JSON with array extensions into
+   *              a POJO. If necessary, this behavior can still be achieved by
+   *              fetching the ObjectNode with {@link #getExtensionObjectNode()}
+   *              and adding the array value manually.
    */
+  @Deprecated(since = "4.0.1")
   public void addExtensionValue(@Nullable final Path path,
                                 @NotNull final ArrayNode values)
       throws ScimException


### PR DESCRIPTION
This commit deprecates the addExtensionValue methods, which would add schema extension data in array form. This formats the SCIM data in a way that is also incompatible with deserialization. To avoid confusion about whether such data formats are permitted, these methods will be removed in a future release.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-50646