### PR TITLE
Update bulk patch operation handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Update Jackson from 3.13.0 to 3.20.0 and jackson-annotations to from 2.21 to 2.2
 Fixed an issue where GenericScimResource would use case-sensitive property names if the resource was
 initialized with an ObjectNode that was not a SCIM SDK `CaseIgnoreObjectNode`.
 
+Updated the handling of bulk patch operations to reflect the information shown in RFC 7644's
+[errata](https://errata.rfc-editor.org/eid5050/). Now, `BulkOperation` objects with a "PATCH" method
+will always contain the `data.schemas` subfield, reflecting that the `data` is a `PatchRequest`.
+Previously, this subfield was not printed. When a bulk patch JSON is converted to an object, the
+`schemas` subfield is not required to be present in the source JSON. However, it will be added if it
+was missing, ensuring that a `PatchRequest` is always available at runtime when `getData()` and
+`getDataAsScimResource()` are called. See the `BulkOperation.java` Javadoc for more information.
+
+Corrected an annotation in `PatchRequest` which did not mark `Operations` with a multiValueClass.
+
 ## 6.0.0 - 2026-May-11
 The UnboundID SCIM SDK has been updated to use version 3 of the Jackson library (this release ships
 with v3.1.3). This change aligns the SCIM SDK with HTTP libraries such as Spring Framework 7/Spring

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/bulk/BulkOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/bulk/BulkOperation.java
@@ -509,7 +509,7 @@ public abstract class BulkOperation
         final ObjectNode data)
             throws BulkRequestException
     {
-      // Use an object to eliminate potential variance from source JSON data.
+      // Re-encode the source JSON into an object to reformat the input.
       this(path, asPatchRequest(data));
     }
 
