### PR TITLE
Fix ErrorResponse serialization case with ID.

### DIFF
--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ErrorResponse.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/ErrorResponse.java
@@ -86,7 +86,7 @@ import java.util.Objects;
  */
 @Schema(id="urn:ietf:params:scim:api:messages:2.0:Error",
     name="Error Response", description = "SCIM 2.0 Error Response")
-@JsonPropertyOrder({"schemas", "scimType", "detail", "status"})
+@JsonPropertyOrder({"schemas", "id", "scimType", "detail", "status"})
 public class ErrorResponse extends BaseScimResource
 {
   @Nullable

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/ErrorResponseTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/ErrorResponseTest.java
@@ -155,5 +155,19 @@ public class ErrorResponseTest
     BadRequestException e = BadRequestException.invalidSyntax(
         "Request is unparsable, syntactically incorrect, or violates schema.");
     assertThat(e.getScimError().toString()).isEqualTo(expectedJSON);
+
+    // Check the case where the same error message has an ID.
+    String jsonWithID = """
+        {
+          "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+          "id": "353dcc28-f5c5-4d8b-8c11-d33e274e1fd2",
+          "scimType": "invalidSyntax",
+          "detail": "Request is unparsable, syntactically incorrect, or violates schema.",
+          "status": "400"
+        }""";
+    String expectedJSONithID = JsonUtils.getObjectReader().readTree(jsonWithID)
+        .toPrettyString();
+    errorResponse.setId("353dcc28-f5c5-4d8b-8c11-d33e274e1fd2");
+    assertThat(errorResponse.toString()).isEqualTo(expectedJSONithID);
   }
 }


### PR DESCRIPTION
Fixed an edge case on the ordering for 'id' if it is present in an error response.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-51249