### PR TITLE
Allow null $ref fields for Member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ rely on libraries provided with Java SE instead. A new `DateTimeUtils.parse(long
 added, but the API of the `DateTimeUtils` class has remained unchanged otherwise. Existing projects
 that upgrade to this version of the library should not require any changes.
 
+Updated the definition of the `Member` class so that `$ref` is no longer a `required` attribute,
+since it is a reflection of the `value` parameter and is sometimes set to `null` in practice.
+
 ## v4.1.0 - 2025-Oct-06
 Added new methods to the Path class to simplify certain usages and make interaction, especially
 instantiation, less verbose. These include:

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Member.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/Member.java
@@ -51,7 +51,7 @@ public class Member
 
   @Nullable
   @Attribute(description = "The URI of the member resource.",
-      isRequired = true,
+      isRequired = false,
       referenceTypes = { "User", "Group" },
       mutability = AttributeDefinition.Mutability.IMMUTABLE,
       returned = AttributeDefinition.Returned.DEFAULT,


### PR DESCRIPTION
The $ref field of the Member class has been updated to remove the requirement that it must always be set. This is not explicitly required by the standard, so it is no longer being enforced.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-50893

Resolves #269