@@ -729,7 +729,7 @@ public abstract class BulkOperation
                                     @NotNull final PatchOperation op1,
                                     @Nullable final PatchOperation... ops)
   {
-    return patch(endpoint, toList(op1, ops));
+    return new BulkPatchOperation(endpoint, new PatchRequest(toList(op1, ops)));
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/bulk/BulkOperation.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/bulk/BulkOperation.java
@@ -32,6 +32,7 @@
 
 package com.unboundid.scim2.common.bulk;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -77,8 +78,7 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  *   <li> {@code path}: The HTTP endpoint that the request should target.
  *   <li> {@code bulkId}: An optional field that allows other operations within
  *        the bulk request to reference this operation. This field may only be
- *        set on POST requests, but other operations types may reference a POST
- *        operation with a bulk ID.
+ *        set on POST requests.
  *   <li> {@code version}: The ETag version of the resource. For more
  *        information, see {@link ETagConfig}.
  *   <li> {@code data}: The JSON body/payload of the SCIM request. For example,
@@ -86,20 +86,7 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  * </ul>
  * <br><br>
  *
- * To construct a bulk operation, use one of the static methods defined on this
- * class. Some examples include:
- * <ul>
- *   <li> {@link #post(String, ScimResource)}
- *   <li> {@link #put(String, ScimResource)}
- *   <li> {@link #patch(String, PatchOperation, PatchOperation...)}
- *   <li> {@link #delete(String)}
- * </ul>
- *
- * Note that the {@code bulkId} and {@code version} fields may be set with the
- * {@link #setBulkId} and {@link #setVersion} methods.
- * <br><br>
- *
- * The following JSON is an example bulk operation that updates an existing user
+ * The following JSON is an example bulk operation that creates a new user
  * resource. It may be included in a request to a SCIM service, alongside other
  * bulk operations.
  * <pre>
@@ -115,34 +102,30 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  *   }
  * </pre>
  *
- * The example JSON above can be created with the following Java code:
+ * This bulk operation can be created with the following Java code. These
+ * objects are constructed with static methods such as {@link #delete(String)}.
  * <pre><code>
  *   UserResource user = new UserResource().setUserName("Eggs").setActive(true);
  *   BulkOperation op = BulkOperation.post("/Users", user).setBulkId("qwerty");
  * </code></pre>
- * <br><br>
  *
- * Because bulk operations can contain data of many forms, this class contains
- * the {@link #getDataAsScimResource()} helper method to help easily extract the
- * {@code data} field into a useful forms.
+ * Note that the {@code bulkId} and {@code version} fields may be set with the
+ * {@link #setBulkId} and {@link #setVersion} methods. This class also contains
+ * the {@link #getDataAsScimResource()} method to easily fetch the {@code data}
+ * field as a Java object.
+ * <br><br>
  *
  * <h2>Bulk Patch Operations</h2>
- * A bulk operation with a "patch" method is called a bulk patch operation. This
- * is different from a standard patch operation, represented by the
- * {@link PatchOperation} class (which is a subfield of a {@link PatchRequest}).
- * <br><br>
- *
- * It is important to note that RFC 7644 indicates that the {@code data} field
- * for bulk patch operations are a list of operation objects. However, the
- * example usages in the spec are not valid JSON because they do not form
- * key-value pairs. For this reason, many SCIM implementations, including the
- * UnboundID SCIM SDK, include an {@code "Operations"} identifier within bulk
- * patch requests, similar to a {@link PatchRequest}. For example:
+ * A bulk operation with a "PATCH" method is called a bulk patch operation. This
+ * is different from a standard SCIM {@link PatchOperation}, which is a subfield
+ * of a {@link PatchRequest}. The UnboundID SCIM SDK always prints bulk patch
+ * operations in the form of:
  * <pre>
  * {
  *   "method": "PATCH",
  *   "path": "/Users/5d8d29d3-342c-4b5f-8683-a3cb6763ffcc",
  *   "data": {
+ *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
  *     "Operations": [ {
  *       "op": "remove",
  *       "path": "nickName"
@@ -155,12 +138,20 @@ import static com.unboundid.scim2.common.utils.StaticUtils.toList;
  * }
  * </pre>
  *
- * Some services also include the {@code schemas} field of a patch request to
- * fully match that data model. When fetching the {@code data} of a bulk patch
- * operation with {@link #getDataAsScimResource()}, a {@link PatchRequest}
- * object is always returned for simplicity. When bulk patch operations are
- * serialized, they are always printed in the form shown above, without a
- * {@code schemas} field.
+ * Some SCIM services may display the {@code data} of bulk patch operations
+ * differently due to an error in the initial publication of RFC 7644, where the
+ * field only contained a list of patch operations and was not valid JSON. The
+ * <a href="https://errata.rfc-editor.org/eid5050/">errata</a> of RFC 7644 fixes
+ * this however, and states that the {@code data} JSON should represent a
+ * {@link PatchRequest} similar to a request to {@code PATCH /Users/{userID}}.
+ * <br><br>
+ *
+ * To ensure broad compatibility with JSON that may be formatted differently,
+ * the SCIM SDK is tolerant when converting JSON into a BulkOperation, as long
+ * as an {@code Operations} field is present and contains patch operations. The
+ * JSON will then be re-encoded to represent a full PatchRequest. Thus, when
+ * {@link #getDataAsScimResource()} is called on any {@link BulkOperation} with
+ * a method of {@code PATCH}, a {@link PatchRequest} will always be returned.
  *
  * @see BulkRequest
  * @since 5.1.0
@@ -362,16 +353,6 @@ public abstract class BulkOperation
    * {@link GenericScimResource} instance will be returned.
    * <br><br>
    *
-   * Note that patch operations are a special case due to their unique
-   * structure. The {@code data} for a patch operation is a list of
-   * {@link PatchOperation} objects, which is not a ScimResource. However, this
-   * is very close to a {@link PatchRequest}, which is likely a desirable form
-   * for SCIM server implementations. Thus, to simplify handling of the data for
-   * bulk patch operations, this method will return a {@link PatchRequest}
-   * instance for bulk patch operations. The list of patch operations may be
-   * obtained with {@link PatchRequest#getOperations()}.
-   * <br><br>
-   *
    * If you have custom classes that should be used, they may be registered with
    * the {@link BulkResourceMapper}. However, any JSON object may be manually
    * converted to a Java object with {@link JsonUtils#nodeToValue}:
@@ -397,11 +378,6 @@ public abstract class BulkOperation
   public ScimResource getDataAsScimResource()
     throws BulkRequestException
   {
-    if (this instanceof BulkPatchOperation)
-    {
-      return new PatchRequest(getPatchOperationList());
-    }
-
     try
     {
       return BulkResourceMapper.asScimResource(data);
@@ -411,29 +387,6 @@ public abstract class BulkOperation
       throw new BulkRequestException(
           "Failed to convert a malformed JSON into a SCIM resource.", e);
     }
-  }
-
-  /**
-   * Fetches the {@code data} field of the bulk operation as a list of patch
-   * operations. This method may only be used for bulk PATCH operations.
-   *
-   * @return  The list of patch operations in the bulk operation.
-   * @throws IllegalStateException  If this bulk operation is not a bulk PATCH.
-   */
-  @NotNull
-  @JsonIgnore
-  protected List<PatchOperation> getPatchOperationList()
-      throws IllegalStateException
-  {
-    if (this instanceof BulkPatchOperation bulkPatchOp)
-    {
-      return bulkPatchOp.patchOperationList;
-    }
-
-    // This is not a BulkRequestException since it cannot occur during
-    // deserialization.
-    throw new IllegalStateException(
-        "Cannot fetch patch data for a '" + method + "' bulk operation.");
   }
 
   /**
@@ -542,9 +495,13 @@ public abstract class BulkOperation
    */
   protected static final class BulkPatchOperation extends BulkOperation
   {
+    // Represents the 'schemas' array value for a PatchRequest resource.
     @NotNull
-    private final List<PatchOperation> patchOperationList;
+    private static final ArrayNode PATCH_REQUEST_SCHEMAS =
+        JsonUtils.getJsonNodeFactory().arrayNode()
+            .add("urn:ietf:params:scim:api:messages:2.0:PatchOp");
 
+    @JsonCreator
     private BulkPatchOperation(
         @NotNull @JsonProperty(value = "path", required = true)
         final String path,
@@ -552,20 +509,36 @@ public abstract class BulkOperation
         final ObjectNode data)
             throws BulkRequestException
     {
-      super(BulkOpType.PATCH, path, data);
-      patchOperationList = parseOperations(data);
+      // Use an object to eliminate potential variance from source JSON data.
+      this(path, asPatchRequest(data));
+    }
+
+    private BulkPatchOperation(@NotNull final String path,
+                               @NotNull final PatchRequest pr)
+    {
+      // The patch request is not cached since it may contain bulkID references.
+      super(BulkOpType.PATCH, path, pr.asGenericScimResource().getObjectNode());
     }
 
     /**
-     * Converts a bulk patch operation's {@code data} field into a usable list
-     * of PatchOperations.
+     * This method deserializes data into a PatchRequest with extra flexibility.
+     * Due to an erroneous patch request model in the first publication of RFC
+     * 7644, there is variance on how this JSON data is displayed by some SCIM
+     * services. This method is called from the constructor to guarantee that
+     * all bulk patch operations have a usable PatchRequest model at runtime.
      */
-    private List<PatchOperation> parseOperations(@NotNull final ObjectNode data)
+    private static PatchRequest asPatchRequest(@NotNull final ObjectNode data)
         throws BulkRequestException
     {
       JsonNode operationsNode = data.get("Operations");
       if (operationsNode == null)
       {
+        // Check for an Operations list that could have been empty.
+        if (data.isEmpty() || PATCH_REQUEST_SCHEMAS.equals(data.get("schemas")))
+        {
+          return new PatchRequest(List.of());
+        }
+
         // This most likely indicates that the JSON is not a bulk operation, and
         // instead represents some other data type.
         throw new BulkRequestException(
@@ -581,15 +554,15 @@ public abstract class BulkOperation
 
       try
       {
-        // Convert the ArrayNode to a list of patch operations.
-        return JsonUtils.getObjectReader().forType(PATCH_REF)
-            .readValue(arrayNode);
+        List<PatchOperation> patchOperations = JsonUtils.getObjectReader()
+            .forType(PATCH_REF).readValue(arrayNode);
+        return new PatchRequest(patchOperations);
       }
       catch (JacksonException e)
       {
         Debug.debugException(e);
         throw new BulkRequestException(
-            "Failed to convert an array to a patch operation list.", e);
+            "Failed to convert a malformed patch operation list.", e);
       }
     }
   }
@@ -720,6 +693,7 @@ public abstract class BulkOperation
    *   "method": "PATCH",
    *   "path": "/Users/5d8d29d3-342c-4b5f-8683-a3cb6763ffcc",
    *   "data": {
+   *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
    *     "Operations": [ {
    *       "op": "remove",
    *       "path": "nickName"
@@ -774,25 +748,15 @@ public abstract class BulkOperation
   {
     List<PatchOperation> operationList = (ops == null) ? List.of() : ops;
     operationList = operationList.stream().filter(Objects::nonNull).toList();
-
-    // Convert the list to an ArrayNode by iteration, since valueToNode() can
-    // miss fields if the entire list is passed in.
-    ArrayNode array = JsonUtils.getJsonNodeFactory().arrayNode();
-    for (PatchOperation operation : operationList)
-    {
-      array.add(JsonUtils.valueToNode(operation));
-    }
-
-    ObjectNode node = JsonUtils.getJsonNodeFactory().objectNode();
-    return patch(endpoint, node.set("Operations", array));
+    return new BulkPatchOperation(endpoint, new PatchRequest(operationList));
   }
 
   /**
    * Creates a bulk patch operation. The provided ObjectNode should be
-   * structured similarly to a {@link PatchRequest} JSON. An example is shown
-   * below:
+   * structured as a {@link PatchRequest}:
    * <pre>
    *   {
+   *     "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
    *     "Operations": [
    *       {
    *         (patch operation 1),
@@ -809,14 +773,14 @@ public abstract class BulkOperation
    *                  {@link PatchOperation} objects.
    *
    * @return  The new bulk operation.
-   * @throws BulkRequestException  If the ObjectNode improperly formatted.
+   * @throws BulkRequestException  If the ObjectNode is improperly formatted.
    */
   @NotNull
   public static BulkOperation patch(@NotNull final String endpoint,
                                     @NotNull final ObjectNode data)
       throws BulkRequestException
   {
-    return new BulkPatchOperation(endpoint, data.deepCopy());
+    return new BulkPatchOperation(endpoint, Objects.requireNonNull(data));
   }
 
   /**

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/bulk/BulkOperationResult.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/bulk/BulkOperationResult.java
@@ -547,8 +547,7 @@ public class BulkOperationResult
   /**
    * Fetches the response of this BulkOperationResult as a {@link ScimResource}
    * based POJO. See {@link BulkOperation#getDataAsScimResource()} for more
-   * information. Note that this method will never return a
-   * {@code PatchRequest}, unlike the variant in {@code BulkOperation}.
+   * information.
    *
    * @return  The bulk operation result response, or {@code null} if there was
    *          no response.

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/bulk/BulkResourceMapper.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/bulk/BulkResourceMapper.java
@@ -38,18 +38,15 @@ import com.unboundid.scim2.common.annotations.NotNull;
 import com.unboundid.scim2.common.annotations.Nullable;
 import com.unboundid.scim2.common.annotations.Schema;
 import com.unboundid.scim2.common.messages.ErrorResponse;
+import com.unboundid.scim2.common.messages.PatchRequest;
 import com.unboundid.scim2.common.types.GroupResource;
-import com.unboundid.scim2.common.types.SchemaResource;
 import com.unboundid.scim2.common.types.UserResource;
-import com.unboundid.scim2.common.utils.Debug;
 import com.unboundid.scim2.common.utils.JsonUtils;
-import com.unboundid.scim2.common.utils.SchemaUtils;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 
-import java.beans.IntrospectionException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Objects;
@@ -142,26 +139,15 @@ public class BulkResourceMapper
       @NotNull final Class<T> clazz)
           throws IllegalArgumentException
   {
-    SchemaResource schema;
-
-    try
-    {
-      schema = SchemaUtils.getSchema(clazz);
-    }
-    catch (IntrospectionException e)
-    {
-      Debug.debugException(e);
-      throw new RuntimeException(e);
-    }
-
-    if (schema == null || schema.getId() == null)
+    Schema schema = clazz.getAnnotation(Schema.class);
+    if (schema == null)
     {
       throw new IllegalArgumentException("Requested schema for the "
           + clazz.getName()
           + " class, which does not have a valid @Schema annotation.");
     }
 
-    SCHEMAS_MAP.put(Set.of(schema.getId()), clazz);
+    SCHEMAS_MAP.put(Set.of(schema.id()), clazz);
   }
 
   /**
@@ -286,5 +272,6 @@ public class BulkResourceMapper
     add(UserResource.class);
     add(GroupResource.class);
     add(ErrorResponse.class);
+    add(PatchRequest.class);
   }
 }

--- a/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
+++ b/scim2-sdk-common/src/main/java/com/unboundid/scim2/common/messages/PatchRequest.java
@@ -111,7 +111,8 @@ public class PatchRequest
     implements Iterable<PatchOperation>
 {
   @NotNull
-  @Attribute(description = "Patch Operations")
+  @Attribute(description = "Patch Operations",
+             multiValueClass = PatchOperation.class)
   @JsonProperty(value = "Operations", required = true)
   private final List<PatchOperation> operations;
 

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/bulk/BulkOperationTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/bulk/BulkOperationTest.java
@@ -145,7 +145,6 @@ public class BulkOperationTest
         .hasMessageContaining("of a bulk POST operation");
   }
 
-
   /**
    * Tests the behavior of bulk PUT operations.
    */
@@ -204,38 +203,168 @@ public class BulkOperationTest
   {
     // Instantiate a bulk patch operation.
     var patchOp = PatchOperation.replace("displayName", "New Value");
-    BulkOperation operation = BulkOperation.patch("/Groups/resource", patchOp)
+    var bulkOperation = BulkOperation.patch("/Groups/resource", patchOp)
         .setVersion("newVersion");
 
-    assertThat(operation.getMethod()).isEqualTo(BulkOpType.PATCH);
-    assertThat(operation.getPath()).isEqualTo("/Groups/resource");
-    assertThat(operation.getBulkId()).isNull();
-    assertThat(operation.getVersion()).isEqualTo("newVersion");
-    assertThat(operation.getData()).isNotNull();
+    assertThat(bulkOperation.getMethod()).isEqualTo(BulkOpType.PATCH);
+    assertThat(bulkOperation.getPath()).isEqualTo("/Groups/resource");
+    assertThat(bulkOperation.getBulkId()).isNull();
+    assertThat(bulkOperation.getVersion()).isEqualTo("newVersion");
+    assertThat(bulkOperation.getData()).isNotNull();
 
-    // Validate serialization of the bulk operation.
+    // Validate serialization of a standard bulk patch operation as defined in
+    // the errata of RFC 7644. This states that the 'data' field should be the
+    // same JSON that represents a PatchRequest.
     String expectedString = """
         {
           "method": "PATCH",
           "path": "/Groups/resource",
           "version": "newVersion",
           "data": {
-            "Operations": [
-              {
-                "op": "replace",
-                "path": "displayName",
-                "value": "New Value"
-              }
-            ]
+            "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+            "Operations": [ {
+              "op": "replace",
+              "path": "displayName",
+              "value": "New Value"
+            } ]
           }
         }""";
     String normalizedJSON = reader.readTree(expectedString).toPrettyString();
-    assertThat(operation.toString()).isEqualTo(normalizedJSON);
+    assertThat(bulkOperation.toString()).isEqualTo(normalizedJSON);
 
-    // Validate deserialization of the JSON.
+    // Test deserializing the bulk operation directly. This should be equivalent
+    // to the constructed 'bulkOperation' object.
     BulkOperation deserialized = reader.forType(BulkOperation.class)
         .readValue(expectedString);
-    assertThat(operation).isEqualTo(deserialized);
+    assertThat(bulkOperation).isEqualTo(deserialized);
+
+    // Validate the contents of the patch operation list.
+    assertThat(deserialized.getDataAsScimResource())
+        .isInstanceOfSatisfying(PatchRequest.class, patchRequest ->
+            assertThat(patchRequest.getOperations()).containsExactly(patchOp));
+
+    // Validate the previous JSON, this time with no 'schemas' attribute. The
+    // SCIM SDK should still accept this for broad compatibility.
+    String noSchemasJson = """
+        {
+          "method": "PATCH",
+          "path": "/Groups/resource",
+          "version": "newVersion",
+          "data": {
+            "Operations": [ {
+              "op": "replace",
+              "path": "displayName",
+              "value": "New Value"
+            } ]
+          }
+        }""";
+    BulkOperation noSchemas = reader.forType(BulkOperation.class)
+        .readValue(noSchemasJson);
+    assertThat(noSchemas).isEqualTo(bulkOperation);
+
+    // Ensure case-insensitive subfields. Use a lowercase 'o' for Operations.
+    String differentCasingJson = """
+        {
+          "method": "PATCH",
+          "path": "/Groups/resource",
+          "version": "newVersion",
+          "data": {
+            "oPeRaTiOnS": [ {
+              "Op": "replace",
+              "Path": "displayName",
+              "Value": "New Value"
+            } ]
+          }
+        }""";
+    BulkOperation differentCasing = reader.forType(BulkOperation.class)
+        .readValue(differentCasingJson);
+    assertThat(differentCasing).isEqualTo(bulkOperation);
+
+    // Serialize the new object. The casing should be normalized.
+    assertThat(differentCasing.toString()).isEqualTo(bulkOperation.toString());
+
+    // Validate a list with multiple elements.
+    String multipleOpsJson = """
+        {
+          "method": "PATCH",
+          "path": "/Users/resource",
+          "data": {
+            "Operations": [ {
+              "op": "add",
+              "path": "emails[type eq \\"work\\"].value",
+              "value": "name@example.com"
+            }, {
+              "op": "remove",
+              "path": "locale"
+            }, {
+              "op": "replace",
+              "path": "active",
+              "value": true
+            } ]
+          }
+        }""";
+    BulkOperation multipleOps = reader.forType(BulkOperation.class)
+        .readValue(multipleOpsJson);
+    String addPath = "emails[type eq \"work\"].value";
+    assertThat(multipleOps.getDataAsScimResource())
+        .isInstanceOf(PatchRequest.class)
+        .isEqualTo(new PatchRequest(
+            PatchOperation.add(addPath, StringNode.valueOf("name@example.com")),
+            PatchOperation.remove("locale"),
+            PatchOperation.replace("active", true)
+        ));
+
+    // When 'multipleOps' is serialized again, it should print the 'schemas'
+    // field even though it was not originally present in the source JSON.
+    assertThat(multipleOps.toString())
+        .contains("schemas")
+        .contains("urn:ietf:params:scim:api:messages:2.0:PatchOp");
+    assertThat(multipleOps.getData()).isInstanceOfSatisfying(ObjectNode.class,
+        o -> assertThat(o.get("schemas")).containsExactly(StringNode.valueOf(
+            "urn:ietf:params:scim:api:messages:2.0:PatchOp")));
+
+    // Validate a list with no elements.
+    String emptyJson = """
+        {
+          "method": "PATCH",
+          "path": "/Users/resource",
+          "data": {
+            "Operations": []
+          }
+        }""";
+    BulkOperation empty = reader.forType(BulkOperation.class)
+        .readValue(emptyJson);
+    assertThat(empty.getDataAsScimResource())
+        .isInstanceOfSatisfying(PatchRequest.class,
+            patchRequest -> assertThat(patchRequest.getOperations()).isEmpty());
+
+    // Validate an empty data value.
+    String emptyDataJson = """
+        {
+          "method": "PATCH",
+          "path": "/Users/resource",
+          "data": { }
+        }""";
+    BulkOperation emptyData = reader.forType(BulkOperation.class)
+        .readValue(emptyDataJson);
+    assertThat(emptyData.getDataAsScimResource())
+        .isInstanceOfSatisfying(PatchRequest.class,
+            patchRequest -> assertThat(patchRequest.getOperations()).isEmpty());
+
+    // Validate a bulk operation with a null operations field.
+    String nullOperationsJson = """
+        {
+          "method": "PATCH",
+          "path": "/Users/resource",
+          "data": {
+            "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ]
+          }
+        }""";
+    BulkOperation nullOperations = reader.forType(BulkOperation.class)
+        .readValue(nullOperationsJson);
+    assertThat(nullOperations.getDataAsScimResource())
+        .isInstanceOfSatisfying(PatchRequest.class,
+            patchRequest -> assertThat(patchRequest.getOperations()).isEmpty());
   }
 
   /**
@@ -244,15 +373,33 @@ public class BulkOperationTest
   @Test
   public void testImproperlyFormattedPatch()
   {
-    String patchWithNoOperations = """
+    // Ensure that other resource types are not silently accepted.
+    String wrongType = """
         {
           "method": "PATCH",
           "path": "/Groups/resource",
           "data": {
+            "otherResourceType": true
           }
         }""";
     assertThatThrownBy(() ->
-        reader.forType(BulkOperation.class).readValue(patchWithNoOperations))
+        reader.forType(BulkOperation.class).readValue(wrongType))
+        .isInstanceOf(JacksonException.class)
+        .hasMessageContaining("Could not parse the patch operation list")
+        .hasMessageContaining("because the value of 'Operations' is absent");
+
+    // Ensure that other resource types with a schema are not silently accepted.
+    String wrongSchema = """
+        {
+          "method": "PATCH",
+          "path": "/Groups/resource",
+          "data": {
+            "schemas": [ "urn:ietf:params:scim:api:messages:2.0:Error" ],
+            "detail": "message"
+          }
+        }""";
+    assertThatThrownBy(() ->
+        reader.forType(BulkOperation.class).readValue(wrongSchema))
         .isInstanceOf(JacksonException.class)
         .hasMessageContaining("Could not parse the patch operation list")
         .hasMessageContaining("because the value of 'Operations' is absent");
@@ -292,19 +439,20 @@ public class BulkOperationTest
     assertThatThrownBy(() ->
         reader.forType(BulkOperation.class).readValue(badOperationFormat))
         .isInstanceOf(JacksonException.class)
-        .hasMessageContaining("Failed to convert an array to a patch")
-        .hasMessageContaining("operation list");
+        .hasMessageContaining("Failed to convert a malformed patch operation");
   }
 
   /**
-   * Validate {@link BulkOperation#getPatchOperationList()}.
+   * Validate fetching PatchRequest objects from bulk operations.
    */
   @Test
   public void testPatchOpList() throws Exception
   {
     BulkOperation emptyBulkPatch =
         BulkOperation.patch("/Users/userID", (List<PatchOperation>) null);
-    assertThat(emptyBulkPatch.getPatchOperationList()).isEmpty();
+    assertThat(emptyBulkPatch.getDataAsScimResource())
+        .isInstanceOfSatisfying(PatchRequest.class,
+            patchRequest -> assertThat(patchRequest.getOperations()).isEmpty());
 
     List<PatchOperation> patchList = List.of(
         PatchOperation.addStringValues("customPhoneNumbers", "512-111-1111"),
@@ -312,20 +460,32 @@ public class BulkOperationTest
         PatchOperation.replace("userName", "myUserName")
     );
     BulkOperation bulkPatch = BulkOperation.patch("/Users/userID", patchList);
-    assertThat(bulkPatch.getPatchOperationList()).isEqualTo(patchList);
-    assertThat(bulkPatch.getPatchOperationList() != patchList).isTrue();
+    assertThat(bulkPatch.getDataAsScimResource())
+        .isInstanceOfSatisfying(PatchRequest.class, patchRequest ->
+          assertThat(patchRequest.getOperations())
+              .isEqualTo(patchList).isNotSameAs(patchList)
+        );
 
-    // The method should only be allowed for PATCH operations.
+    // Repeat the previous test case with the source data as an ObjectNode.
+    ObjectNode patchNode = new PatchRequest(patchList)
+        .asGenericScimResource().getObjectNode();
+    BulkOperation bulkPatch2 = BulkOperation.patch("/Users/userID", patchNode);
+    assertThat(bulkPatch2.getDataAsScimResource())
+        .isInstanceOfSatisfying(PatchRequest.class, patchRequest2 ->
+          assertThat(patchRequest2.getOperations())
+              .isEqualTo(patchList).isNotSameAs(patchList)
+        );
+
+    // Only patch operation types should return a PatchRequest.
     ObjectNode node = JsonUtils.getJsonNodeFactory().objectNode();
-    assertThatThrownBy(() -> {
-      BulkOperation.post("/Users", node).getPatchOperationList();
-    }).isInstanceOf(IllegalStateException.class);
-    assertThatThrownBy(() -> {
-      BulkOperation.put("/Users/userID", node).getPatchOperationList();
-    }).isInstanceOf(IllegalStateException.class);
-    assertThatThrownBy(() -> {
-      BulkOperation.delete("/Users/userID").getPatchOperationList();
-    }).isInstanceOf(IllegalStateException.class);
+    assertThat(BulkOperation.patch("/Users", node).getDataAsScimResource())
+        .isInstanceOf(PatchRequest.class);
+    assertThat(BulkOperation.post("/Users", node).getDataAsScimResource())
+        .isNotInstanceOf(PatchRequest.class);
+    assertThat(BulkOperation.put("/Users/userID", node).getDataAsScimResource())
+        .isNotInstanceOf(PatchRequest.class);
+    assertThat(BulkOperation.delete("/Users/userID").getDataAsScimResource())
+        .satisfies(d -> assertThat(d instanceof PatchRequest).isFalse());
   }
 
   /**

--- a/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/bulk/BulkRequestTest.java
+++ b/scim2-sdk-common/src/test/java/com/unboundid/scim2/common/bulk/BulkRequestTest.java
@@ -155,8 +155,7 @@ public class BulkRequestTest
     final var reader = JsonUtils.getObjectReader().forType(BulkRequest.class);
 
     // Example JSON bulk request from RFC 7644. This was slightly revised to
-    // include the "Operations" attribute within the bulk patch request (the
-    // third bulk operation) so that it's a valid JSON with key-value pairs.
+    // use the updated bulk patch model as described by the errata.
     String json = """
         {
           "schemas": [ "urn:ietf:params:scim:api:messages:2.0:BulkRequest" ],
@@ -186,6 +185,7 @@ public class BulkRequestTest
               "path": "/Users/5d8d29d3-342c-4b5f-8683-a3cb6763ffcc",
               "version": "W/\\"edac3253e2c0ef2\\"",
               "data": {
+                "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
                 "Operations": [
                   {
                     "op": "remove",


### PR DESCRIPTION
The errata of RFC 7644 contains details on the intended form of bulk patch operations. It affirms that the 'data' field reflects the JSON payload that would be sent to the provided endpoint if the request were made individually to an endpoint such as 'PATCH /Users/{userID}'. Thus, it explicitly states that the JSON data provided on a bulk patch should always represent a PatchRequest resource with a "schemas" value.

This commit updates the SCIM SDK to reflect this behavior. To ensure compatibility during deserialization, extra leniency has been added when initializing bulk patch operations to reduce exceptions. After instantiation, the data field of bulk patch operation objects will always represent a full PatchRequest model.

Reviewer: dougbulkley
Reviewer: vyhhuang

JiraIssue: DS-51673