### PR TITLE
Add Java 25 to the GitHub Actions pipeline. 

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -2,8 +2,8 @@ name: Build Status
 
 on:
   push:
-    # Run tests on any push to feature branches.
-    branches: [ "master", "main", "DS-[0-9]+*", "ubid-test" ]
+    # Run tests on any push to the main branch.
+    branches: [ "master", "main", "ubid-test" ]
   pull_request:
     branches: [ "master", "main" ]
 


### PR DESCRIPTION
JDK 25 is the newest LTS release of Java, and was released last month.
This release has now been added to the build automation for pull
requests.

The EndpointTestCase has been known to intermittently fail when multiple
runners are executing the test class at the same time. Adding a third
parallel runner will make failures much more likely. To resolve this,
the tests will be run sequentially to avoid socket exceptions. This
slightly increases the execution time for reliability.

Since test cases are run sequentially now, the dedicated Checkstyle
stage has been removed, as linting errors will always fail on the first
build.

Reviewer: vyhhuang

JiraIssue: DS-50774