### PR TITLE
Avoid errors when parsing list responses. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ that upgrade to this version of the library should not require any changes.
 Updated the definition of the `Member` class so that `$ref` is no longer a `required` attribute,
 since it is a reflection of the `value` parameter and is sometimes set to `null` in practice.
 
+Fixed an issue with SearchRequestBuilder where it was possible for the parser to hang if a list
+response contained undefined attributes.
+
 ## v4.1.0 - 2025-Oct-06
 Added new methods to the Path class to simplify certain usages and make interaction, especially
 instantiation, less verbose. These include:

--- a/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/SearchRequestBuilder.java
+++ b/scim2-sdk-client/src/main/java/com/unboundid/scim2/client/requests/SearchRequestBuilder.java
@@ -272,9 +272,7 @@ public class SearchRequestBuilder
            JsonParser parser = factory.createParser(inputStream))
       {
         parser.nextToken();
-
-        boolean proceed = true;
-        while (proceed && parser.nextToken() != JsonToken.END_OBJECT)
+        while (!parser.isClosed() && parser.nextToken() != JsonToken.END_OBJECT)
         {
           String field = String.valueOf(parser.currentName());
           parser.nextToken();
@@ -298,7 +296,6 @@ public class SearchRequestBuilder
               {
                 if (!resultHandler.resource(parser.readValueAs(cls)))
                 {
-                  proceed = false;
                   break;
                 }
               }

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/EndpointTestCase.java
@@ -1169,6 +1169,35 @@ public class EndpointTestCase extends JerseyTestNg.ContainerPerClassTest
 
 
   /**
+   * Validate an edge case where a list response with an unknown attribute is
+   * included at the very end of a response. In previous releases, this caused
+   * parsing issues. The list response returned by the service is defined in
+   * {@link TestResourceEndpoint#testLastFieldUnknown}.
+   */
+  @Test(timeOut = 5_000L)
+  public void testLastFieldUnknown() throws Exception
+  {
+    final ScimService service = new ScimService(target());
+    ListResponse<UserResource> response =
+        service.searchRequest("/Users/testLastFieldUnknown")
+            .invoke(UserResource.class);
+
+    assertThat(response.getSchemaUrns())
+        .hasSize(1)
+        .first()
+        .isEqualTo("urn:ietf:params:scim:api:messages:2.0:ListResponse");
+    assertThat(response.getTotalResults()).isEqualTo(1);
+    assertThat(response.getItemsPerPage()).isEqualTo(1);
+    assertThat(response.getResources())
+        .hasSize(1)
+        .first().isEqualTo(new UserResource().setUserName("GNX"));
+    assertThat(response.toString())
+        .doesNotContain("unknownAttribute")
+        .doesNotContain("unknownValue");
+  }
+
+
+  /**
    * Test custom content-type.
    *
    * @throws ScimException if an error occurs.

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestResourceEndpoint.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestResourceEndpoint.java
@@ -179,4 +179,36 @@ public class TestResourceEndpoint
               ]
             }""").build();
   }
+
+  /**
+   * Returns a list response with an extra undefined attribute listed as the
+   * last attribute in the list.
+   *
+   * @return  A list response.
+   */
+  @GET
+  @Path("testLastFieldUnknown")
+  @Produces({MEDIA_TYPE_SCIM, MediaType.APPLICATION_JSON})
+  public Response testLastFieldUnknown()
+  {
+    return Response.status(Response.Status.OK)
+        .type(MEDIA_TYPE_SCIM)
+        .entity("""
+            {
+              "schemas": [
+                "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+              ],
+              "totalResults": 1,
+              "itemsPerPage": 1,
+              "Resources": [
+                {
+                  "schemas": [
+                    "urn:ietf:params:scim:schemas:core:2.0:User"
+                  ],
+                  "userName": "GNX"
+                }
+              ],
+              "unknownAttribute": "unknownValue"
+            }""").build();
+  }
 }


### PR DESCRIPTION
An edge case in SearchRequestBuilder made it possible for the parser to
loop indefinitely when the final attribute in a list response was a
non-standard one. This has been updated to be more defensive by adding
an additional check that validates whether the parser is closed.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-50909

Resolves #272