### PR TITLE
Validate non-standard patch removes on creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ since it is a reflection of the `value` parameter and is sometimes set to `null`
 Fixed an issue with SearchRequestBuilder where it was possible for the parser to hang if a list
 response contained undefined attributes.
 
+Updated "remove" patch operations to validate paths when objects are created. Previously, paths were
+only validated when operations were applied. This behavior is specific to non-standard remove
+operations that set a `value` field, and does not affect most patch operations.
+
 ## v4.1.0 - 2025-Oct-06
 Added new methods to the Path class to simplify certain usages and make interaction, especially
 instantiation, less verbose. These include:

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -620,6 +620,14 @@ public abstract class PatchOperation
 
       // Check for explicit null values stored in the JSON.
       this.value = (NullNode.getInstance().equals(value)) ? null : value;
+
+      // For non-standard remove operations that set a value, the SCIM SDK only
+      // supports group membership updates.
+      if (this.value != null && !"members".equalsIgnoreCase(path.toString()))
+      {
+        throw new BadRequestException("Cannot create the operation since it"
+            + " has a value, but an invalid '%s' path.".formatted(path));
+      }
     }
 
     /**
@@ -657,12 +665,6 @@ public abstract class PatchOperation
       Path path = Objects.requireNonNull(getPath());
       if (value != null)
       {
-        if (!"members".equalsIgnoreCase(path.toString()))
-        {
-          throw new BadRequestException("Cannot apply the operation since it"
-              + " has a value, but an invalid '%s' path.".formatted(path));
-        }
-
         // This is a non-standard remove operation for group membership removal.
         path = combinePathAndValue();
         if (path == null)

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/NonStandardRemoveOperationTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/NonStandardRemoveOperationTest.java
@@ -33,6 +33,7 @@
 package com.unboundid.scim2.common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -491,14 +492,14 @@ public class NonStandardRemoveOperationTest
    * JSON values that are improperly formatted.
    */
   @Test
-  public void testApplyingInvalidOperations() throws Exception
+  public void testInvalidOperations() throws Exception
   {
+    final var reader = JsonUtils.getObjectReader().forType(PatchRequest.class);
     GenericScimResource resource = new GenericScimResource();
 
-    // Applying this operation is invalid because we only support targeting
+    // Creating this operation is invalid because we only support targeting
     // "members".
-    PatchRequest opWithNestedAttr = JsonUtils.getObjectReader()
-        .forType(PatchRequest.class).readValue("""
+    String invalidPath = """
             {
               "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
               "Operations": [{
@@ -509,15 +510,14 @@ public class NonStandardRemoveOperationTest
                 }
               }]
             }
-            """);
-    assertThatThrownBy(() -> opWithNestedAttr.apply(resource))
-        .isInstanceOf(BadRequestException.class)
-        .hasMessageContaining("Cannot apply the operation since it has a")
+            """;
+    assertThatThrownBy(() -> reader.readValue(invalidPath))
+        .isInstanceOf(JsonMappingException.class)
+        .hasMessageContaining("Cannot create the operation since it has a")
         .hasMessageContaining("value, but an invalid 'emails' path.");
 
-    // Applying this operation is invalid because the path has a value filter.
-    PatchRequest operationWithFilter = JsonUtils.getObjectReader()
-        .forType(PatchRequest.class).readValue("""
+    // Creating this operation is invalid because the path has a value filter.
+    String operationWithFilter = """
             {
               "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
               "Operations": [{
@@ -528,10 +528,10 @@ public class NonStandardRemoveOperationTest
                 }
               }]
             }
-            """);
-    assertThatThrownBy(() -> operationWithFilter.apply(resource))
-        .isInstanceOf(BadRequestException.class)
-        .hasMessageContaining("Cannot apply the operation since it has a")
+            """;
+    assertThatThrownBy(() -> reader.readValue(operationWithFilter))
+        .isInstanceOf(JsonMappingException.class)
+        .hasMessageContaining("Cannot create the operation since it has a")
         .hasMessageContaining("value, but an invalid 'members[value sw");
 
     // Applying this operation is invalid because the Member field has other


### PR DESCRIPTION
To ensure better parity with older releases, the paths of non-standard remove operations are validated during object creation. Previously, validation occurred when applying/processing the operations.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-50911