### PR TITLE
Support non-standard patch group membership remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## v4.0.1 - TBD
+## v4.1.0 - TBD
 Added new methods to the Path class to simplify certain usages and make interaction, especially
 instantiation, less verbose. These include:
 * Creation of simple attributes (e.g., `username`) previously had to be performed with
@@ -45,6 +45,44 @@ Updated documentation for `GroupResource` and `Group` to highlight the distincti
 classes, as well as provide examples of how they may be used. GroupResource represents a group
 object/entity, whereas a `Group` is a subfield on a user resource (like `Email`). The documentation
 for `UserResource` was also updated.
+
+Added support for non-standard group membership patch remove requests that contain a value. An
+example JSON for this request type is shared below:
+```json
+    {
+      "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+      "Operations": [{
+        "op": "remove",
+        "path": "members",
+        "value": {
+          "members": [{
+            "value": "2819c223-7f76-453a-919d-413861904646"
+          }]
+        }
+      }]
+    }
+```
+RFC 7644 states that remove operations do not have a `value`. Nevertheless, some SCIM services
+mandate the use of such a field to process group membership operations. To help interface with these
+type of APIs, `PatchOperation` has new `removeOpValue()` and `getRemoveMemberList()` methods. This
+change includes support for applying these operations, where the SCIM SDK will transform the above
+request into the one shown below. For more details, see `PatchOperation#removeOpValue(JsonNode)`.
+Note that this request cannot be created with `PatchOperation#create` for backward compatibility.
+```json
+    {
+      "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+      "Operations": [{
+        "op": "remove",
+        "path": "members[value eq \"2819c223-7f76-453a-919d-413861904646\"]"
+      }]
+    }
+```
+
+The `PatchRequest` and `PatchOperation` classes have been updated so that they are no longer `final`
+and may be extended if desired.
+
+Added a new variant of `GroupResource#setMembers` that allows specifying members individually, so
+that arguments no longer need to be wrapped in a list.
 
 ## v4.0.0 - 2025-Jun-10
 Removed support for Java 11. The UnboundID SCIM 2 SDK now requires Java 17 or a later release.

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.unboundid.product.scim2</groupId>
   <artifactId>scim2-parent</artifactId>
-  <version>4.0.1-SNAPSHOT</version>
+  <version>4.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>UnboundID SCIM2 SDK Parent</name>
   <description>

--- a/scim2-assembly/pom.xml
+++ b/scim2-assembly/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-assembly</artifactId>
   <packaging>pom</packaging>

--- a/scim2-sdk-client/pom.xml
+++ b/scim2-sdk-client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>scim2-sdk-client</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/RequestBuilder.java
@@ -307,7 +307,7 @@ public class RequestBuilder<T extends RequestBuilder<T>>
    * @param resource  The SCIM resource that will be serialized into JSON.
    * @return  An equivalent GenericScimResource.
    *
-   * @since 4.0.1
+   * @since 4.1.0
    */
   @NotNull
   protected GenericScimResource generify(@NotNull final ScimResource resource)

--- a/scim2-sdk-common/pom.xml
+++ b/scim2-sdk-common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>scim2-parent</artifactId>
         <groupId>com.unboundid.product.scim2</groupId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>scim2-sdk-common</artifactId>
     <packaging>jar</packaging>

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/Path.java
@@ -462,7 +462,7 @@ public final class Path implements Iterable<Path.Element>
    * @throws IndexOutOfBoundsException  If this path is the root attribute
    *                                    (i.e., the element list size is 0).
    *
-   * @since 4.0.1
+   * @since 4.1.0
    */
   @NotNull
   public Element getLastElement() throws IndexOutOfBoundsException
@@ -560,7 +560,7 @@ public final class Path implements Iterable<Path.Element>
    * @throws IllegalArgumentException  If the attribute name is a sub-attribute
    * (e.g., "name.familyName"), schema extension, or contains a filter.
    *
-   * @since 4.0.1
+   * @since 4.1.0
    */
   @NotNull
   public static Path of(@NotNull final String attribute)

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ForbiddenException.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/exceptions/ForbiddenException.java
@@ -117,7 +117,7 @@ public class ForbiddenException extends ScimException
    * @param errorMsg  The error message for this SCIM exception.
    * @return  The new {@code ForbiddenException}.
    *
