### PR TITLE
Consoldiate ComparisonFilter utility methods 

### DIFF
--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/AndFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/AndFilter.java
@@ -121,17 +121,10 @@ public final class AndFilter extends CombiningFilter
     {
       return true;
     }
-    if (!(o instanceof AndFilter that))
-    {
-      return false;
-    }
 
-    if (getCombinedFilters().size() != that.getCombinedFilters().size())
-    {
-      return false;
-    }
-
-    return getCombinedFilters().containsAll(that.getCombinedFilters());
+    return o instanceof AndFilter that
+        && getCombinedFilters().size() == that.getCombinedFilters().size()
+        && getCombinedFilters().containsAll(that.getCombinedFilters());
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ComparisonFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ComparisonFilter.java
@@ -38,6 +38,9 @@ import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.utils.JsonUtils;
 import tools.jackson.databind.node.ValueNode;
 
+import java.util.Objects;
+
+
 /**
  * This superclass represents filter types that are used to compare attribute
  * values of SCIM resources.
@@ -122,5 +125,37 @@ public abstract class ComparisonFilter extends Filter
     builder.append(getFilterType().getStringValue());
     builder.append(' ');
     builder.append(filterValue);
+  }
+
+  /**
+   * Indicates whether the provided object is equal to this comparison filter.
+   *
+   * @param o   The object to compare.
+   * @return    {@code true} if the provided object is equal to this filter, or
+   *            {@code false} if not.
+   */
+  @Override
+  public boolean equals(@Nullable final Object o)
+  {
+    if (this == o)
+    {
+      return true;
+    }
+
+    return o instanceof ComparisonFilter that
+        && this.getClass().equals(that.getClass())
+        && filterAttribute.equals(that.filterAttribute)
+        && filterValue.equals(that.filterValue);
+  }
+
+  /**
+   * Retrieves a hash code for this comparison filter.
+   *
+   * @return  A hash code for this comparison filter.
+   */
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(this.getClass(), filterAttribute, filterValue);
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ComplexValueFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ComplexValueFilter.java
@@ -170,17 +170,10 @@ public final class ComplexValueFilter extends Filter
     {
       return true;
     }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
 
-    ComplexValueFilter that = (ComplexValueFilter) o;
-    if (!filterAttribute.equals(that.filterAttribute))
-    {
-      return false;
-    }
-    return valueFilter.equals(that.valueFilter);
+    return o instanceof ComplexValueFilter that
+        && filterAttribute.equals(that.filterAttribute)
+        && valueFilter.equals(that.valueFilter);
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ContainsFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/ContainsFilter.java
@@ -38,7 +38,6 @@ import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import tools.jackson.databind.node.ValueNode;
 
