### PR TITLE
Include a test to evaluate empty array diffs

### DIFF
--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/DiffTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/DiffTestCase.java
@@ -29,7 +29,6 @@ import com.unboundid.scim2.common.types.Name;
 import com.unboundid.scim2.common.types.PhoneNumber;
 import com.unboundid.scim2.common.types.Photo;
 import com.unboundid.scim2.common.utils.JsonUtils;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -40,9 +39,9 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.fail;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 /**
  * Test the SCIM resource diff utility.


### PR DESCRIPTION
Add coverage for JsonDiff calculations between null values and empty
arrays. These should be treated as equivalent.

This was originally created for a previous PR that was not merged (#75),
so the test case is being added now.

Reviewer: dougbulkley

JiraIssue: DS-14934