### PR TITLE
Add new applyToResource() patch update methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ and HTTP 429 status codes.
 Added new `status()` and `statusInt()` method to all exception types. For example, to obtain a
 string of `"400"` corresponding to `400 BAD REQUEST`, use `BadRequestException.status()`.
 
+Simplified patch processing by adding `applyToResource()` on `PatchRequest` and `PatchOperation`.
+These are an improvement over the existing `apply()` variants, which require passing in `ObjectNode`
+or `GenericScimResource` instances. Conversely, the new methods instead accept any ScimResource,
+which is useful since SCIM patch updates almost always target a SCIM resource. For example:
+```
+// Before:
+UserResource user = getUser();
+GenericScimResource genericUser = user.asGenericScimResource();
+patchRequest.apply(genericUser);
+UserResource updatedUser =
+    JsonUtils.nodeToValue(genericUser.getObjectNode(), UserResource.class);
+
+// New in 5.1.0:
+UserResource user = getUser();
+UserResource updatedUser = patchRequest.applyToResource(user);
+```
+The existing `apply()` methods are not deprecated and may still be used.
+
 ## v5.0.0 - 2025-Dec-15
 For consistency with other open source Ping Identity software, the UnboundID SCIM 2 SDK for Java is
 now available under the terms of the Apache License (version 2.0). For legacy compatibility, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ and HTTP 429 status codes.
 Added new `status()` and `statusInt()` method to all exception types. For example, to obtain a
 string of `"400"` corresponding to `400 BAD REQUEST`, use `BadRequestException.status()`.
 