-import java.util.Objects;
 
 /**
  * This class represents a SCIM {@code co} filter. Containing filters are used
@@ -95,43 +94,5 @@ public final class ContainsFilter extends ComparisonFilter
   public FilterType getFilterType()
   {
     return FilterType.CONTAINS;
-  }
-
-  /**
-   * Indicates whether the provided object is equal to this contains filter.
-   *
-   * @param o   The object to compare.
-   * @return    {@code true} if the provided object is equal to this filter, or
-   *            {@code false} if not.
-   */
-  @Override
-  public boolean equals(@Nullable final Object o)
-  {
-    if (this == o)
-    {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
-
-    ComparisonFilter that = (ComparisonFilter) o;
-    if (!getAttributePath().equals(that.getAttributePath()))
-    {
-      return false;
-    }
-    return getComparisonValue().equals(that.getComparisonValue());
-  }
-
-  /**
-   * Retrieves a hash code for this contains filter.
-   *
-   * @return  A hash code for this contains filter.
-   */
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(getAttributePath(), getComparisonValue());
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EndsWithFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EndsWithFilter.java
@@ -38,7 +38,6 @@ import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import tools.jackson.databind.node.ValueNode;
 
-import java.util.Objects;
 
 /**
  * This class represents a SCIM {@code ew} filter. "Ends With" filters are used
@@ -95,43 +94,5 @@ public final class EndsWithFilter extends ComparisonFilter
   public FilterType getFilterType()
   {
     return FilterType.ENDS_WITH;
-  }
-
-  /**
-   * Indicates whether the provided object is equal to this "ends with" filter.
-   *
-   * @param o   The object to compare.
-   * @return    {@code true} if the provided object is equal to this filter, or
-   *            {@code false} if not.
-   */
-  @Override
-  public boolean equals(@Nullable final Object o)
-  {
-    if (this == o)
-    {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
-
-    ComparisonFilter that = (ComparisonFilter) o;
-    if (!getAttributePath().equals(that.getAttributePath()))
-    {
-      return false;
-    }
-    return getComparisonValue().equals(that.getComparisonValue());
-  }
-
-  /**
-   * Retrieves a hash code for this "ends with" filter.
-   *
-   * @return  A hash code for this "ends with" filter.
-   */
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(getAttributePath(), getComparisonValue());
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/EqualFilter.java
@@ -38,7 +38,6 @@ import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import tools.jackson.databind.node.ValueNode;
 
-import java.util.Objects;
 
 /**
  * This class represents a SCIM {@code eq} filter. Equality filters are used to
@@ -94,43 +93,5 @@ public final class EqualFilter extends ComparisonFilter
   public FilterType getFilterType()
   {
     return FilterType.EQUAL;
-  }
-
-  /**
-   * Indicates whether the provided object is equal to this equality filter.
-   *
-   * @param o   The object to compare.
-   * @return    {@code true} if the provided object is equal to this equality
-   *            filter, or {@code false} if not.
-   */
-  @Override
-  public boolean equals(@Nullable final Object o)
-  {
-    if (this == o)
-    {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
-
-    ComparisonFilter that = (ComparisonFilter) o;
-    if (!getAttributePath().equals(that.getAttributePath()))
-    {
-      return false;
-    }
-    return getComparisonValue().equals(that.getComparisonValue());
-  }
-
-  /**
-   * Retrieves a hash code for this equality filter.
-   *
-   * @return  A hash code for this equality filter.
-   */
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(getAttributePath(), getComparisonValue());
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/Filter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/Filter.java
@@ -40,12 +40,13 @@ import com.unboundid.scim2.common.exceptions.ScimException;
 import com.unboundid.scim2.common.utils.DateTimeUtils;
 import com.unboundid.scim2.common.utils.JsonUtils;
 import com.unboundid.scim2.common.utils.Parser;
+import com.unboundid.scim2.common.utils.StaticUtils;
 import tools.jackson.databind.node.ValueNode;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This class represents a SCIM 2 filter expression as defined by
@@ -1231,14 +1232,12 @@ public abstract class Filter
                            @NotNull final Filter filter2,
                            @Nullable final Filter... filters)
   {
-    ArrayList<Filter> components =
-        new ArrayList<>(filters != null ? 2 + filters.length : 2);
+    Objects.requireNonNull(filter1);
+    List<Filter> otherFilters = StaticUtils.toList(filter2, filters);
+
+    ArrayList<Filter> components = new ArrayList<>(otherFilters.size() + 1);
     components.add(filter1);
-    components.add(filter2);
-    if (filters != null)
-    {
-      Collections.addAll(components, filters);
-    }
+    components.addAll(otherFilters);
     return new AndFilter(components);
   }
 
@@ -1257,17 +1256,15 @@ public abstract class Filter
                            @Nullable final String... filters)
       throws BadRequestException
   {
-    ArrayList<Filter> components =
-        new ArrayList<>(filters != null ? 2 + filters.length : 2);
+    List<String> otherFilters = StaticUtils.toList(filter2, filters);
+    ArrayList<Filter> components = new ArrayList<>(otherFilters.size() + 1);
+
     components.add(fromString(filter1));
-    components.add(fromString(filter2));
-    if (filters != null)
+    for (final String filter : otherFilters)
     {
-      for (final String filter : filters)
-      {
-        components.add(fromString(filter));
-      }
+      components.add(fromString(filter));
     }
+
     return new AndFilter(components);
   }
 
@@ -1301,14 +1298,12 @@ public abstract class Filter
                           @NotNull final Filter filter2,
                           @Nullable final Filter... filters)
   {
-    ArrayList<Filter> components =
-        new ArrayList<>(filters != null ? 2 + filters.length : 2);
+    Objects.requireNonNull(filter1);
+    List<Filter> otherFilters = StaticUtils.toList(filter2, filters);
+
+    ArrayList<Filter> components = new ArrayList<>(otherFilters.size() + 1);
     components.add(filter1);
-    components.add(filter2);
-    if (filters != null)
-    {
-      Collections.addAll(components, filters);
-    }
+    components.addAll(otherFilters);
     return new OrFilter(components);
   }
 
