### PR TITLE
Add system property for UTC timestamps. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ UserResource updatedUser = patchRequest.applyToResource(user);
 ```
 The existing `apply()` methods are not deprecated and may still be used.
 
+Added a system property that can use the UTC timezone when converting ISO timestamps from JSON data
+into Calendar objects. The "GMT+00:00" timezone is still the default. The value may also be updated
+directly via the public `DateTimeUtils.USE_GMT_CALENDARS` variable. Note that existing properties,
+`BaseScimResource.IGNORE_UNKOWN_FIELDS` and `PatchOperation.APPEND_NEW_PATCH_VALUES_PROPERTY`,
+have been updated so that they can be toggled by a Java system property as well. This allows
+changing these values without requiring a code change. Note that if the system property value is
+changed at runtime, a restart is required for the change to take effect.
+
 ## v5.0.0 - 2025-Dec-15
 For consistency with other open source Ping Identity software, the UnboundID SCIM 2 SDK for Java is
 now available under the terms of the Apache License (version 2.0). For legacy compatibility, the

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/BaseScimResource.java
@@ -48,6 +48,7 @@ import com.unboundid.scim2.common.exceptions.ScimException;
 import com.unboundid.scim2.common.types.Meta;
 import com.unboundid.scim2.common.utils.JsonUtils;
 import com.unboundid.scim2.common.utils.SchemaUtils;
+import com.unboundid.scim2.common.utils.StaticUtils;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -107,7 +108,8 @@ public abstract class BaseScimResource
    *
    * @since 4.0.0
    */
-  public static boolean IGNORE_UNKNOWN_FIELDS = false;
+  public static boolean IGNORE_UNKNOWN_FIELDS = StaticUtils.getProperty(
+      "com.unboundid.scim2.common.BaseScimResource.ignoreUnknownFields", false);
 
   @Nullable
   private String id;

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/bulk/BulkRequest.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/bulk/BulkRequest.java
@@ -152,11 +152,11 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  *     "status": "201",
  *     "response": {
  *       "schemas": [ "urn:ietf:params:scim:schemas:core:2.0:User" ],
- *       "userName": "Whiplash!"
+ *       "userName": "Whiplash!",
  *       "id": "5b261bdf",
  *       "meta": {
  *         "created": "1970-01-01T13:00:00Z"
- *       },
+ *       }
  *     }
  *   } ]
  * }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchOperation.java
@@ -74,6 +74,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
+import static com.unboundid.scim2.common.utils.StaticUtils.getProperty;
 import static com.unboundid.scim2.common.utils.StaticUtils.toList;
 
 /**
@@ -2501,5 +2502,8 @@ public abstract class PatchOperation
    *
    * @since 3.2.0
    */
-  public static boolean APPEND_NEW_PATCH_VALUES_PROPERTY = false;
+  public static boolean APPEND_NEW_PATCH_VALUES_PROPERTY = getProperty(
+      "com.unboundid.scim2.common.messages.PatchOperation.appendPatchValues",
+      false
+  );
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/DateTimeUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/DateTimeUtils.java
@@ -60,6 +60,20 @@ public final class DateTimeUtils
   private static final TimeZone GMT = TimeZone.getTimeZone("GMT+00:00");
 
   /**
+   * Property that allows toggling the default region between UTC and GMT.
+   * <br><br>
+   *
+   * When string timestamps are deserialized into Calendar objects, previous
+   * releases would set timestamps in the default region as {@code GMT+00:00}.
+   * This property allows changing this behavior to use UTC instead.
+   * {@code GMT+00:00} is the default value.
+   *
+   * @since 5.1.0
+   */
+  public static boolean USE_GMT_CALENDARS = StaticUtils.getProperty(
+      "com.unboundid.scim2.common.utils.DateTimeUtils.useGMTCalendars", true);
+
+  /**
    * Formats a {@link Date} value as a SCIM 2 DateTime string.
    * This will use UTC as the time zone.
    *
@@ -140,14 +154,14 @@ public final class DateTimeUtils
       throw new IllegalArgumentException(e);
     }
 
-    // Extract the timestamp and timezone. Timezones in the default region
-    // should be considered as "GMT+00:00" for backward compatibility.
-    Date timestamp = Date.from(parsedTime.toInstant());
-    TimeZone zone = parsedTime.getOffset().equals(ZoneOffset.ofHours(0))
-        ? GMT : TimeZone.getTimeZone(parsedTime.getOffset());
+    // In previous releases, the default region was "GMT+00:00".
+    // This property allows using UTC as the default if desired.
+    ZoneOffset offset = parsedTime.getOffset();
+    TimeZone zone = USE_GMT_CALENDARS && offset.equals(ZoneOffset.ofHours(0))
+        ? GMT : TimeZone.getTimeZone(offset);
 
     Calendar calendar = Calendar.getInstance(zone);
-    calendar.setTime(timestamp);
+    calendar.setTime(Date.from(parsedTime.toInstant()));
     return calendar;
   }
 

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StaticUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/StaticUtils.java
@@ -283,4 +283,44 @@ public final class StaticUtils
 
     return list;
   }
+
+
+  /**
+   * Evaluates whether the provided JVM system property name is set to a boolean
+   * value, where the comparison is case-insensitive. If the system property is
+   * not defined or cannot be obtained (e.g., due to security manager
+   * protections), the default value will be used.
+   *
+   * @param name          The name of the system property.
+   * @param defaultValue  The value that should be used if the property is not
+   *                      defined or cannot be fetched.
+   *
+   * @return  The property value as a boolean if the system property exists and
+   *          is obtainable.
+   */
+  public static boolean getProperty(@NotNull final String name,
+                                    final boolean defaultValue)
+  {
+    String property;
+    try
+    {
+      property = System.getProperty(name);
+    }
+    catch (Throwable t)
+    {
+      Debug.debugException(t);
+      property = null;
+    }
+
+    if ("true".equalsIgnoreCase(property))
+    {
+      return true;
+    }
+    else if ("false".equalsIgnoreCase(property))
+    {
+      return false;
+    }
+
+    return defaultValue;
+  }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/DateTimeUtilsTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/DateTimeUtilsTest.java
@@ -58,6 +58,9 @@ public class DateTimeUtilsTest
 {
   private static final TimeZone GMT = TimeZone.getTimeZone("GMT+00:00");
 
+  /**
+   * Reset the value of the system property.
+   */
   @AfterMethod
   public void tearDown()
   {
@@ -67,6 +70,10 @@ public class DateTimeUtilsTest
         "com.unboundid.scim2.common.utils.DateTimeUtils.useGMTCalendars", true);
   }
 
+  /**
+   * Validate updates to the {@link DateTimeUtils#USE_GMT_CALENDARS} system
+   * property.
+   */
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void testGMTProperty() throws Exception

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/DateTimeUtilsTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/DateTimeUtilsTest.java
@@ -37,6 +37,8 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.unboundid.scim2.common.types.UserResource;
 import com.unboundid.scim2.common.utils.DateTimeUtils;
 import com.unboundid.scim2.common.utils.JsonUtils;
+import com.unboundid.scim2.common.utils.StaticUtils;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -55,6 +57,46 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class DateTimeUtilsTest
 {
   private static final TimeZone GMT = TimeZone.getTimeZone("GMT+00:00");
+
+  @AfterMethod
+  public void tearDown()
+  {
+    // The variable must be public and non-final so that it may be modified by
+    // applications.
+    DateTimeUtils.USE_GMT_CALENDARS = StaticUtils.getProperty(
+        "com.unboundid.scim2.common.utils.DateTimeUtils.useGMTCalendars", true);
+  }
+
+  @SuppressWarnings("DataFlowIssue")
+  @Test
+  public void testGMTProperty() throws Exception
+  {
+    // A SCIM resource that has a timestamp in the default timezone.
+    String userJSON = """
+        {
+          "schemas": [ "urn:ietf:params:scim:schemas:core:2.0:User" ],
+          "userName": "Whiplash!",
+          "id": "5b261bdf",
+          "meta": {
+            "created": "1970-01-01T13:00:00Z"
+          }
+        }""";
+
+    // When the property is disabled, deserialized timestamps should be UTC.
+    DateTimeUtils.USE_GMT_CALENDARS = false;
+    UserResource user = JsonUtils.getObjectReader().forType(UserResource.class)
+        .readValue(userJSON);
+    assertThat(user.getMeta().getCreated().getTimeZone())
+        .isEqualTo(TimeZone.getTimeZone(ZoneOffset.UTC));
+
+    // When the property is enabled, timestamps should use the legacy value.
+    DateTimeUtils.USE_GMT_CALENDARS = true;
+    user = JsonUtils.getObjectReader().forType(UserResource.class)
+        .readValue(userJSON);
+    assertThat(user.getMeta().getCreated().getTimeZone())
+        .isEqualTo(TimeZone.getTimeZone("GMT+00:00"))
+        .isNotEqualTo(TimeZone.getTimeZone("GMT"));
+  }
 
   /**
    * Validate {@link DateTimeUtils#format(Date, TimeZone)}.

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/StaticUtilsTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/StaticUtilsTest.java
@@ -35,6 +35,7 @@ package com.unboundid.scim2.common;
 import com.unboundid.scim2.common.utils.StaticUtils;
 import org.testng.annotations.Test;
 
+import static com.unboundid.scim2.common.utils.StaticUtils.getProperty;
 import static com.unboundid.scim2.common.utils.StaticUtils.splitCommaSeparatedString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -121,5 +122,47 @@ public class StaticUtilsTest
     assertThat(StaticUtils.toLowerCase("lowerstring")).isEqualTo("lowerstring");
     assertThat(StaticUtils.toLowerCase("sPoNgEbOb tExT"))
         .isEqualTo("spongebob text");
+  }
+
+  /**
+   * Test for the {@link StaticUtils#getProperty} method.
+   */
+  @Test
+  public void testBooleanSystemPropertyEnabled()
+  {
+    String propertyName = "StaticUtilsTest_" + System.currentTimeMillis();
+
+    try
+    {
+      // A property that does not exist should use the default value.
+      assertThat(getProperty(propertyName, false)).isFalse();
+      assertThat(getProperty(propertyName, true)).isTrue();
+
+      // Set the system property to true. The default value should not be used.
+      System.setProperty(propertyName, "TRUE");
+      assertThat(getProperty(propertyName, false)).isTrue();
+      System.setProperty(propertyName, "true");
+      assertThat(getProperty(propertyName, false)).isTrue();
+
+      // Set the system property to false.
+      System.setProperty(propertyName, "FALSE");
+      assertThat(getProperty(propertyName, true)).isFalse();
+      System.setProperty(propertyName, "false");
+      assertThat(getProperty(propertyName, true)).isFalse();
+
+      // Values that are not well-defined should use the default value.
+      System.setProperty(propertyName, "other");
+      assertThat(getProperty(propertyName, true)).isTrue();
+      assertThat(getProperty(propertyName, false)).isFalse();
+
+      // A well-defined system property that is not set to a boolean string
+      // should use the default value.
+      assertThat(getProperty("java.vm.vendor", false)).isFalse();
+      assertThat(getProperty("java.vm.vendor", true)).isTrue();
+    }
+    finally
+    {
+      System.clearProperty(propertyName);
+    }
   }
 }


### PR DESCRIPTION
In previous releases where JAX-B was used for timestamp deserialization,
all timestamps that occurred in the default region were placed in a
timezone with an ID of "GMT+00:00". In many cases, it may be desirable
to use UTC as the default value instead.

This commit adds a new system property that can be enabled so that
deserialized timestamps will result in Calendar objects with a timezone
corresponding to UTC. This also updates existing customizable
properties to use Java system properties as well, without changing
their default value.

Reviewer: vyhhuang
Reviewer: dougbulkley

JiraIssue: DS-51419