-Simplified patch processing by adding `applyToResource()` on `PatchRequest` and `PatchOperation`.
-These are an improvement over the existing `apply()` variants, which require passing in `ObjectNode`
-or `GenericScimResource` instances. Conversely, the new methods instead accept any ScimResource,
-which is useful since SCIM patch updates almost always target a SCIM resource. For example:
+Simplified patch processing by adding `applyToResource()` on the `PatchRequest` and `PatchOperation`
+classes. These are an improvement over the existing `apply()` variants, which require passing in
+`ObjectNode` or `GenericScimResource` instances. Conversely, the new methods accept any ScimResource
+object, which is useful since SCIM patch updates almost always target a SCIM resource. For example:
 ```
 // Before:
 UserResource user = getUser();

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -51,6 +51,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.unboundid.scim2.common.GenericScimResource;
 import com.unboundid.scim2.common.Path;
+import com.unboundid.scim2.common.ScimResource;
 import com.unboundid.scim2.common.annotations.NotNull;
 import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.exceptions.BadRequestException;
@@ -64,6 +65,7 @@ import com.unboundid.scim2.common.utils.FilterEvaluator;
 import com.unboundid.scim2.common.utils.JsonUtils;
 import com.unboundid.scim2.common.utils.SchemaUtils;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -134,6 +136,10 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  * If a {@code null} path is needed for an {@code add} or {@code replace}
  * operation, then use the {@link #add(JsonNode)} and
  * {@link #replace(ObjectNode)} methods.
+ * <br><br>
+ *
+ * For examples on applying patch updates to SCIM resource objects, see
+ * {@link PatchRequest}.
  *
  * @see PatchRequest
  */
@@ -1098,6 +1104,37 @@ public abstract class PatchOperation
    */
   public abstract void apply(@NotNull final ObjectNode node)
       throws ScimException;
+
+  /**
+   * Apply this patch operation to a {@link ScimResource} and return an updated
+   * resource.
+   *
+   * @param <T>       The Java type of this resource.
+   * @param resource  The original resource.
+   * @return          The updated resource.
+   *
+   * @throws ScimException  If the update resulted in a malformed resource,
+   *                        e.g., a boolean value for a timestamp attribute.
+   */
+  @NotNull
+  public <T extends ScimResource> T applyToResource(@NotNull final T resource)
+      throws ScimException
+  {
+    // Extract the JSON data and apply the change.
+    ObjectNode node = resource.asGenericScimResource().getObjectNode();
+    apply(node);
+
+    try
+    {
+      return JsonUtils.getObjectReader()
+          .forType(resource.getClass()).readValue(node);
+    }
+    catch (IOException e)
+    {
+      throw new BadRequestException(
+          "The update could not be applied to the resource.", e);
+    }
+  }
 
   /**
    * Retrieves a string representation of this patch operation.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
@@ -34,14 +34,18 @@ package com.unboundid.scim2.common.messages;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.unboundid.scim2.common.ScimResource;
 import com.unboundid.scim2.common.annotations.NotNull;
 import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.annotations.Schema;
 import com.unboundid.scim2.common.annotations.Attribute;
+import com.unboundid.scim2.common.exceptions.BadRequestException;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import com.unboundid.scim2.common.BaseScimResource;
 import com.unboundid.scim2.common.GenericScimResource;
+import com.unboundid.scim2.common.utils.JsonUtils;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -60,9 +64,7 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  * of a patch request in JSON form:
  * <pre>
  * {
- *   "schemas": [
- *     "urn:ietf:params:scim:api:messages:2.0:PatchOp"
- *   ],
+ *   "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
  *   "Operations": [
  *     {
  *       "op": "replace",
@@ -74,8 +76,8 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  * </pre>
  *
  * This example request contains a single operation that sets the {@code active}
- * value to {@code true}. This request can be created with the following Java
- * code:
+ * value of a targeted SCIM resource to {@code true}. This request can be
+ * created with the following Java code:
  * <pre><code>
  *   PatchRequest request = new PatchRequest(
  *       PatchOperation.replace("active", true)
@@ -85,6 +87,20 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  * All patch requests are performed atomically. RFC 7644 Section 3.5.2 states
  * that if any operation within the operation list fails, then the resource
  * SHALL not be updated at all.
+ * <br><br>
+ *
+ * A patch request object, as well as an individual patch operation, can be used
+ * to update a SCIM resource with the {@link #applyToResource(ScimResource)}
+ * methods. For example, a user's {@code active} status can be updated with the
+ * above patch request with the following:
+ * <pre><code>
+ *   UserResource user = new UserResource().setUserName("link");
+ *   UserResource updatedUser = request.applyToResource(user);
+ *
+ *   // An example representing an update from an individual patch operation.
+ *   PatchOperation patchOperation = request.getOperations().get(0);
+ *   UserResource firstUpdate = patchOperation.applyToResource(user);
+ * </code></pre>
  *
  * @see PatchOperation
  */
@@ -148,18 +164,58 @@ public class PatchRequest
   }
 
   /**
-   * Apply this patch request to the GenericScimResourceObject.
+   * Apply this patch request to the GenericScimResource.
+   * <br><br>
    *
-   * @param object The GenericScimResourceObject to apply this patch to.
+   * The {@link #applyToResource} method is likely a better choice if you have a
+   * {@link BaseScimResource} derived object. See the class-level Javadoc for
+   * more details.
+   *
+   * @param object The GenericScimResource that will be the target of this patch
+   *               request.
+   * @return  The {@code object} provided to this method.
    *
    * @throws ScimException If one or more patch operations are invalid.
    */
-  public void apply(@NotNull final GenericScimResource object)
+  @NotNull
+  public GenericScimResource apply(@NotNull final GenericScimResource object)
       throws ScimException
   {
     for (PatchOperation operation : this)
     {
       operation.apply(object.getObjectNode());
+    }
+
+    return object;
+  }
+
+  /**
+   * Apply this patch request to the provided ScimResource.
+   *
+   * @param <T>      The Java type of the SCIM resource.
+   * @param resource The resource that will be the target of this patch request.
+   * @return         The updated SCIM resource with the same Java type.
+   *
+   * @throws ScimException  If the update resulted in a malformed resource,
+   *                        e.g., a boolean value for a timestamp attribute.
+   */
+  @NotNull
+  public <T extends ScimResource> T applyToResource(@NotNull final T resource)
+      throws ScimException
+  {
+    try
+    {
+      // Use this instead of PatchOperation#applyToResource so that the Jackson
+      // parsing and conversion is only done once.
+      GenericScimResource updatedJson = apply(resource.asGenericScimResource());
+
+      return JsonUtils.getObjectReader().forType(resource.getClass())
+          .readValue(updatedJson.getObjectNode());
+    }
+    catch (IOException e)
+    {
+      throw new BadRequestException(
+          "The patch request resulted in an invalid object model.", e);
     }
   }
 

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
@@ -91,8 +91,8 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  *
  * A patch request object, as well as an individual patch operation, can be used
  * to update a SCIM resource with the {@link #applyToResource(ScimResource)}
- * methods. For example, a user's {@code active} status can be updated with the
- * above patch request with the following:
+ * methods. For example, using the {@code request} object created above, a
+ * user's {@code active} status can be updated with:
  * <pre><code>
  *   UserResource user = new UserResource().setUserName("link");
  *   UserResource updatedUser = request.applyToResource(user);

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/AddOperationValueFilterTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/AddOperationValueFilterTestCase.java
@@ -32,7 +32,6 @@
 
 package com.unboundid.scim2.common;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.unboundid.scim2.common.exceptions.BadRequestException;
 import com.unboundid.scim2.common.exceptions.ScimException;
@@ -107,7 +106,7 @@ public class AddOperationValueFilterTestCase
     {
       Path newPath = Path.fromString("roles[" + unsupportedFilter + "].value");
       PatchRequest request = createAddRequest(newPath, "newValue");
-      assertThatThrownBy(() -> applyPatchRequest(request, new UserResource()))
+      assertThatThrownBy(() -> request.applyToResource(new UserResource()))
           .isInstanceOf(BadRequestException.class);
     }
   }
@@ -133,7 +132,7 @@ public class AddOperationValueFilterTestCase
     assertThat(resource.getEmails()).hasSize(2);
     path = Path.fromString("emails[type eq \"work\"].value");
     request = createAddRequest(path, "sissel@example.com");
-    resource = applyPatchRequest(request, resource);
+    resource = request.applyToResource(resource);
     assertThat(resource.getEmails())
         .hasSize(3)
         .contains(new Email().setValue("sissel@example.com").setType("work"));
@@ -144,7 +143,7 @@ public class AddOperationValueFilterTestCase
     assertThat(resource.getAddresses()).isNullOrEmpty();
     path = Path.fromString("addresses[type eq \"secret\"].streetAddress");
     request = createAddRequest(path, "The Batcave");
-    resource = applyPatchRequest(request, resource);
+    resource = request.applyToResource(resource);
     assertThat(resource.getAddresses())
         .hasSize(1)
         .containsOnly(
@@ -158,7 +157,7 @@ public class AddOperationValueFilterTestCase
     );
     path = Path.fromString("addresses[type eq \"home\"].country");
     request = createAddRequest(path, "US");
-    resource = applyPatchRequest(request, resource);
+    resource = request.applyToResource(resource);
     assertThat(resource.getAddresses()).hasSize(1);
     var address = resource.getAddresses().get(0);
     assertThat(address.getCountry()).isEqualTo("US");
@@ -170,7 +169,7 @@ public class AddOperationValueFilterTestCase
         "emails[type eq \"work\"].value[display eq \"Special Email\"]");
     assertThatThrownBy(() -> {
       PatchRequest req = createAddRequest(multipleFilter, "bob@example.com");
-      applyPatchRequest(req, new UserResource());
+      req.applyToResource(new UserResource());
     }).isInstanceOf(IllegalArgumentException.class)
       .hasCauseInstanceOf(BadRequestException.class);
 
@@ -180,7 +179,7 @@ public class AddOperationValueFilterTestCase
         "emails[type eq \"work\"].display[value eq \"bob@example.com\"]");
     assertThatThrownBy(() -> {
       PatchRequest req = createAddRequest(otherFilter, "Special Email");
-      applyPatchRequest(req, new UserResource());
+      req.applyToResource(new UserResource());
     }).isInstanceOf(BadRequestException.class)
       .hasMessageContaining(
           "only allowed to contain a single value selection filter");
@@ -189,7 +188,7 @@ public class AddOperationValueFilterTestCase
     // element (i.e., path.size() == 1).
     Path singleElement = Path.fromString("ims[type eq \"skype\"]");
     PatchRequest singleElementRequest = createAddRequest(singleElement, "invalid");
-    assertThatThrownBy(() -> applyPatchRequest(singleElementRequest, new UserResource()))
+    assertThatThrownBy(() -> singleElementRequest.applyToResource(new UserResource()))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("needs to be 'attribute[filter].subAttribute'");
 
@@ -201,7 +200,7 @@ public class AddOperationValueFilterTestCase
     );
     path = Path.fromString("addresses[type eq \"home\"].streetAddress");
     PatchRequest existingSubAttrRequest = createAddRequest(path, "7 Mile Rd.");
-    assertThatThrownBy(() -> applyPatchRequest(existingSubAttrRequest, userWithStreet))
+    assertThatThrownBy(() -> existingSubAttrRequest.applyToResource(userWithStreet))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("The add operation attempted to add a new 'streetAddress' field")
         .hasMessageContaining("already has a 'streetAddress' defined");
@@ -213,7 +212,7 @@ public class AddOperationValueFilterTestCase
         PatchOperation.add(path, TextNode.valueOf("https://example.com/1.png")),
         PatchOperation.add(path, TextNode.valueOf("https://example.com/2.png"))
     );
-    assertThatThrownBy(() -> applyPatchRequest(requestWithConflict, new UserResource()))
+    assertThatThrownBy(() -> requestWithConflict.applyToResource(new UserResource()))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("The add operation attempted to add a new 'value' field")
         .hasMessageContaining("already has a 'value' defined");
@@ -228,7 +227,7 @@ public class AddOperationValueFilterTestCase
     PatchRequest requestOnInvalidResource = new PatchRequest(
         PatchOperation.add(path, TextNode.valueOf("aThirdStreet"))
     );
-    assertThatThrownBy(() -> applyPatchRequest(requestOnInvalidResource, existingUser))
+    assertThatThrownBy(() -> requestOnInvalidResource.applyToResource(existingUser))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("The operation could not be applied on the resource because")
         .hasMessageContaining("the value filter matched more than one element in")
@@ -240,7 +239,7 @@ public class AddOperationValueFilterTestCase
     PatchRequest improperFormat = new PatchRequest(
         PatchOperation.addStringValues(path, "home@example.com")
     );
-    assertThatThrownBy(() -> applyPatchRequest(improperFormat, new UserResource()))
+    assertThatThrownBy(() -> improperFormat.applyToResource(new UserResource()))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("cannot set the 'value' field to an array");
 
@@ -250,7 +249,7 @@ public class AddOperationValueFilterTestCase
     Path singleValuedAttr =
         Path.fromString("preferredLanguage[type eq \"work\"].value");
     PatchRequest invalidAttr = createAddRequest(singleValuedAttr, "en-US");
-    assertThatThrownBy(() -> applyPatchRequest(invalidAttr, userWithLanguage))
+    assertThatThrownBy(() -> invalidAttr.applyToResource(userWithLanguage))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("could not be processed")
         .hasMessageContaining("value selection filter was provided");
@@ -258,8 +257,8 @@ public class AddOperationValueFilterTestCase
     // Perform another add on a single-valued attribute when it does not have a
     // pre-existing value.
     PatchRequest invalidAttr2 = createAddRequest(singleValuedAttr, "en-US");
-    assertThatThrownBy(() -> applyPatchRequest(invalidAttr2, new UserResource()))
-        .isInstanceOf(JsonProcessingException.class);
+    assertThatThrownBy(() -> invalidAttr2.applyToResource(new UserResource()))
+        .isInstanceOf(ScimException.class);
 
     // Value filters must be the first element in the path.
     Path nestedFilter = Path.fromString("parent.examples[type eq \"best\"].value");
@@ -272,7 +271,7 @@ public class AddOperationValueFilterTestCase
     assertThatThrownBy(() -> {
       Path emptyFilterPath = Path.fromString("entitlements[].value");
       PatchRequest emptyFilterReq = createAddRequest(emptyFilterPath, "ent1");
-      applyPatchRequest(emptyFilterReq, new UserResource());
+      emptyFilterReq.applyToResource(new UserResource());
     }).isInstanceOf(BadRequestException.class);
   }
 
@@ -318,7 +317,7 @@ public class AddOperationValueFilterTestCase
     );
     Path path = Path.fromString("emails[type eq \"home\"].value");
     PatchRequest request = createAddRequest(path, "yomiel@example.com");
-    resource = applyPatchRequest(request, resource);
+    resource = request.applyToResource(resource);
 
     // Deserialize the new resource into JSON.
     String resourceString = JsonUtils.valueToNode(resource).toString();
@@ -349,7 +348,7 @@ public class AddOperationValueFilterTestCase
     );
     path = Path.fromString("phoneNumbers[type eq \"mobile\"].value");
     request = createAddRequest(path, "+1 271-828-1828");
-    resource = applyPatchRequest(request, resource);
+    resource = request.applyToResource(resource);
     assertThat(resource.getPhoneNumbers())
         .hasSize(2)
         .containsExactly(
@@ -363,7 +362,7 @@ public class AddOperationValueFilterTestCase
         PatchOperation.add(path, TextNode.valueOf("https://example.com/1.png")),
         PatchOperation.add(path, TextNode.valueOf("https://example.com/2.png"))
     );
-    resource = applyPatchRequest(request, resource);
+    resource = request.applyToResource(resource);
     assertThat(resource.getPhotos())
         .filteredOn(photo -> "thumbnail".equals(photo.getType()))
         .hasSize(2);
@@ -376,18 +375,5 @@ public class AddOperationValueFilterTestCase
   private static PatchRequest createAddRequest(Path path, String value)
   {
     return new PatchRequest(PatchOperation.add(path, TextNode.valueOf(value)));
-  }
-
-  /**
-   * This method applies a patch request to a UserResource object and returns
-   * a new UserResource reflecting the modifications.
-   */
-  private static UserResource applyPatchRequest(PatchRequest request,
-                                                UserResource userResource)
-      throws JsonProcessingException, ScimException
-  {
-    GenericScimResource user = userResource.asGenericScimResource();
-    request.apply(user);
-    return JsonUtils.nodeToValue(user.getObjectNode(), UserResource.class);
   }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/NonStandardRemoveOperationTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/NonStandardRemoveOperationTest.java
@@ -38,7 +38,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.unboundid.scim2.common.exceptions.BadRequestException;
 import com.unboundid.scim2.common.messages.PatchOperation;
@@ -129,7 +128,7 @@ public class NonStandardRemoveOperationTest
     PatchOperation op;
     List<Member> member;
 
-    GroupResource origGroup = new GroupResource()
+    GroupResource group = new GroupResource()
         .setDisplayName("testGroup")
         .setMembers(new Member().setValue("ca11ab1e"),
                     new Member().setValue("c0a1e5ce"),
@@ -137,16 +136,15 @@ public class NonStandardRemoveOperationTest
                     new Member().setValue("e5ca1a7e"),
                     new Member().setValue("def1ec75"),
                     new Member().setValue("ba5eba11"));
-    ObjectNode group = origGroup.asGenericScimResource().getObjectNode();
 
     int groupSize = 6;
-    assertThat(group.get("members")).hasSize(groupSize);
+    assertThat(group.getMembers()).hasSize(groupSize);
 
     // Attempt removing an unrelated member.
     member = List.of(new Member().setValue("fa1afe1"));
     op = PatchOperation.remove("members").setRemoveOpValue(member, true);
-    op.apply(group);
-    assertThat(group.get("members")).hasSize(groupSize);
+    group = op.applyToResource(group);
+    assertThat(group.getMembers()).hasSize(groupSize);
 
     // Using the library methods, remove a member by specifying the "value"
     // field in the JSON.
@@ -154,8 +152,8 @@ public class NonStandardRemoveOperationTest
     member = List.of(new Member().setValue(memberID));
     op = PatchOperation.remove("members").setRemoveOpValue(member, true);
     groupSize--;
-    op.apply(group);
-    assertThat(group.get("members")).hasSize(groupSize);
+    group = op.applyToResource(group);
+    assertThat(group.getMembers()).hasSize(groupSize);
     assertThat(group.toString()).doesNotContain(memberID);
 
     // Remove multiple members in a single request.
@@ -165,8 +163,8 @@ public class NonStandardRemoveOperationTest
             new Member().setValue("50f7ba11")
         ), true);
     groupSize -= 2;
-    op.apply(group);
-    assertThat(group.get("members")).hasSize(groupSize);
+    group = op.applyToResource(group);
+    assertThat(group.getMembers()).hasSize(groupSize);
     assertThat(group.toString()).doesNotContain("c0a1e5ce", "50f7ba11");
 
     // Remove a member using the alternate JSON structure.
@@ -174,8 +172,8 @@ public class NonStandardRemoveOperationTest
     member = List.of(new Member().setValue(memberID));
     op = PatchOperation.remove("members").setRemoveOpValue(member, false);
     groupSize--;
-    op.apply(group);
-    assertThat(group.get("members")).hasSize(groupSize);
+    group = op.applyToResource(group);
+    assertThat(group.getMembers()).hasSize(groupSize);
     assertThat(group.toString()).doesNotContain(memberID);
 
     // Remove multiple members in a single request with the alternate JSON
@@ -186,9 +184,9 @@ public class NonStandardRemoveOperationTest
             new Member().setValue("ba5eba11")
         ), false);
     groupSize -= 2;
-    op.apply(group);
+    group = op.applyToResource(group);
     assertThat(groupSize).isEqualTo(0);
-    assertThat(group.get("members")).isNull();
+    assertThat(group.getMembers()).isNull();
     assertThat(group.toString()).doesNotContain("def1ec75", "ba5eba11");
 
     // Passing a non-initialized Member value to 'setRemoveOpValue()' should be

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/PatchOpTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/PatchOpTestCase.java
@@ -33,12 +33,13 @@
 package com.unboundid.scim2.common;
 
 import com.fasterxml.jackson.core.Base64Variants;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.unboundid.scim2.common.exceptions.BadRequestException;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import com.unboundid.scim2.common.messages.PatchOpType;
@@ -46,6 +47,7 @@ import com.unboundid.scim2.common.messages.PatchOperation;
 import com.unboundid.scim2.common.messages.PatchRequest;
 import com.unboundid.scim2.common.types.Address;
 import com.unboundid.scim2.common.types.Email;
+import com.unboundid.scim2.common.types.Name;
 import com.unboundid.scim2.common.types.Photo;
 import com.unboundid.scim2.common.types.UserResource;
 import com.unboundid.scim2.common.utils.JsonUtils;
@@ -824,7 +826,7 @@ public class PatchOpTestCase
     request = new PatchRequest(
         PatchOperation.add("emails", EMPTY_ARRAY)
     );
-    user = applyPatchRequest(user, request);
+    user = request.applyToResource(user);
     assertThat(user.getEmails()).hasSize(1);
 
     // Replace the attribute with an empty array. This should delete all email
@@ -832,7 +834,7 @@ public class PatchOpTestCase
     request = new PatchRequest(
         PatchOperation.replace("emails", EMPTY_ARRAY)
     );
-    user = applyPatchRequest(user, request);
+    user = request.applyToResource(user);
     assertThat(user.getEmails()).isNull();
 
     // Apply an "empty" value to a resource that already does not have a value
@@ -841,14 +843,14 @@ public class PatchOpTestCase
     request = new PatchRequest(
         PatchOperation.add("addresses", EMPTY_ARRAY)
     );
-    user = applyPatchRequest(user, request);
+    user = request.applyToResource(user);
     assertThat(user.getAddresses()).isNull();
 
     // Delete all attribute values when none previously exist.
     request = new PatchRequest(
         PatchOperation.replace("addresses", EMPTY_ARRAY)
     );
-    user = applyPatchRequest(user, request);
+    user = request.applyToResource(user);
     assertThat(user.getAddresses()).isNull();
 
     // If multiple values exist on a resource, the behavior of an 'add' should
@@ -862,12 +864,12 @@ public class PatchOpTestCase
     request = new PatchRequest(
         PatchOperation.add("photos", EMPTY_ARRAY)
     );
-    user = applyPatchRequest(user, request);
+    user = request.applyToResource(user);
     assertThat(user.getPhotos()).hasSize(3);
     request = new PatchRequest(
         PatchOperation.replace("photos", EMPTY_ARRAY)
     );
-    user = applyPatchRequest(user, request);
+    user = request.applyToResource(user);
     assertThat(user.getPhotos()).isNull();
   }
 
@@ -892,7 +894,7 @@ public class PatchOpTestCase
     request = new PatchRequest(
         PatchOperation.replace("emails[type eq \"home\"]", EMPTY_ARRAY)
     );
-    user = applyPatchRequest(user, request);
+    user = request.applyToResource(user);
     assertThat(user.getEmails()).hasSize(3);
     assertThat(user.getEmails()).noneMatch(
         email -> "home".equalsIgnoreCase(email.getType())
@@ -902,7 +904,7 @@ public class PatchOpTestCase
     request = new PatchRequest(
         PatchOperation.replace("emails[type eq \"work\"]", EMPTY_ARRAY)
     );
-    user = applyPatchRequest(user, request);
+    user = request.applyToResource(user);
     assertThat(user.getEmails()).hasSize(1);
     assertThat(user.getEmails()).first().matches(
         email -> "other".equalsIgnoreCase(email.getType())
@@ -912,7 +914,7 @@ public class PatchOpTestCase
     request = new PatchRequest(
         PatchOperation.replace("emails[type eq \"other\"]", EMPTY_ARRAY)
     );
-    user = applyPatchRequest(user, request);
+    user = request.applyToResource(user);
     assertThat(user.getEmails()).isNull();
 
     // Send a delete request that does not match any values on the resource.
@@ -924,7 +926,7 @@ public class PatchOpTestCase
     PatchRequest unmatchedRequest = new PatchRequest(
         PatchOperation.replace("addresses[type eq \"work\"]", EMPTY_ARRAY)
     );
-    assertThatThrownBy(() -> applyPatchRequest(newUser, unmatchedRequest))
+    assertThatThrownBy(() -> unmatchedRequest.applyToResource(newUser))
         .isInstanceOf(BadRequestException.class)
         .satisfies(ex -> {
           var e = (BadRequestException) ex;
@@ -940,7 +942,7 @@ public class PatchOpTestCase
     PatchRequest emailRequest = new PatchRequest(
         PatchOperation.replace("emails[type eq \"home\"]", EMPTY_ARRAY)
     );
-    assertThatThrownBy(() -> applyPatchRequest(emptyUser, emailRequest))
+    assertThatThrownBy(() -> emailRequest.applyToResource(emptyUser))
         .isInstanceOf(BadRequestException.class)
         .satisfies(ex -> {
           var e = (BadRequestException) ex;
@@ -1015,15 +1017,83 @@ public class PatchOpTestCase
   }
 
   /**
-   * This method applies a patch request to a UserResource object and returns
-   * a new UserResource reflecting the modifications.
+   * Tests for {@link PatchOperation#applyToResource} and
+   * {@link PatchRequest#applyToResource}.
    */
-  private static UserResource applyPatchRequest(UserResource userResource,
-                                                PatchRequest request)
-      throws JsonProcessingException, ScimException
+  @Test
+  public void testApplyingScimResources() throws Exception
   {
-    GenericScimResource user = userResource.asGenericScimResource();
-    request.apply(user);
-    return JsonUtils.nodeToValue(user.getObjectNode(), UserResource.class);
+    UserResource source1 = new UserResource()
+        .setUserName("gaben")
+        .setEmails(new Email().setValue("gabeN@example.com"));
+
+    PatchRequest request = new PatchRequest(
+        PatchOperation.replace("name.givenName", "Gabe"),
+        PatchOperation.remove("emails"),
+        PatchOperation.replace("nickName", "thisPie"),
+        PatchOperation.add("title", TextNode.valueOf("CEO")),
+        PatchOperation.replace("password", "HL3"),
+        PatchOperation.remove("password")
+    );
+
+    // Test PatchRequest.applyToResource() by applying the patch request.
+    UserResource resultUser = request.applyToResource(source1);
+    UserResource complexUser = new UserResource()
+        .setUserName("gaben")
+        .setName(new Name().setGivenName("Gabe"))
+        .setNickName("thisPie")
+        .setTitle("CEO");
+    assertThat(resultUser).isEqualTo(complexUser);
+
+    // Test PatchOperation.applyToResource() by applying the list of patch
+    // operations directly against the resource.
+    UserResource source2 = new UserResource()
+        .setUserName("gaben")
+        .setEmails(new Email().setValue("gabeN@example.com"));
+    for (PatchOperation op : request)
+    {
+      source2 = op.applyToResource(source2);
+    }
+    assertThat(source2)
+        .isEqualTo(complexUser)
+        .isEqualTo(resultUser);
+
+    // Try removing an attribute that is not present. This should result in no
+    // change. Check against both the PatchOperation and PatchRequest variants.
+    PatchOperation removeNonExistingOp = PatchOperation.remove("displayName");
+    UserResource unchanged = removeNonExistingOp.applyToResource(complexUser);
+    UserResource unchanged2 =
+        new PatchRequest(removeNonExistingOp).applyToResource(complexUser);
+    assertThat(complexUser)
+        .isEqualTo(unchanged)
+        .isEqualTo(unchanged2);
+
+    // Attempt setting a field to an invalid format.
+    var invalidFormatOp = PatchOperation.add("addresses", IntNode.valueOf(200));
+    PatchRequest invalidFormatRequest = new PatchRequest(invalidFormatOp);
+
+    assertThatThrownBy(() -> invalidFormatOp.applyToResource(complexUser))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("The update could not be applied to the")
+        .hasMessageContaining("resource.");
+    assertThatThrownBy(() -> invalidFormatRequest.applyToResource(complexUser))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("The patch request resulted in an invalid object")
+        .hasMessageContaining("model.");
+
+    // Attempt adding an unknown field.
+    var invalidAddOp = PatchOperation.add("unknownField", IntNode.valueOf(100));
+    PatchRequest invalidAddRequest = new PatchRequest(invalidAddOp);
+
+    // In Jackson 2.x, this results in an invalid data model and an exception.
+    // As of Jackson 3.x, invalid attributes are ignored.
+    assertThatThrownBy(() -> invalidAddOp.applyToResource(complexUser))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("The update could not be applied to the")
+        .hasMessageContaining("resource.");
+    assertThatThrownBy(() -> invalidAddRequest.applyToResource(complexUser))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("The patch request resulted in an invalid object")
+        .hasMessageContaining("model.");
   }
 }


### PR DESCRIPTION
The existing PatchOperation.apply() and PatchRequest.apply() methods
have provided a viable way to process patch updates since the inception
of the project. However, they require that clients manually perform
conversions between objects and JsonNodes. Applications would also
frequently instantiate and maintain their own object mapper for this
(instead of using JsonUtils), adding further friction.

To make this process smoother, new applyToResource() methods have been
added. These accept any ScimResource-based object and returns the same
instance type in a single line of code. This removes the need for manual
JSON conversions, and provides a streamlined and more direct manner for
applying SCIM patch updates.

Existing helper methods that mimicked this behavior in the unit tests
have been updated to leverage the new API. The new methods have also
been added to the documentation as the recommended approach for update
processing.

Reviewer: dougbulkley
Reviewer: vyhhuang

JiraIssue: DS-51406