@@ -1327,16 +1322,13 @@ public abstract class Filter
                           @Nullable final String... filters)
       throws BadRequestException
   {
-    ArrayList<Filter> components =
-        new ArrayList<>(filters != null ? 2 + filters.length : 2);
+    List<String> otherFilters = StaticUtils.toList(filter2, filters);
+    ArrayList<Filter> components = new ArrayList<>(otherFilters.size() + 1);
+
     components.add(fromString(filter1));
-    components.add(fromString(filter2));
-    if (filters != null)
+    for (final String filter : otherFilters)
     {
-      for (final String filter : filters)
-      {
-        components.add(fromString(filter));
-      }
+      components.add(fromString(filter));
     }
     return new OrFilter(components);
   }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanFilter.java
@@ -38,7 +38,6 @@ import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import tools.jackson.databind.node.ValueNode;
 
-import java.util.Objects;
 
 /**
  * This class represents a SCIM {@code gt} filter. For a given attribute name,
@@ -97,44 +96,5 @@ public final class GreaterThanFilter extends ComparisonFilter
   public FilterType getFilterType()
   {
     return FilterType.GREATER_THAN;
-  }
-
-  /**
-   * Indicates whether the provided object is equal to this "greater than"
-   * filter.
-   *
-   * @param o   The object to compare.
-   * @return    {@code true} if the provided object is equal to this filter, or
-   *            {@code false} if not.
-   */
-  @Override
-  public boolean equals(@Nullable final Object o)
-  {
-    if (this == o)
-    {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
-
-    ComparisonFilter that = (ComparisonFilter) o;
-    if (!getAttributePath().equals(that.getAttributePath()))
-    {
-      return false;
-    }
-    return getComparisonValue().equals(that.getComparisonValue());
-  }
-
-  /**
-   * Retrieves a hash code for this "greater than" filter.
-   *
-   * @return  A hash code for this "greater than" filter.
-   */
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(getAttributePath(), getComparisonValue());
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanOrEqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/GreaterThanOrEqualFilter.java
@@ -38,7 +38,6 @@ import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import tools.jackson.databind.node.ValueNode;
 
-import java.util.Objects;
 
 /**
  * This class represents a SCIM {@code ge} filter. For a given attribute name,
@@ -97,44 +96,5 @@ public final class GreaterThanOrEqualFilter extends ComparisonFilter
   public FilterType getFilterType()
   {
     return FilterType.GREATER_OR_EQUAL;
-  }
-
-  /**
-   * Indicates whether the provided object is equal to this "greater than or
-   * equal" filter.
-   *
-   * @param o   The object to compare.
-   * @return    {@code true} if the provided object is equal to this filter, or
-   *            {@code false} if not.
-   */
-  @Override
-  public boolean equals(@Nullable final Object o)
-  {
-    if (this == o)
-    {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
-
-    ComparisonFilter that = (ComparisonFilter) o;
-    if (!getAttributePath().equals(that.getAttributePath()))
-    {
-      return false;
-    }
-    return getComparisonValue().equals(that.getComparisonValue());
-  }
-
-  /**
-   * Retrieves a hash code for this "greater than or equal" filter.
-   *
-   * @return  A hash code for this "greater than or equal" filter.
-   */
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(getAttributePath(), getComparisonValue());
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanFilter.java
@@ -38,7 +38,6 @@ import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import tools.jackson.databind.node.ValueNode;
 
-import java.util.Objects;
 
 /**
  * This class represents a SCIM {@code lt} filter. For a given attribute name,
@@ -97,43 +96,5 @@ public final class LessThanFilter extends ComparisonFilter
   public FilterType getFilterType()
   {
     return FilterType.LESS_THAN;
-  }
-
-  /**
-   * Indicates whether the provided object is equal to this "less than" filter.
-   *
-   * @param o   The object to compare.
-   * @return    {@code true} if the provided object is equal to this filter, or
-   *            {@code false} if not.
-   */
-  @Override
-  public boolean equals(@Nullable final Object o)
-  {
-    if (this == o)
-    {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
-
-    ComparisonFilter that = (ComparisonFilter) o;
-    if (!getAttributePath().equals(that.getAttributePath()))
-    {
-      return false;
-    }
-    return getComparisonValue().equals(that.getComparisonValue());
-  }
-
-  /**
-   * Retrieves a hash code for this "less than" filter.
-   *
-   * @return  A hash code for this "less than" filter.
-   */
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(getAttributePath(), getComparisonValue());
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanOrEqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/LessThanOrEqualFilter.java
@@ -38,7 +38,6 @@ import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import tools.jackson.databind.node.ValueNode;
 
-import java.util.Objects;
 
 /**
  * This class represents a SCIM {@code le} filter. For a given attribute name,
@@ -97,44 +96,5 @@ public final class LessThanOrEqualFilter extends ComparisonFilter
   public FilterType getFilterType()
   {
     return FilterType.LESS_OR_EQUAL;
-  }
-
-  /**
-   * Indicates whether the provided object is equal to this "less than or equal"
-   * filter.
-   *
-   * @param o   The object to compare.
-   * @return    {@code true} if the provided object is equal to this filter, or
-   *            {@code false} if not.
-   */
-  @Override
-  public boolean equals(@Nullable final Object o)
-  {
-    if (this == o)
-    {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
-
-    ComparisonFilter that = (ComparisonFilter) o;
-    if (!getAttributePath().equals(that.getAttributePath()))
-    {
-      return false;
-    }
-    return getComparisonValue().equals(that.getComparisonValue());
-  }
-
-  /**
-   * Retrieves a hash code for this "less than or equal" filter.
-   *
-   * @return  A hash code for this "less than or equal" filter.
-   */
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(getAttributePath(), getComparisonValue());
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotEqualFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotEqualFilter.java
@@ -38,7 +38,6 @@ import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import tools.jackson.databind.node.ValueNode;
 
-import java.util.Objects;
 
 /**
  * This class represents a SCIM {@code ne} filter. "Not Equal" filters are used
@@ -96,43 +95,5 @@ public final class NotEqualFilter extends ComparisonFilter
   public FilterType getFilterType()
   {
     return FilterType.NOT_EQUAL;
-  }
-
-  /**
-   * Indicates whether the provided object is equal to this "not equal" filter.
-   *
-   * @param o   The object to compare.
-   * @return    {@code true} if the provided object is equal to this filter, or
-   *            {@code false} if not.
-   */
-  @Override
-  public boolean equals(@Nullable final Object o)
-  {
-    if (this == o)
-    {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
-
-    ComparisonFilter that = (ComparisonFilter) o;
-    if (!getAttributePath().equals(that.getAttributePath()))
-    {
-      return false;
-    }
-    return getComparisonValue().equals(that.getComparisonValue());
-  }
-
-  /**
-   * Retrieves a hash code for this "not equal" filter.
-   *
-   * @return  A hash code for this "not equal" filter.
-   */
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(getAttributePath(), getComparisonValue());
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/NotFilter.java
@@ -145,13 +145,9 @@ public final class NotFilter extends Filter
     {
       return true;
     }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
 
-    NotFilter notFilter = (NotFilter) o;
-    return filterComponent.equals(notFilter.filterComponent);
+    return o instanceof NotFilter notFilter
+        && filterComponent.equals(notFilter.filterComponent);
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/OrFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/OrFilter.java
@@ -122,17 +122,10 @@ public final class OrFilter extends CombiningFilter
     {
       return true;
     }
-    if (!(o instanceof OrFilter that))
-    {
-      return false;
-    }
 
-    if (getCombinedFilters().size() != that.getCombinedFilters().size())
-    {
-      return false;
-    }
-
-    return getCombinedFilters().containsAll(that.getCombinedFilters());
+    return o instanceof OrFilter that
+        && getCombinedFilters().size() == that.getCombinedFilters().size()
+        && getCombinedFilters().containsAll(that.getCombinedFilters());
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/PresentFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/PresentFilter.java
@@ -143,13 +143,9 @@ public final class PresentFilter extends Filter
     {
       return true;
     }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
 
-    PresentFilter that = (PresentFilter) o;
-    return filterAttribute.equals(that.filterAttribute);
+    return o instanceof PresentFilter that
+        && filterAttribute.equals(that.filterAttribute);
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/StartsWithFilter.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/filters/StartsWithFilter.java
@@ -38,7 +38,6 @@ import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import tools.jackson.databind.node.ValueNode;
 
-import java.util.Objects;
 
 /**
  * This class represents a SCIM {@code sw} filter. "Starts With" filters are
@@ -95,44 +94,5 @@ public final class StartsWithFilter extends ComparisonFilter
   public FilterType getFilterType()
   {
     return FilterType.STARTS_WITH;
-  }
-
-  /**
-   * Indicates whether the provided object is equal to this "starts with"
-   * filter.
-   *
-   * @param o   The object to compare.
-   * @return    {@code true} if the provided object is equal to this filter, or
-   *            {@code false} if not.
-   */
-  @Override
-  public boolean equals(@Nullable final Object o)
-  {
-    if (this == o)
-    {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass())
-    {
-      return false;
-    }
-
-    ComparisonFilter that = (ComparisonFilter) o;
-    if (!getAttributePath().equals(that.getAttributePath()))
-    {
-      return false;
-    }
-    return getComparisonValue().equals(that.getComparisonValue());
-  }
-
-  /**
-   * Retrieves a hash code for this "starts with" filter.
-   *
-   * @return  A hash code for this "starts with" filter.
-   */
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(getAttributePath(), getComparisonValue());
   }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
@@ -562,33 +562,6 @@ public class FilterEvaluatorTestCase
 
 
   /**
-   * Test the {@code equals()} method for complex filter types.
-   */
-  @Test
-  @SuppressWarnings("all")
-  public void testComplexFilterEquals() throws Exception
-  {
-    Filter orig = Filter.complex("emails", Filter.eq("type", "work"));
-    Filter alsoOrig = Filter.complex("emails", Filter.eq("type", "work"));
-    assertThat(orig == alsoOrig).isFalse();
-    assertThat(orig.equals(alsoOrig)).isTrue();
-    assertThat(orig.getFilterType()).isEqualTo(alsoOrig.getFilterType());
-
-    // Complex filters should not be equal if the path is different.
-    Filter otherPath = Filter.complex("addresses", Filter.eq("type", "work"));
-    assertThat(orig.equals(otherPath)).isFalse();
-    assertThat(otherPath.equals(orig)).isFalse();
-    assertThat(otherPath.hashCode()).isNotEqualTo(orig.hashCode());
-
-    // Complex filters should not be equal if the value filter is different.
-    Filter otherValue = Filter.complex("emails", Filter.ne("type", "work"));
-    assertThat(orig.equals(otherValue)).isFalse();
-    assertThat(otherValue.equals(orig)).isFalse();
-    assertThat(otherValue.hashCode()).isNotEqualTo(orig.hashCode());
-  }
-
-
-  /**
    * Test filter parsing.
    *
    * @param filter The filter string to evaluate.
@@ -679,7 +652,7 @@ public class FilterEvaluatorTestCase
   }
 
   /**
-   * Test the complex filter creation methods.
+   * Test {@link com.unboundid.scim2.common.filters.ComplexValueFilter} methods.
    */
   @Test
   public void testComplexFilters() throws Exception
@@ -720,6 +693,7 @@ public class FilterEvaluatorTestCase
     // The filters should be equivalent, and both should match only the
     // "matching" node.
     assertThat(complexFilter).isEqualTo(alternateFilter);
+    assertThat(complexFilter == alternateFilter).isFalse();
     assertThat(FilterEvaluator.evaluate(complexFilter, matching)).isTrue();
     assertThat(FilterEvaluator.evaluate(complexFilter, invalid)).isFalse();
     assertThat(FilterEvaluator.evaluate(alternateFilter, matching)).isTrue();
@@ -745,5 +719,18 @@ public class FilterEvaluatorTestCase
     assertThat(FilterEvaluator.evaluate(complexFilter, invalid)).isFalse();
     assertThat(FilterEvaluator.evaluate(alternateFilter, matching)).isTrue();
     assertThat(FilterEvaluator.evaluate(alternateFilter, invalid)).isFalse();
+
+    // Complex filters should not be equal if the path is different.
+    Filter otherPath = Filter.complex("otherAttr",
+        Filter.eq("postalCode", "12345"));
+    assertThat(complexFilter.equals(otherPath)).isFalse();
+    assertThat(otherPath.equals(complexFilter)).isFalse();
+    assertThat(otherPath.hashCode()).isNotEqualTo(complexFilter.hashCode());
+
+    // Complex filters should not be equal if the value filter is different.
+    Filter otherValue = Filter.complex("addresses", Filter.eq("type", "work"));
+    assertThat(complexFilter.equals(otherValue)).isFalse();
+    assertThat(otherValue.equals(complexFilter)).isFalse();
+    assertThat(otherValue.hashCode()).isNotEqualTo(complexFilter.hashCode());
   }
 }

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
@@ -39,17 +39,18 @@ import com.unboundid.scim2.common.filters.FilterType;
 import com.unboundid.scim2.common.utils.DateTimeUtils;
 import com.unboundid.scim2.common.utils.FilterEvaluator;
 import com.unboundid.scim2.common.utils.JsonUtils;
+import org.assertj.core.api.ThrowableAssert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import tools.jackson.databind.JsonNode;
 
-import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -64,11 +65,9 @@ public class FilterEvaluatorTestCase
 
   /**
    * Sets up the test by creating a new JsonNode.
-   *
-   * @throws IOException if an unexpected JSON parsing error occurs.
    */
   @BeforeClass
-  public void setup() throws IOException
+  public void setup()
   {
     date = new Date();
 
@@ -393,6 +392,7 @@ public class FilterEvaluatorTestCase
     );
     assertThat(andFilter.equals(andFilterSuperset)).isFalse();
     assertThat(andFilterSuperset.equals(andFilter)).isFalse();
+    assertThat(andFilter.hashCode()).isNotEqualTo(andFilterSuperset.hashCode());
 
     Filter orFilterSuperset = Filter.or(
         Filter.eq("userName", "Ganon"),
@@ -401,6 +401,7 @@ public class FilterEvaluatorTestCase
     );
     assertThat(orFilter.equals(orFilterSuperset)).isFalse();
     assertThat(orFilterSuperset.equals(orFilter)).isFalse();
+    assertThat(orFilter.hashCode()).isNotEqualTo(orFilterSuperset.hashCode());
 
     // The order of the subordinate filters should not affect equivalency.
     Filter andFilterDifferentOrder = Filter.and(
@@ -434,6 +435,157 @@ public class FilterEvaluatorTestCase
             + " or workAddress pr)");
     assertThat(filter3.equals(filter4)).isTrue();
     assertThat(filter4.equals(filter3)).isTrue();
+
+    // The list methods should enforce a minimum of two filters.
+    List<ThrowableAssert.ThrowingCallable> tooFewFilters = List.of(
+        () -> Filter.and(List.of()),
+        () -> Filter.and(List.of(Filter.pr("invalid"))),
+        () -> Filter.or(List.of()),
+        () -> Filter.or(List.of(Filter.pr("invalid")))
+    );
+    for (var filterCallable : tooFewFilters)
+    {
+      assertThatThrownBy(filterCallable)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("must combine at least 2 filters");
+    }
+
+    // Ensure parity between the varargs constructors.
+    assertThat(Filter.and(Filter.pr("ims"), Filter.eq("name", (byte[]) null)))
+        .isEqualTo(Filter.and("ims pr", "name eq null"));
+    assertThat(Filter.or(Filter.pr("ims"), Filter.eq("name", (byte[]) null)))
+        .isEqualTo(Filter.or("ims pr", "name eq null"));
+  }
+
+
+  /**
+   * Test the {@code equals()} method for comparison filter types.
+   */
+  @SuppressWarnings("all")
+  @Test
+  public void testComparisonEquals() throws Exception
+  {
+    final Date date = new Date(407448000000L);
+
+    Filter ne = Filter.ne("billie", 1.0f);
+    assertThat(ne).isEqualTo(ne);
+
+    // A comparison filter should not be equal to a different filter type.
+    assertThat(ne).isNotEqualTo(Filter.pr("billie"));
+
+    // A comparison filter and its hashcode should not equal another type.
+    Filter eq = Filter.eq("billie", 1.0f);
+    assertThat(eq).isNotEqualTo(ne);
+    assertThat(ne.hashCode()).isNotEqualTo(eq.hashCode());
+    assertThat(ne.toString()).isNotEqualTo(eq.toString());
+
+    // Test other comparison filter types.
+    assertThat(ne)
+        .isNotEqualTo(Filter.lt("billie", 1.0f))
+        .isNotEqualTo(Filter.le("billie", 1.0f))
+        .isNotEqualTo(Filter.gt("billie", 1.0f))
+        .isNotEqualTo(Filter.ge("billie", 1.0f))
+        .isNotEqualTo(Filter.co("billie", "jean"))
+        .isNotEqualTo(Filter.sw("billie", "jean"))
+        .isNotEqualTo(Filter.ew("billie", "jean"));
+
+    // Filters should not be equivalent if the paths are different.
+    assertThat(ne)
+        .isNotEqualTo(Filter.ne("jean", 1.0f));
+
+    assertThat(Filter.eq("billie", 1.0f))
+        .isNotEqualTo(Filter.eq("jean", 1.0f));
+    assertThat(Filter.eq("billie", 1.0d))
+        .isNotEqualTo(Filter.eq("jean", 1.0d));
+    assertThat(Filter.eq("billie", 40L))
+        .isNotEqualTo(Filter.eq("jean", 40L));
+    assertThat(Filter.eq("billie", date))
+        .isNotEqualTo(Filter.eq("jean", date));
+    assertThat(Filter.eq("theOne", "kid"))
+        .isNotEqualTo(Filter.eq("theOne", "mySon"));
+
+    assertThat(Filter.lt("billie", 1.0f))
+        .isNotEqualTo(Filter.lt("jean", 1.0f));
+    assertThat(Filter.lt("billie", 1.0d))
+        .isNotEqualTo(Filter.lt("jean", 1.0d));
+    assertThat(Filter.lt("billie", 40L))
+        .isNotEqualTo(Filter.lt("jean", 40L));
+    assertThat(Filter.lt("billie", date))
+        .isNotEqualTo(Filter.lt("jean", date));
+    assertThat(Filter.lt("theOne", "kid"))
+        .isNotEqualTo(Filter.lt("theOne", "mySon"));
+
+    assertThat(Filter.le("billie", 1.0f))
+        .isNotEqualTo(Filter.le("jean", 1.0f));
+    assertThat(Filter.le("billie", 1.0d))
+        .isNotEqualTo(Filter.le("jean", 1.0d));
+    assertThat(Filter.le("billie", 40L))
+        .isNotEqualTo(Filter.le("jean", 40L));
+    assertThat(Filter.le("billie", date))
+        .isNotEqualTo(Filter.le("jean", date));
+    assertThat(Filter.le("theOne", "kid"))
+        .isNotEqualTo(Filter.le("theOne", "mySon"));
+
+    assertThat(Filter.gt("billie", 1.0f))
+        .isNotEqualTo(Filter.gt("jean", 1.0f));
+    assertThat(Filter.gt("billie", 1.0d))
+        .isNotEqualTo(Filter.gt("jean", 1.0d));
+    assertThat(Filter.gt("billie", 40L))
+        .isNotEqualTo(Filter.gt("jean", 40L));
+    assertThat(Filter.gt("billie", date))
+        .isNotEqualTo(Filter.gt("jean", date));
+    assertThat(Filter.gt("theOne", "kid"))
+        .isNotEqualTo(Filter.gt("theOne", "mySon"));
+
+    assertThat(Filter.ge("billie", 1.0f))
+        .isNotEqualTo(Filter.ge("jean", 1.0f));
+    assertThat(Filter.ge("billie", 1.0d))
+        .isNotEqualTo(Filter.ge("jean", 1.0d));
+    assertThat(Filter.ge("billie", 40L))
+        .isNotEqualTo(Filter.ge("jean", 40L));
+    assertThat(Filter.ge("billie", date))
+        .isNotEqualTo(Filter.ge("jean", date));
+    assertThat(Filter.ge("theOne", "kid"))
+        .isNotEqualTo(Filter.ge("theOne", "mySon"));
+
+    // Filters should not be equivalent to other filters if the value is
+    // different.
+    assertThat(ne)
+        .isNotEqualTo(Filter.ne("billie", 0.0f))
+        .isNotEqualTo(Filter.ne("billie", 0.0d))
+        .isNotEqualTo(Filter.ne("billie", 0))
+        .isNotEqualTo(Filter.ne("billie", 0L))
+        .isNotEqualTo(Filter.ne("billie", "0"))
+        .isNotEqualTo(Filter.ne("billie", false))
+        .isNotEqualTo(Filter.ne("billie", new byte[]{ 0x00 }))
+        .isNotEqualTo(Filter.ne("billie", new Date(0L)));
+  }
+
+
+  /**
+   * Test the {@code equals()} method for complex filter types.
+   */
+  @Test
+  @SuppressWarnings("all")
+  public void testComplexFilterEquals() throws Exception
+  {
+    Filter orig = Filter.complex("emails", Filter.eq("type", "work"));
+    Filter alsoOrig = Filter.complex("emails", Filter.eq("type", "work"));
+    assertThat(orig == alsoOrig).isFalse();
+    assertThat(orig.equals(alsoOrig)).isTrue();
+    assertThat(orig.getFilterType()).isEqualTo(alsoOrig.getFilterType());
+
+    // Complex filters should not be equal if the path is different.
+    Filter otherPath = Filter.complex("addresses", Filter.eq("type", "work"));
+    assertThat(orig.equals(otherPath)).isFalse();
+    assertThat(otherPath.equals(orig)).isFalse();
+    assertThat(otherPath.hashCode()).isNotEqualTo(orig.hashCode());
+
+    // Complex filters should not be equal if the value filter is different.
+    Filter otherValue = Filter.complex("emails", Filter.ne("type", "work"));
+    assertThat(orig.equals(otherValue)).isFalse();
+    assertThat(otherValue.equals(orig)).isFalse();
+    assertThat(otherValue.hashCode()).isNotEqualTo(orig.hashCode());
   }
 
 
@@ -455,7 +607,7 @@ public class FilterEvaluatorTestCase
 
   /**
    * Tests the helper methods defined on the base Filter class that determine
-   * the filter type (e.g., {@link Filter#isCombiningFilter()}.
+   * the filter type (e.g., {@link Filter#isCombiningFilter()}).
    */
   @Test
   public void testTypeMethods() throws Exception
@@ -516,6 +668,15 @@ public class FilterEvaluatorTestCase
     assertThat(presentResults)
         .hasSize(1)
         .containsOnly(Filter.pr("attr"));
+
+    // Evaluate some negative cases explicitly.
+    assertThat(Filter.eq("path", 1).getCombinedFilters()).isNull();
+    assertThat(Filter.eq("path", 1.0d).getInvertedFilter()).isNull();
+    assertThat(Filter.not("path pr").getAttributePath()).isNull();
+    assertThat(Filter.pr("path").getValueFilter()).isNull();
+
+    Filter f = Filter.eq("path", new byte[]{ 0x00 });
+    assertThat(Filter.not(f).getComparisonValue()).isNull();
   }
 
   /**

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/FilterEvaluatorTestCase.java
@@ -548,8 +548,7 @@ public class FilterEvaluatorTestCase
     assertThat(Filter.ge("theOne", "kid"))
         .isNotEqualTo(Filter.ge("theOne", "mySon"));
 
-    // Filters should not be equivalent to other filters if the value is
-    // different.
+    // Filters should not be equivalent when the value is a different data type.
     assertThat(ne)
         .isNotEqualTo(Filter.ne("billie", 0.0f))
         .isNotEqualTo(Filter.ne("billie", 0.0d))


### PR DESCRIPTION
Subclasses of ComparisonFilter had duplicated logic for equivalency and
hash code evaluation. This has now been consolidated into a single place
for better testability. Additional improvements and coverage for the
filters package have been included.

Reviewer: dougbulkley
Reviewer: vyhhuang

JiraIssue: DS-51561