### PR TITLE
Deprecate parameters in anticipation of Jackson 3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ have been updated so that they can be toggled by a Java system property as well.
 changing these values without requiring a code change. Note that if the system property value is
 changed at runtime, a restart is required for the change to take effect.
 
+Deprecated the `com.unboundid.scim2.server.PATCH` annotation class. At the time this class was
+written, JAX-RS did not support a PATCH annotation like it did for other HTTP methods. Now, the
+`jakarta.ws.rs.PATCH` is a better choice that should be used instead.
+
+Deprecated getters and setters in the `MapperFactory.java` class. In the upcoming Jackson 3 release,
+many of the referenced classes (e.g., `SerializationFeature.java`) have been renamed. The
+MapperFactory now supports an alternate scheme for adding customizations with the `createBuilder()`
+method. This provides access to a `JsonMapper.Builder` object that can directly take customizations.
+If your application does not make customizations to the SCIM SDK's object mapper instance, then
+there is no change required. See the class-level documentation of `MapperFactory` for more info.
+
 ## v5.0.0 - 2025-Dec-15
 For consistency with other open source Ping Identity software, the UnboundID SCIM 2 SDK for Java is
 now available under the terms of the Apache License (version 2.0). For legacy compatibility, the

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/UserResource.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/types/UserResource.java
@@ -98,7 +98,7 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  * <pre>
  *   public class CustomUser extends UserResource
  *   {
- *    {@literal @}Override
+ *     &#064;Override
  *     public UserResource setEmails(List&lt;Email&gt; emails)
  *     {
  *       if (emails != null &amp;&amp; emails.size() > 1)

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/JsonUtils.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
@@ -1244,6 +1245,23 @@ public class JsonUtils
   public static ObjectMapper createObjectMapper()
   {
     return mapperFactory.createObjectMapper();
+  }
+
+  /**
+   * This method returns the initial, default configuration for the JsonMapper
+   * builder used by the SCIM SDK to customize the way it serializes and
+   * deserializes data between JSON and object form. For more details on how
+   * to update the SCIM SDK's configuration, see {@link MapperFactory}.
+   *
+   * @return  A JsonMapper builder with the default settings used by the
+   *          UnboundID SCIM SDK.
+   *
+   * @since 5.1.0
+   */
+  @NotNull
+  public static JsonMapper.Builder getInitialMapperConfig()
+  {
+    return new MapperFactory().createBuilder();
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/MapperFactory.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/utils/MapperFactory.java
@@ -47,6 +47,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.fasterxml.jackson.databind.MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES;
 
@@ -63,28 +64,20 @@ import static com.fasterxml.jackson.databind.MapperFeature.ACCEPT_CASE_INSENSITI
  * SDK will ignore {@code null} fields from the object.
  * <br><br>
  *
- * If your project would benefit from enabling or disabling certain Jackson
- * features on the SCIM SDK's object mapper, use one of the following methods:
- * <ul>
- *   <li> {@link #setMapperCustomFeatures}
- *   <li> {@link #setDeserializationCustomFeatures}
- *   <li> {@link #setSerializationCustomFeatures}
- *   <li> {@link #setJsonParserCustomFeatures}
- *   <li> {@link #setJsonGeneratorCustomFeatures}
- * </ul>
- *
- * For example, to disable the
+ * The SCIM SDK provides access to the initial builder used for the shared
+ * object mapper in the {@link JsonUtils#getInitialMapperConfig()} and
+ * {@link #createBuilder()} methods. This may be useful if your application
+ * needs to modify Jackson settings. For example, to disable the Jackson
  * {@link MapperFeature#ACCEPT_CASE_INSENSITIVE_PROPERTIES} property, use the
  * following Java code:
  * <pre><code>
- *   MapperFactory newFactory = new MapperFactory();
- *   newFactory.setMapperCustomFeatures(
- *       Map.of(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, false)
- *   );
+ *   JsonMapper.Builder newConfig = JsonUtils.getInitialMapperConfig()
+ *       .disable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
  *
- *   // Register the new MapperFactory with the SCIM SDK.
- *   JsonUtils.setCustomMapperFactory(newFactory);
+ *   // Register a new MapperFactory with the desired settings.
+ *   JsonUtils.setCustomMapperFactory(new MapperFactory().setConfig(newConfig));
  * </code></pre>
+ * <br><br>
  *
  * If your desired customization is more complicated than enabling/disabling
  * Jackson features, an alternative is to create a custom {@code MapperFactory}
@@ -95,20 +88,20 @@ import static com.fasterxml.jackson.databind.MapperFeature.ACCEPT_CASE_INSENSITI
  * <pre><code>
  *   public class CustomMapperFactory extends MapperFactory
  *   {
- *    {@literal @}Override
+ *     &#064;Override
  *     public ObjectMapper createObjectMapper()
  *     {
- *       // Fetch the initial object mapper from the superclass, then add your
- *       // customizations. Do not instantiate a new ObjectMapper.
- *       ObjectMapper mapper = super.createObjectMapper();
+ *       // Fetch the initial builder from the superclass, then add your
+ *       // customizations. Do not instantiate a new builder.
+ *       JsonMapper.Builder builder = super.createBuilder();
  *
  *       // Add the desired customizations.
  *       SimpleModule module = new SimpleModule();
  *       module.addSerializer(DesiredClass.class, new CustomSerializer());
  *       module.addDeserializer(DesiredClass.class, new CustomDeserializer());
- *       mapper.registerModule(module);
+ *       builder.addModule(module);
  *
- *       return mapper;
+ *       return builder.build();
  *     }
  *   }
  * </code></pre>
@@ -142,6 +135,13 @@ public class MapperFactory
       Collections.emptyMap();
 
   /**
+   * The JsonMapper builder with the appropriate configuration for creating new
+   * object mappers.
+   */
+  @NotNull
+  private JsonMapper.Builder mapperConfigBuilder = createBuilder();
+
+  /**
    * Sets custom deserialization features for any JSON ObjectMapper that is
    * used and returned by the SCIM 2 SDK.  This class should be used
    * to configure any object mapper customizations needed prior to using
@@ -149,12 +149,20 @@ public class MapperFactory
    *
    * @param customFeatures The list of custom deserialization feature settings.
    * @return this object.
+   *
+   * @deprecated  Use {@link #createBuilder()} to make updates to a builder
+   *              instance instead. See the class-level Javadoc for more info.
    */
   @NotNull
+  @Deprecated(since = "5.1.0")
   public MapperFactory setDeserializationCustomFeatures(
       @NotNull final Map<DeserializationFeature, Boolean> customFeatures)
   {
     deserializationCustomFeatures = customFeatures;
+
+    // Once custom features have been set, reinitialize the stored builder
+    // instance so that it is updated with the desired configuration.
+    mapperConfigBuilder = createBuilder();
     return this;
   }
 
@@ -166,12 +174,17 @@ public class MapperFactory
    *
    * @param customFeatures The list of custom JSON generator feature settings.
    * @return this object.
+   *
+   * @deprecated  Use {@link #createBuilder()} to make updates to a builder
+   *              instance instead. See the class-level Javadoc for more info.
    */
   @NotNull
+  @Deprecated(since = "5.1.0")
   public MapperFactory setJsonGeneratorCustomFeatures(
       @NotNull final Map<JsonGenerator.Feature, Boolean> customFeatures)
   {
     jsonGeneratorCustomFeatures = customFeatures;
+    mapperConfigBuilder = createBuilder();
     return this;
   }
 
@@ -183,12 +196,17 @@ public class MapperFactory
    *
    * @param customFeatures The list of custom JSON parser feature settings.
    * @return this object.
+   *
+   * @deprecated  Use {@link #createBuilder()} to make updates to a builder
+   *              instance instead. See the class-level Javadoc for more info.
    */
   @NotNull
+  @Deprecated(since = "5.1.0")
   public MapperFactory setJsonParserCustomFeatures(
       @NotNull final Map<JsonParser.Feature, Boolean> customFeatures)
   {
     jsonParserCustomFeatures = customFeatures;
+    mapperConfigBuilder = createBuilder();
     return this;
   }
 
@@ -200,12 +218,17 @@ public class MapperFactory
    *
    * @param customFeatures The list of custom mapper feature settings.
    * @return this object.
+   *
+   * @deprecated  Use {@link #createBuilder()} to make updates to a builder
+   *              instance instead. See the class-level Javadoc for more info.
    */
   @NotNull
+  @Deprecated(since = "5.1.0")
   public MapperFactory setMapperCustomFeatures(
       @NotNull final Map<MapperFeature, Boolean> customFeatures)
   {
     mapperCustomFeatures = customFeatures;
+    mapperConfigBuilder = createBuilder();
     return this;
   }
 
@@ -217,26 +240,30 @@ public class MapperFactory
    *
    * @param customFeatures The list of custom serialization feature settings.
    * @return this object.
+   *
+   * @deprecated  Use {@link #createBuilder()} to make updates to a builder
+   *              instance instead. See the class-level Javadoc for more info.
   */
   @NotNull
+  @Deprecated(since = "5.1.0")
   public MapperFactory setSerializationCustomFeatures(
       @NotNull final Map<SerializationFeature, Boolean> customFeatures)
   {
     serializationCustomFeatures = customFeatures;
+    mapperConfigBuilder = createBuilder();
     return this;
   }
 
   /**
-   * Creates a custom SCIM compatible Jackson ObjectMapper. Creating new
-   * ObjectMapper instances are expensive so instances should be shared if
-   * possible. This can be used to set the factory used to build new instances
-   * of the object mapper used by the SCIM 2 SDK.
+   * Creates a SCIM compatible {@link JsonMapper} builder instance. This
+   * contains the mapper configuration that is used by the SCIM SDK.
    *
-   * @return an Object Mapper with the correct options set for serializing
-   *     and deserializing SCIM JSON objects.
+   * @return  A builder object with the initial SCIM SDK mapper configuration.
+   *
+   * @since 5.1.0
    */
   @NotNull
-  public ObjectMapper createObjectMapper()
+  public JsonMapper.Builder createBuilder()
   {
     // Create a new object mapper with case-insensitive settings.
     JsonMapper.Builder builder = JsonMapper.builder(new ScimJsonFactory());
@@ -269,6 +296,36 @@ public class MapperFactory
     jsonParserCustomFeatures.forEach(builder::configure);
     serializationCustomFeatures.forEach(builder::configure);
 
-    return builder.build();
+    return builder;
+  }
+
+  /**
+   * Sets the provided mapper configuration on this MapperFactory.
+   *
+   * @param builder  The builder containing the ObjectMapper configuration.
+   * @return  This instance.
+   *
+   * @since 5.1.0
+   */
+  @NotNull
+  public MapperFactory setConfig(@NotNull final JsonMapper.Builder builder)
+  {
+    mapperConfigBuilder = Objects.requireNonNull(builder);
+    return this;
+  }
+
+  /**
+   * Creates a custom SCIM compatible Jackson ObjectMapper. Creating new
+   * ObjectMapper instances are expensive so instances should be shared if
+   * possible. This can be used to set the factory used to build new instances
+   * of the object mapper used by the SCIM 2 SDK.
+   *
+   * @return an Object Mapper with the correct options set for serializing
+   *     and deserializing SCIM JSON objects.
+   */
+  @NotNull
+  public ObjectMapper createObjectMapper()
+  {
+    return mapperConfigBuilder.build();
   }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/MapperFactoryTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/MapperFactoryTest.java
@@ -34,6 +34,7 @@ package com.unboundid.scim2.common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.unboundid.scim2.common.annotations.NotNull;
@@ -62,6 +63,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * This class contains tests that validate customization of the
  * {@link MapperFactory} and its object mapper.
  */
+@SuppressWarnings("deprecation")
 public class MapperFactoryTest
 {
   /**
@@ -71,6 +73,52 @@ public class MapperFactoryTest
   public void tearDown()
   {
     JsonUtils.setCustomMapperFactory(new MapperFactory());
+  }
+
+  /**
+   * Tests updating the SCIM SDK mapper configuration by appending updates to
+   * the builder provided in {@link MapperFactory#createBuilder()}.
+   * This test is based on {@link #testCustomMapperFeatures}.
+   *
+   * @throws Exception  If an unexpected error occurs.
+   */
+  @Test
+  public void testCustomJsonMapperBuilder() throws Exception
+  {
+    // A SCIM resource with the attributes (except 'schema') sorted
+    // alphabetically.
+    final String rawJSONString = """
+        {
+          "schemas": [ "urn:ietf:params:scim:schemas:core:2.0:User" ],
+          "displayName": "Kendrick Lamar",
+          "emails": [{ "value": "NLU@example.com" }],
+          "userName": "K.Dot"
+        }""";
+
+    // Reformat the string in a standardized form.
+    final String expectedJSON = JsonUtils.getObjectReader()
+        .readTree(rawJSONString).toString();
+
+    UserResource user = new UserResource()
+        .setUserName("K.Dot")
+        .setEmails(new Email().setValue("NLU@example.com"))
+        .setDisplayName("Kendrick Lamar");
+
+    // In the SCIM SDK's default configuration, the 'userName' field appears
+    // before fields like 'email'. Before making any changes, verify that the
+    // serialized user resource does not list attributes in alphabetical order.
+    String userJSON = JsonUtils.getObjectWriter().writeValueAsString(user);
+    assertThat(userJSON).isNotEqualTo(expectedJSON);
+
+    // Update the object mapper to sort the elements of a SCIM resource.
+    JsonMapper.Builder newConfig = JsonUtils.getInitialMapperConfig()
+        .enable(SORT_PROPERTIES_ALPHABETICALLY);
+    JsonUtils.setCustomMapperFactory(new MapperFactory().setConfig(newConfig));
+
+    // Serialize the user resource again. This time, the object mapper should
+    // sort the fields alphabetically.
+    userJSON = JsonUtils.getObjectWriter().writeValueAsString(user);
+    assertThat(userJSON).isEqualTo(expectedJSON);
   }
 
   /**

--- a/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/PATCH.java
+++ b/scim2-sdk-server/src/main/java/com/unboundid/scim2/server/PATCH.java
@@ -40,7 +40,12 @@ import java.lang.annotation.Target;
 
 /**
  * Indicates that the annotated method responds to HTTP PATCH requests.
+ *
+ * @deprecated  At the time this class was created, JAX-RS did not provide a
+ *              PATCH annotation. JAX-RS now has the {@link jakarta.ws.rs.PATCH}
+ *              class, so applications should use leverage this instead.
  */
+@Deprecated(since = "5.1.0")
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @HttpMethod("PATCH")

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/CustomContentEndpoint.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/CustomContentEndpoint.java
@@ -39,6 +39,7 @@ import com.unboundid.scim2.server.annotations.ResourceType;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/ETagTestEndpoint.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/ETagTestEndpoint.java
@@ -38,6 +38,7 @@ import com.unboundid.scim2.common.exceptions.ScimException;
 
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;

--- a/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestSingletonResourceEndpoint.java
+++ b/scim2-sdk-server/src/test/java/com/unboundid/scim2/server/TestSingletonResourceEndpoint.java
@@ -51,6 +51,7 @@ import com.unboundid.scim2.server.utils.SimpleSearchResults;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;


### PR DESCRIPTION
These changes primarily focus on the MapperFactory class. In Jackson 3.x, object mappers will be read only instances. Furthermore, some class names such as "JsonParser.Feature" have been changed, so our existing methods will require upkeep to facilitate customizations.

To simplify configuration management, the SCIM SDK now exposes the builder object that is used to create new object mapper instances. This stored builder instance provides more flexibility for handling configuration updates, and is an improvement over manually tracking each Jackson configuration type in our MapperFactory class.

This commit also deprecates the PATCH annotation, as JAX-RS has provided an annotation for this type for many releases now. This will be removed with the upcoming Jackson 3 upgrade.

Reviewer: dougbulkley
Reviewer: vyhhuang

JiraIssue: DS-51420