-   * @since 4.0.1
+   * @since 4.1.0
    */
   @NotNull
   public static ForbiddenException sensitive(@Nullable final String errorMsg)

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ListResponse.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ListResponse.java
@@ -171,7 +171,7 @@ public class ListResponse<T> extends BaseScimResource
    * this purpose.
    */
   @SuppressWarnings("unchecked")
-  @Deprecated(since = "4.0.1")
+  @Deprecated(since = "4.1.0")
   public ListResponse(@NotNull final Map<String, Object> props)
       throws IllegalArgumentException, IllegalStateException
   {

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
@@ -35,9 +35,13 @@ import java.util.Objects;
 import static com.unboundid.scim2.common.utils.StaticUtils.toList;
 
 /**
- * This class represents a SCIM 2 PATCH request. A patch request contains a list
- * of {@link PatchOperation} elements, where each patch operation represents a
- * change that should be applied to a SCIM resource. The following is an example
+ * This class represents a SCIM 2 PATCH request as defined by
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2">
+ * RFC 7644 Section 3.5.2</a>.
+ * <br><br>
+ *
+ * A patch request contains a list of {@link PatchOperation} elements. Each
+ * operation represents an update to a SCIM resource. This is an example
  * of a patch request in JSON form:
  * <pre>
  * {
@@ -57,11 +61,11 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  * This example request contains a single operation that sets the {@code active}
  * value to {@code true}. This request can be created with the following Java
  * code:
- * <pre>
+ * <pre><code>
  *   PatchRequest request = new PatchRequest(
  *       PatchOperation.replace("active", true)
  *   );
- * </pre>
+ * </code></pre>
  *
  * All patch requests are performed atomically. RFC 7644 Section 3.5.2 states
  * that if any operation within the operation list fails, then the resource
@@ -71,7 +75,7 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  */
 @Schema(id="urn:ietf:params:scim:api:messages:2.0:PatchOp",
     name="Patch Operation", description = "SCIM 2.0 Patch Operation Request")
-public final class PatchRequest
+public class PatchRequest
     extends BaseScimResource
     implements Iterable<PatchOperation>
 {
@@ -133,7 +137,7 @@ public final class PatchRequest
    *
    * @param object The GenericScimResourceObject to apply this patch to.
    *
-   * @throws ScimException If the one or more patch operations is invalid.
+   * @throws ScimException If one or more patch operations are invalid.
    */
   public void apply(@NotNull final GenericScimResource object)
       throws ScimException

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/GroupResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/GroupResource.java
@@ -25,6 +25,8 @@ import com.unboundid.scim2.common.annotations.Schema;
 import java.util.List;
 import java.util.Objects;
 
+import static com.unboundid.scim2.common.utils.StaticUtils.toList;
+
 /**
  * This class represents a group object as defined by
  * <a href="https://datatracker.ietf.org/doc/html/rfc7643#section-4.2">
@@ -68,7 +70,7 @@ import java.util.Objects;
  * <pre><code>
  *   GroupResource group = new GroupResource()
  *       .setDisplayName("Example Group With One Member")
- *       .setMembers(List.of(new Member().setValue("cab1e").setType("DIRECT")));
+ *       .setMembers(new Member().setValue("cab1e").setType("DIRECT"));
  *   group.setId("8e4d749e-6dde-420a-8d71-00faf8d57510");
  * </code></pre>
  */
@@ -143,6 +145,24 @@ public class GroupResource extends BaseScimResource
   }
 
   /**
+   * Alternate version of {@link #setMembers(List)} that accepts individual
+   * Member objects that are not contained in a list.
+   *
+   * @param member    The first member to add. This must not be {@code null}.
+   * @param members   An optional set of additional arguments. Any {@code null}
+   *                  values will be ignored.
+   * @return This object.
+   *
+   * @since 4.1.0
+   */
+  @NotNull
+  public GroupResource setMembers(@NotNull final Member member,
+                                  @Nullable final Member... members)
+  {
+    return setMembers(toList(member, members));
+  }
+
+  /**
    * Indicates whether the provided object is equal to this group resource.
    *
    * @param o   The object to compare.
@@ -165,7 +185,7 @@ public class GroupResource extends BaseScimResource
       return false;
     }
     final GroupResource that = (GroupResource) o;
-    return displayName.equals(that.displayName) &&
+    return Objects.equals(displayName, that.displayName) &&
         Objects.equals(members, that.members);
   }
 

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Member.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Member.java
@@ -185,7 +185,7 @@ public class Member
     }
     final Member member = (Member) o;
     return value.equals(member.value) &&
-        ref.equals(member.ref) &&
+        Objects.equals(ref, member.ref) &&
         Objects.equals(type, member.type) &&
         Objects.equals(display, member.display);
   }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/NonStandardRemoveOperationTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/NonStandardRemoveOperationTest.java
@@ -1,0 +1,669 @@
+/*
+ * Copyright 2025 Ping Identity Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPLv2 only)
+ * or the terms of the GNU Lesser General Public License (LGPLv2.1 only)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses>.
+ */
+
+package com.unboundid.scim2.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.unboundid.scim2.common.exceptions.BadRequestException;
+import com.unboundid.scim2.common.messages.PatchOperation;
+import com.unboundid.scim2.common.messages.PatchRequest;
+import com.unboundid.scim2.common.types.GroupResource;
+import com.unboundid.scim2.common.types.Member;
+import com.unboundid.scim2.common.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+/**
+ * This class contains tests for {@code remove} PATCH operations that set a
+ * {@code value} field in the JSON. This is typically used for group membership
+ * updates that involve removing a user from a group resource. See
+ * {@link PatchOperation#removeOpValue(JsonNode)} for more details.
+ * <br><br>
+ *
+ * The canonical, correct way to remove a member from a group leverages a value
+ * filter of the following form:
+ * <pre>
+ *   {
+ *      "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+ *      "Operations": [{
+ *        "op": "remove",
+ *        "path": "members[value eq \"2819c223-7f76-453a-919d-413861904646\"]"
+ *      }]
+ *    }
+ * </pre>
+ *
+ * However, some SCIM services require providing the user/member ID in a
+ * {@code value} field instead of the filter:
+ * <pre>
+ *   {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+ *     "Operations": [{
+ *       "op": "remove",
+ *       "path": "members",
+ *       "value": {
+ *         "members": [{
+ *           "value": "2819c223-7f76-453a-919d-413861904646"
+ *         }]
+ *       }
+ *     }]
+ *   }
+ * </pre>
+ *
+ * Other service providers also require a {@code value} field, but structure the
+ * data differently:
+ * <pre>
+ *   {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+ *     "Operations": [{
+ *       "op": "remove",
+ *       "path": "members",
+ *       "value": [{
+ *         "$ref": null,
+ *         "value": "2819c223-7f76-453a-919d-413861904646"
+ *       }]
+ *     }]
+ *   }
+ * </pre>
+ *
+ * Note that for both cases above, the {@code value} stored directly under the
+ * {@code Operations} field refers to the patch operation value, and the nested
+ * {@code value} field refers to the {@link Member#getValue} property.
+ * <br><br>
+ *
+ * The SCIM SDK supports these operations by deserializing them properly.
+ * Whenever {@link PatchOperation#apply} is invoked to process the update, the
+ * SCIM SDK will convert the request to use a value filter (in the form shown in
+ * the first example) before attempting to modify the resource.
+ */
+public class NonStandardRemoveOperationTest
+{
+  /**
+   * Basic validation for non-standard remove patch operations. See the
+   * class-level Javadoc for more information.
+   */
+  @Test
+  public void testBasic() throws Exception
+  {
+    PatchOperation op;
+    Member member;
+
+    GroupResource origGroup = new GroupResource()
+        .setDisplayName("testGroup")
+        .setMembers(new Member().setValue("ca11ab1e"),
+                    new Member().setValue("c0a1e5ce"),
+                    new Member().setValue("50f7ba11"),
+                    new Member().setValue("e5ca1a7e"),
+                    new Member().setValue("def1ec75"),
+                    new Member().setValue("ba5eba11"));
+    ObjectNode group = origGroup.asGenericScimResource().getObjectNode();
+
+    int groupSize = 6;
+    assertThat(group.get("members")).hasSize(groupSize);
+
+    // Attempt removing an unrelated member.
+    member = new Member().setValue("fa1afe1");
+    op = PatchOperation.remove("members").removeOpValue(List.of(member), true);
+    op.apply(group);
+    assertThat(group.get("members")).hasSize(groupSize);
+
+    // Using the library methods, remove a member by specifying the "value"
+    // field in the JSON.
+    String memberID = "ca11ab1e";
+    member = new Member().setValue(memberID);
+    op = PatchOperation.remove("members").removeOpValue(List.of(member), true);
+    groupSize--;
+    op.apply(group);
+    assertThat(group.get("members")).hasSize(groupSize);
+    assertThat(group.toString()).doesNotContain(memberID);
+
+    // Remove multiple members in a single request.
+    op = PatchOperation.remove("members")
+        .removeOpValue(List.of(
+            new Member().setValue("c0a1e5ce"),
+            new Member().setValue("50f7ba11")
+        ), true);
+    groupSize -= 2;
+    op.apply(group);
+    assertThat(group.get("members")).hasSize(groupSize);
+    assertThat(group.toString()).doesNotContain("c0a1e5ce", "50f7ba11");
+
+    // Remove a member using the alternate JSON structure.
+    memberID = "e5ca1a7e";
+    member = new Member().setValue(memberID);
+    op = PatchOperation.remove("members").removeOpValue(List.of(member), false);
+    groupSize--;
+    op.apply(group);
+    assertThat(group.get("members")).hasSize(groupSize);
+    assertThat(group.toString()).doesNotContain(memberID);
+
+    // Remove multiple members in a single request with the alternate JSON
+    // structure (by providing "false").
+    op = PatchOperation.remove("members")
+        .removeOpValue(List.of(
+            new Member().setValue("def1ec75"),
+            new Member().setValue("ba5eba11")
+        ), false);
+    groupSize -= 2;
+    op.apply(group);
+    assertThat(groupSize).isEqualTo(0);
+    assertThat(group.get("members")).isNull();
+    assertThat(group.toString()).doesNotContain("def1ec75", "ba5eba11");
+
+    // Passing a non-initialized Member value to 'removeOpValue()' should be a
+    // no-op.
+    PatchOperation initialRemove = PatchOperation.remove("members")
+        .removeOpValue(List.of(new Member().setValue("value")), true);
+    JsonNode initialState = initialRemove.getJsonNode();
+
+    initialRemove.removeOpValue(null, true);
+    assertThat(initialRemove.getJsonNode()).isEqualTo(initialState);
+    initialRemove.removeOpValue(List.of(), true);
+    assertThat(initialRemove.getJsonNode()).isEqualTo(initialState);
+    initialRemove.removeOpValue(Arrays.asList(null, null), true);
+    assertThat(initialRemove.getJsonNode()).isEqualTo(initialState);
+
+    // removeOpValue() should not be permitted for other operation types.
+    var addOp = PatchOperation.add("userName", TextNode.valueOf("initialVal"));
+    assertThatThrownBy(() -> addOp.removeOpValue(TextNode.valueOf("value")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("The 'removeValue()' method may only be used for")
+        .hasMessageContaining("remove operations.");
+    var replaceOp = PatchOperation.replace("userName", "newValue");
+    assertThatThrownBy(() -> replaceOp.removeOpValue(TextNode.valueOf("value")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("The 'removeValue()' method may only be used for")
+        .hasMessageContaining("remove operations.");
+  }
+
+  /**
+   * Validate behavior for deserialized patch requests.
+   */
+  @Test
+  public void testDeserialization() throws Exception
+  {
+    // Deserialize a JSON string.
+    PatchRequest deserialized = JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue("""
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [{
+                "op": "remove",
+                "path": "members",
+                "value": {
+                  "members": [{
+                    "value": "2819c223"
+                  }]
+                }
+              }]
+            }
+            """);
+
+    // Construct an equivalent patch request and ensure it is equal.
+    PatchRequest pojo = new PatchRequest(
+        PatchOperation.remove("members")
+            .removeOpValue(List.of(new Member().setValue("2819c223")), true)
+    );
+    assertThat(deserialized).isEqualTo(pojo);
+
+    // Repeat this for the other type of group membership removal request.
+    deserialized = JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue("""
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [{
+                  "op": "remove",
+                  "path": "members",
+                  "value": [{
+                      "value": "2819c223"
+                  }]
+              }]
+            }
+            """);
+    pojo = new PatchRequest(
+        PatchOperation.remove("members")
+            .removeOpValue(List.of(new Member().setValue("2819c223")), false)
+    );
+    assertThat(deserialized).isEqualTo(pojo);
+
+    // Remove operations must always have a path, even for ones with a value.
+    String jsonWithoutPath = """
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [{
+                  "op": "remove",
+                  "value": [{
+                      "value": "2819c223"
+                  }]
+              }]
+            }
+            """;
+    assertThatThrownBy(() -> JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue(jsonWithoutPath))
+        .isInstanceOf(JsonProcessingException.class)
+        .hasMessageContaining("Missing required creator property 'path'");
+
+    // Ensure explicit null values are deserialized correctly.
+    PatchRequest explicitNullValue = JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue("""
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [{
+                "op": "remove",
+                "path": "members",
+                "value": null
+              }]
+            }
+            """);
+    PatchOperation operation = explicitNullValue.getOperations().get(0);
+    assertThat(operation.getJsonNode())
+        .isNotEqualTo(NullNode.getInstance())
+        .isNull();
+  }
+
+  /**
+   * Explicitly ensure that a patch with an empty member array does not modify
+   * the target resource.
+   */
+  @Test
+  public void testEmpty() throws Exception
+  {
+    GroupResource origGroup = new GroupResource().setDisplayName("testGroup");
+    origGroup.setMembers(
+        new Member().setValue("ca11ab1e"),
+        new Member().setValue("c0a1e5ce"),
+        new Member().setValue("50f7ba11")
+    );
+    GenericScimResource group = origGroup.asGenericScimResource();
+    final int groupSize = 3;
+
+    PatchRequest request = JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue("""
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [{
+                "op": "remove",
+                "path": "members",
+                "value": {
+                  "members": []
+                }
+              }]
+            }
+            """);
+    request.apply(group);
+
+    // Ensure the resource is unmodified.
+    assertThat(group.getValue("members"))
+        .isInstanceOfSatisfying(ArrayNode.class,
+            a -> assertThat(a).hasSize(groupSize));
+
+    // Repeat for the alternate modification type.
+    request = JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue("""
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [{
+                "op": "remove",
+                "path": "members",
+                "value": []
+              }]
+            }
+            """);
+    request.apply(group);
+    assertThat(group.getValue("members"))
+        .isInstanceOfSatisfying(ArrayNode.class,
+            a -> assertThat(a).hasSize(groupSize));
+  }
+
+  /**
+   * Test multiple flavors of these remove operations contained within a single
+   * request.
+   */
+  @Test
+  public void testMultiple() throws Exception
+  {
+    GroupResource origGroup = new GroupResource().setDisplayName("testGroup");
+    origGroup.setMembers(
+        new Member().setValue("ca11ab1e"),
+        new Member().setValue("c0a1e5ce"),
+        new Member().setValue("50f7ba11")
+    );
+    GenericScimResource group = origGroup.asGenericScimResource();
+
+    PatchRequest request = JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue("""
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [
+                {
+                  "op": "remove",
+                  "path": "members",
+                  "value": {
+                    "members": [{
+                      "value": "ca11ab1e"
+                    }]
+                  }
+                },
+                {
+                  "op": "remove",
+                  "path": "members",
+                  "value": {
+                    "members": []
+                  }
+                },
+                {
+                  "op": "remove",
+                  "path": "members",
+                  "value": {
+                    "members": [
+                      {
+                        "value": "c0a1e5ce"
+                      },
+                      {
+                        "value": "50f7ba11"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+            """);
+    request.apply(group);
+    assertThat(group.getObjectNode().get("members")).isNull();
+
+    // Repeat the same modifications for the other type of group membership
+    // removal request.
+    group = origGroup.asGenericScimResource();
+    request = JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue("""
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [
+                {
+                  "op": "remove",
+                  "path": "members",
+                  "value": [{
+                      "value": "ca11ab1e"
+                  }]
+                },
+                {
+                  "op": "remove",
+                  "path": "members",
+                  "value": []
+                },
+                {
+                  "op": "remove",
+                  "path": "members",
+                  "value": [
+                    {
+                        "value": "c0a1e5ce"
+                    },
+                    {
+                        "value": "50f7ba11"
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+    request.apply(group);
+    assertThat(group.getObjectNode().get("members")).isNull();
+  }
+
+  /**
+   * Remove operation tests for {@link PatchOperation#getJsonNode()}.
+   */
+  @Test
+  public void testGetJsonNode() throws Exception
+  {
+    // Fetch getJsonNode() for a standard remove operation, which should always
+    // be null.
+    PatchOperation op = JsonUtils.getObjectReader()
+        .forType(PatchOperation.class).readValue("""
+            {
+              "op": "remove",
+              "path": "members[value eq \\"2819c223\\"]"
+            }
+            """);
+    assertThat(op.getJsonNode()).isNull();
+
+    // For a remove operation with a value field, the stored JSON field should
+    // be returned.
+    PatchOperation opWithValue = JsonUtils.getObjectReader()
+        .forType(PatchOperation.class).readValue("""
+            {
+              "op": "remove",
+              "path": "members",
+              "value": [{
+                "value": "2819c223"
+              }]
+            }
+            """);
+
+    ArrayNode expected = JsonUtils.getJsonNodeFactory().arrayNode();
+    expected.add(JsonUtils.getJsonNodeFactory().objectNode()
+        .set("value", TextNode.valueOf("2819c223")));
+    assertThat(opWithValue.getJsonNode()).isEqualTo(expected);
+  }
+
+  /**
+   * This test ensures that appropriate error messages are returned when using
+   * JSON values that are improperly formatted.
+   */
+  @Test
+  public void testApplyingInvalidOperations() throws Exception
+  {
+    GenericScimResource resource = new GenericScimResource();
+
+    // Applying this operation is invalid because we only support targeting
+    // "members".
+    PatchRequest opWithNestedAttr = JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue("""
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [{
+                "op": "remove",
+                "path": "emails",
+                "value": {
+                  "members": []
+                }
+              }]
+            }
+            """);
+    assertThatThrownBy(() -> opWithNestedAttr.apply(resource))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("Cannot apply the operation since it has a")
+        .hasMessageContaining("value, but an invalid 'emails' path.");
+
+    // Applying this operation is invalid because the path has a value filter.
+    PatchRequest operationWithFilter = JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue("""
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [{
+                "op": "remove",
+                "path": "members[value sw \\"existingFilterValue\\"]",
+                "value": {
+                  "members": []
+                }
+              }]
+            }
+            """);
+    assertThatThrownBy(() -> operationWithFilter.apply(resource))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("Cannot apply the operation since it has a")
+        .hasMessageContaining("value, but an invalid 'members[value sw");
+
+    // Applying this operation is invalid because the Member field has other
+    // attributes such as '$ref' and 'display', but it does not have 'value'.
+    PatchRequest opWithBadValue = JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue("""
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [{
+                "op": "remove",
+                "path": "members",
+                "value": {
+                  "members": [{
+                    "$ref": "https://example.com/",
+                    "display": "A Member Object Without A Value"
+                  }]
+                }
+              }]
+            }
+            """);
+    assertThatThrownBy(() -> opWithBadValue.apply(resource))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("The remove operation was formatted incorrectly")
+        .hasMessageContaining("because it did not contain a Member object with")
+        .hasMessageContaining("a 'value' subfield set.");
+    PatchRequest otherOpWithBadValue = JsonUtils.getObjectReader()
+        .forType(PatchRequest.class).readValue("""
+            {
+              "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+              "Operations": [{
+                "op": "remove",
+                "path": "members",
+                "value": [{
+                  "$ref": "https://example.com/",
+                  "display": "Other Type Of Member Object Without A Value"
+                }]
+              }]
+            }
+            """);
+    assertThatThrownBy(() -> otherOpWithBadValue.apply(resource))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("The remove operation was formatted incorrectly")
+        .hasMessageContaining("because it did not contain a Member object with")
+        .hasMessageContaining("a 'value' subfield set.");
+  }
+
+  /**
+   * Tests for the {@link PatchOperation#getRemoveMemberList} method.
+   */
+  @Test
+  public void testGetMemberList() throws Exception
+  {
+    final ObjectReader reader =
+        JsonUtils.getObjectReader().forType(PatchOperation.class);
+
+    // The method must only be callable for remove operations.
+    PatchOperation invalid;
+    invalid = PatchOperation.add("path", TextNode.valueOf("value"));
+    assertThatThrownBy(invalid::getRemoveMemberList)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Fetching members is only supported for")
+        .hasMessageContaining("'remove' operations");
+    invalid = PatchOperation.replace("path", TextNode.valueOf("value"));
+    assertThatThrownBy(invalid::getRemoveMemberList)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Fetching members is only supported for")
+        .hasMessageContaining("'remove' operations");
+
+    // A standard-compliant remove operation should return an empty list.
+    PatchOperation standard = reader.readValue("""
+            {
+              "op": "remove",
+              "path": "members[value eq \\"2819c223\\"]"
+            }""");
+    assertThat(standard.getRemoveMemberList()).isNotNull().isEmpty();
+
+    // Ensure a nested member array is properly converted.
+    PatchOperation nestedType = reader.readValue("""
+            {
+              "op": "remove",
+              "path": "members",
+              "value": {
+                "members": [{
+                  "value": "2819c223",
+                  "type": "nested"
+                }]
+              }
+            }""");
+
+    assertThat(nestedType.getRemoveMemberList())
+        .hasSize(1)
+        .containsExactly(new Member().setValue("2819c223").setType("nested"));
+
+    // Repeat this for the un-nested group membership removal request type.
+    PatchOperation notNestedType = reader.readValue("""
+            {
+              "op": "remove",
+              "path": "members",
+              "value": [
+                {
+                  "value": "2819c223",
+                  "type": "first"
+                },
+                {
+                  "value": "2819c223",
+                  "type": "second"
+                }
+              ]
+            }""");
+    assertThat(notNestedType.getRemoveMemberList())
+        .hasSize(2)
+        .containsExactly(
+            new Member().setValue("2819c223").setType("first"),
+            new Member().setValue("2819c223").setType("second")
+        );
+
+    // A JSON with invalid array data should throw an exception. This patch
+    // operation does not have a "value.members" array.
+    PatchOperation invalidValue = reader.readValue("""
+            {
+              "op": "remove",
+              "path": "members",
+              "value": {
+                "otherData": "extraneous"
+              }
+            }""");
+    assertThatThrownBy(invalidValue::getRemoveMemberList)
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("Could not extract a Member object list from the")
+        .hasMessageContaining("patch operation");
+
+    // A JSON with an invalid Member object should throw an exception.
+    PatchOperation invalidMember = reader.readValue("""
+            {
+              "op": "remove",
+              "path": "members",
+              "value": {
+                "members": [{
+                  "userName": "notAMemberObject",
+                  "displayName": "Actually A UserResource",
+                  "timezone": "America/Los_Angeles"
+                }]
+              }
+            }""");
+    assertThatThrownBy(invalidMember::getRemoveMemberList)
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("The provided JSON contained an invalid Member")
+        .hasMessageContaining("representation.");
+  }
+}

--- a/scim2-sdk-server/pom.xml
+++ b/scim2-sdk-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>scim2-parent</artifactId>
     <groupId>com.unboundid.product.scim2</groupId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-sdk-server</artifactId>
   <packaging>jar</packaging>

--- a/scim2-ubid-extensions/pom.xml
+++ b/scim2-ubid-extensions/pom.xml
@@ -19,7 +19,7 @@
   <parent>
       <artifactId>scim2-parent</artifactId>
       <groupId>com.unboundid.product.scim2</groupId>
-      <version>4.0.1-SNAPSHOT</version>
+      <version>4.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim2-ubid-extensions</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
Some SCIM service providers mandate patch remove requests that violate the standard's definition. This has been seen specifically for requests that seek to update a group to remove one or more members. For more details and background, see the new PatchOperation#removeOpValue method, as well as the documentation for the
NonStandardRemoveOperationTest test class.

To help clients interface with these endpoints, a new removeOpValue() method has been added that allows setting a value on a remove operation conditionally. Support for applying these updates to a SCIM resource has also been added to provide server-side support.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-50483
Resolves #174